### PR TITLE
feat: introduce DaoError for cleaner error report.

### DIFF
--- a/kong-0.0.1beta-1.rockspec
+++ b/kong-0.0.1beta-1.rockspec
@@ -55,6 +55,7 @@ build = {
 
     ["kong.dao.schemas"] = "src/kong/dao/schemas.lua",
 
+    ["kong.dao.error"] = "src/kong/dao/error.lua",
     ["kong.dao.cassandra.factory"] = "src/kong/dao/cassandra/factory.lua",
     ["kong.dao.cassandra.base_dao"] = "src/kong/dao/cassandra/base_dao.lua",
     ["kong.dao.cassandra.apis"] = "src/kong/dao/cassandra/apis.lua",

--- a/spec/unit/dao/error_spec.lua
+++ b/spec/unit/dao/error_spec.lua
@@ -1,0 +1,40 @@
+local DaoError = require "kong.dao.error"
+
+describe("DaoError", function()
+
+  it("should be instanciable with a message and a type", function()
+    local err = DaoError("error message", "some_type")
+    assert.truthy(err)
+    assert.truthy(err.message)
+    assert.truthy(err.some_type)
+  end)
+
+  it("should return nil if trying to instanciate with an empty error message", function()
+    -- this way we can directly construct a DaoError from any returned err value without testing if err is not nil first.
+    local err = DaoError()
+    assert.falsy(err)
+  end)
+
+  it("should print it's message property if printed", function()
+    local err = DaoError("error message", "some_type")
+    assert.are.same("error message", tostring(err))
+  end)
+
+  it("should print it's message property if concatenated", function()
+    local err = DaoError("error message", "some_type")
+    assert.are.same("error: error message", "error: "..err)
+    assert.are.same("this is some error message to not ignore",  "this is some "..err.." to not ignore")
+  end)
+
+  it("should handle a table as an error message", function ()
+    -- example: schema validation returns a table with key/values for errors
+    local stub_error = {
+      name = "name is required",
+      public_dns = "invalid url"
+    }
+
+    local err = DaoError(stub_error, "some_type")
+    assert.are.same("name: name is required | public_dns: invalid url", tostring(err))
+  end)
+
+end)

--- a/spec/unit/faker_spec.lua
+++ b/spec/unit/faker_spec.lua
@@ -1,5 +1,6 @@
 local uuid = require "uuid"
 local Faker = require "kong.tools.faker"
+local DaoError = require "kong.dao.error"
 
 describe("Faker #tools", function()
 
@@ -105,7 +106,7 @@ describe("Faker #tools", function()
       local inspect = require "inspect"
 
       factory_mock.apis.insert = function(self, t)
-                                   return nil, { database = true, message = "cannot insert api error test" }
+                                   return nil, DaoError("cannot insert api error test", "database")
                                  end
       assert.has_error(function()
         faker:seed()

--- a/src/kong/core/access.lua
+++ b/src/kong/core/access.lua
@@ -43,7 +43,7 @@ function _M.execute(conf)
   local api = cache.get_and_set(cache.api_key(host), function()
     local apis, err = dao.apis:find_by_keys({public_dns = host})
     if err then
-      ngx.log(ngx.ERR, err.message)
+      ngx.log(ngx.ERR, err)
       utils.show_error(500)
     elseif not apis or #apis == 0 then
       utils.not_found("API not found")

--- a/src/kong/dao/error.lua
+++ b/src/kong/dao/error.lua
@@ -1,0 +1,48 @@
+-- DAOs need more specific error objects, specifying if the error is due to the schema, the database connection,
+-- a constraint violation etc... We will test this object and might create a KongError class too if successful and needed.
+
+local error_mt = {}
+error_mt.__index = error_mt
+
+function error_mt:print_message()
+  if type(self.message) == "string" then
+    return self.message
+  elseif type(self.message) == "table" then
+    local errors = {}
+    for k, v in pairs(self.message) do
+      table.insert(errors, k..": "..v)
+    end
+
+    return table.concat(errors, " | ")
+  end
+end
+
+function error_mt:__tostring()
+  return self:print_message()
+end
+
+function error_mt.__concat(a, b)
+  if getmetatable(a) == error_mt then
+    return a:print_message() .. b
+  else
+    return a .. b:print_message()
+  end
+end
+
+local mt = {
+  __index = DaoError,
+  __call = function (self, err, type)
+    if err == nil then
+      return nil
+    end
+
+    local t = {
+      [type] = true,
+      message = err
+    }
+
+    return setmetatable(t, error_mt)
+  end
+}
+
+return setmetatable({}, mt)

--- a/src/kong/plugins/authentication/access.lua
+++ b/src/kong/plugins/authentication/access.lua
@@ -166,7 +166,7 @@ function _M.execute(conf)
       local applications, err = dao.applications:find_by_keys { public_key = public_key }
       local result
       if err then
-        ngx.log(ngx.ERR, err.message)
+        ngx.log(ngx.ERR, err)
         utils.show_error(500)
       elseif #applications > 0 then
         result = applications[1]

--- a/src/kong/plugins/ratelimiting/access.lua
+++ b/src/kong/plugins/ratelimiting/access.lua
@@ -17,7 +17,7 @@ function _M.execute(conf)
   -- Load current metric for configured period
   local current_metric, err = dao.metrics:find_one(ngx.ctx.api.id, identifier, current_timestamp, conf.period)
   if err then
-    ngx.log(ngx.ERR, err.message)
+    ngx.log(ngx.ERR, err)
     utils.show_error(500)
   end
 
@@ -40,7 +40,7 @@ function _M.execute(conf)
   -- Increment metrics for all periods if the request goes through
   local _, stmt_err = dao.metrics:increment(ngx.ctx.api.id, identifier, current_timestamp)
   if stmt_err then
-    ngx.log(ngx.ERR, stmt_err.message)
+    ngx.log(ngx.ERR, stmt_err)
     utils.show_error(500)
   end
 end

--- a/src/kong/tools/faker.lua
+++ b/src/kong/tools/faker.lua
@@ -155,7 +155,7 @@ function Faker:insert_from_table(entities_to_insert, pick_relations)
       -- Insert in DB
       local res, err = self.dao_factory[type.."s"]:insert(entity)
       if err then
-        error("Faker failed to insert "..type.." entity: "..inspect(entity).."\n"..err.message)
+        error("Faker failed to insert "..type.." entity: "..inspect(entity).."\n"..err)
       end
 
       -- For other hard-coded entities relashionships

--- a/src/kong/web/routes/base_controller.lua
+++ b/src/kong/web/routes/base_controller.lua
@@ -50,7 +50,7 @@ local function parse_dao_error(err)
   local status
   if err.database then
     status = 500
-    ngx.log(ngx.ERR, err.message)
+    ngx.log(ngx.ERR, err)
   elseif err.unique then
     status = 409
   elseif err.foreign then

--- a/src/main.lua
+++ b/src/main.lua
@@ -43,7 +43,7 @@ local function load_plugin_conf(api_id, application_id, plugin_name)
         name = plugin_name
       }
       if err then
-        ngx.log(ngx.ERR, err.message)
+        ngx.log(ngx.ERR, err)
         utils.show_error(500)
       end
 
@@ -142,7 +142,7 @@ function _M.init()
   -- Initializing DAO
   local err = dao:prepare()
   if err then
-    error("Cannot prepare statements: "..err.message)
+    error("Cannot prepare statements: "..err)
   end
 
   -- Initializing plugins


### PR DESCRIPTION
DaoError is an error with a type and a message, just like the old table returned by `base_dao.build_error()` but it can be printed and concatenated in a string.

Instead of printing err.message, it can be printed by just 'err'. This eliminates confusion when interacting with the DAO and the errors it returns and also allows the Factory to use those, unlike before (before, it was only returning errors from the cassandra driver, as simple strings)