### PR TITLE
Fixing schema data types and database types

### DIFF
--- a/spec/integration/api/api_spec.lua
+++ b/spec/integration/api/api_spec.lua
@@ -113,6 +113,11 @@ describe("Web API #web", function()
 
         local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity)
         local body = cjson.decode(response)
+        if status == 400 then
+          print(response)
+          local inspect= require "inspect"
+          print(inspect(v.entity))
+        end
         assert.are.equal(201, status)
         assert.truthy(body)
 

--- a/spec/integration/api/api_spec.lua
+++ b/spec/integration/api/api_spec.lua
@@ -113,11 +113,6 @@ describe("Web API #web", function()
 
         local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity)
         local body = cjson.decode(response)
-        if status == 400 then
-          print(response)
-          local inspect= require "inspect"
-          print(inspect(v.entity))
-        end
         assert.are.equal(201, status)
         assert.truthy(body)
 

--- a/spec/unit/validations_spec.lua
+++ b/spec/unit/validations_spec.lua
@@ -1,7 +1,17 @@
 local schemas = require "kong.dao.schemas"
+local constants = require "kong.constants"
 local validate = schemas.validate
 
 describe("Validation #schema", function()
+
+  it("should return the right alias", function()
+    assert.are.same("number", schemas.get_type("number"))
+    assert.are.same("string", schemas.get_type("string"))
+    assert.are.same("boolean", schemas.get_type("boolean"))
+    assert.are.same("table", schemas.get_type("table"))
+    assert.are.same("string", schemas.get_type(constants.DATABASE_TYPES.ID))
+    assert.are.same("number", schemas.get_type(constants.DATABASE_TYPES.TIMESTAMP))
+  end)
 
   describe("#validate()", function()
     -- Ok kids, today we're gonna test a custom validation schema,

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -8,6 +8,10 @@ return {
     UNIQUE = "unique",
     FOREIGN = "foreign"
   },
+  DATABASE_TYPES = {
+    ID = "id",
+    TIMESTAMP = "timestamp"
+  },
   HEADERS = {
     SERVER = "Server",
     PROXY_TIME = "X-Kong-Proxy-Time",

--- a/src/dao/cassandra/accounts.lua
+++ b/src/dao/cassandra/accounts.lua
@@ -1,9 +1,10 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
+local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "id" },
-  provider_id = { unique = true, queryable = true },
-  created_at = { type = "timestamp" }
+  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  provider_id = { type = "string", unique = true, queryable = true },
+  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Accounts = BaseDao:extend()

--- a/src/dao/cassandra/accounts.lua
+++ b/src/dao/cassandra/accounts.lua
@@ -2,9 +2,9 @@ local BaseDao = require "kong.dao.cassandra.base_dao"
 local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  id = { type = constants.DATABASE_TYPES.ID },
   provider_id = { type = "string", unique = true, queryable = true },
-  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Accounts = BaseDao:extend()

--- a/src/dao/cassandra/apis.lua
+++ b/src/dao/cassandra/apis.lua
@@ -1,12 +1,13 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
+local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "id" },
-  name = { required = true, unique = true, queryable = true },
-  public_dns = { required = true, unique = true, queryable = true,
+  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  name = { type = "string", required = true, unique = true, queryable = true },
+  public_dns = { type = "string", required = true, unique = true, queryable = true,
                  regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])" },
-  target_url = { required = true },
-  created_at = { type = "timestamp" }
+  target_url = { type = "string", required = true },
+  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Apis = BaseDao:extend()

--- a/src/dao/cassandra/apis.lua
+++ b/src/dao/cassandra/apis.lua
@@ -2,12 +2,12 @@ local BaseDao = require "kong.dao.cassandra.base_dao"
 local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  id = { type = constants.DATABASE_TYPES.ID },
   name = { type = "string", required = true, unique = true, queryable = true },
   public_dns = { type = "string", required = true, unique = true, queryable = true,
                  regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])" },
   target_url = { type = "string", required = true },
-  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Apis = BaseDao:extend()

--- a/src/dao/cassandra/applications.lua
+++ b/src/dao/cassandra/applications.lua
@@ -1,11 +1,12 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
+local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "id" },
-  account_id = { type = "id", required = true, foreign = true, queryable = true },
-  public_key = { required = true, unique = true, queryable = true },
-  secret_key = {},
-  created_at = { type = "timestamp" }
+  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  account_id = { type = "string", represents = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  public_key = { type = "string", required = true, unique = true, queryable = true },
+  secret_key = { type = "string" },
+  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Applications = BaseDao:extend()

--- a/src/dao/cassandra/applications.lua
+++ b/src/dao/cassandra/applications.lua
@@ -2,11 +2,11 @@ local BaseDao = require "kong.dao.cassandra.base_dao"
 local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
-  account_id = { type = "string", represents = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  id = { type = constants.DATABASE_TYPES.ID },
+  account_id = { type = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
   public_key = { type = "string", required = true, unique = true, queryable = true },
   secret_key = { type = "string" },
-  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Applications = BaseDao:extend()

--- a/src/dao/cassandra/base_dao.lua
+++ b/src/dao/cassandra/base_dao.lua
@@ -47,13 +47,13 @@ local function encode_cassandra_values(schema, t, parameters)
     local schema_field = schema[column]
     local value = t[column]
 
-    if schema_field.type == "id" and value then
+    if schema_field.represents == constants.DATABASE_TYPES.ID and value then
       if is_valid_uuid(value) then
         value = cassandra.uuid(value)
       else
         errors = utils.add_error(errors, column, value.." is an invalid uuid")
       end
-    elseif schema_field.type == "timestamp" and value then
+    elseif schema_field.represents == constants.DATABASE_TYPES.TIMESTAMP and value then
       value = cassandra.timestamp(value)
     elseif value == nil then
       value = cassandra.null

--- a/src/dao/cassandra/base_dao.lua
+++ b/src/dao/cassandra/base_dao.lua
@@ -47,13 +47,13 @@ local function encode_cassandra_values(schema, t, parameters)
     local schema_field = schema[column]
     local value = t[column]
 
-    if schema_field.represents == constants.DATABASE_TYPES.ID and value then
+    if schema_field.type == constants.DATABASE_TYPES.ID and value then
       if is_valid_uuid(value) then
         value = cassandra.uuid(value)
       else
         errors = utils.add_error(errors, column, value.." is an invalid uuid")
       end
-    elseif schema_field.represents == constants.DATABASE_TYPES.TIMESTAMP and value then
+    elseif schema_field.type == constants.DATABASE_TYPES.TIMESTAMP and value then
       value = cassandra.timestamp(value)
     elseif value == nil then
       value = cassandra.null

--- a/src/dao/cassandra/plugins.lua
+++ b/src/dao/cassandra/plugins.lua
@@ -12,13 +12,13 @@ local function load_value_schema(plugin_t)
 end
 
 local SCHEMA = {
-  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
-  api_id = { type = "string", represents = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
-  application_id = { type = "string", represents = constants.DATABASE_TYPES.ID, foreign = true, queryable = true, default = constants.DATABASE_NULL_ID },
+  id = { type = constants.DATABASE_TYPES.ID },
+  api_id = { type = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  application_id = { type = constants.DATABASE_TYPES.ID, foreign = true, queryable = true, default = constants.DATABASE_NULL_ID },
   name = { type = "string", required = true, queryable = true, immutable = true },
   value = { type = "table", required = true, schema = load_value_schema },
   enabled = { type = "boolean", default = true },
-  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Plugins = BaseDao:extend()

--- a/src/dao/cassandra/plugins.lua
+++ b/src/dao/cassandra/plugins.lua
@@ -12,13 +12,13 @@ local function load_value_schema(plugin_t)
 end
 
 local SCHEMA = {
-  id = { type = "id" },
-  api_id = { type = "id", required = true, foreign = true, queryable = true },
-  application_id = { type = "id", foreign = true, queryable = true, default = constants.DATABASE_NULL_ID },
-  name = { required = true, queryable = true, immutable = true },
+  id = { type = "string", represents = constants.DATABASE_TYPES.ID },
+  api_id = { type = "string", represents = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  application_id = { type = "string", represents = constants.DATABASE_TYPES.ID, foreign = true, queryable = true, default = constants.DATABASE_NULL_ID },
+  name = { type = "string", required = true, queryable = true, immutable = true },
   value = { type = "table", required = true, schema = load_value_schema },
   enabled = { type = "boolean", default = true },
-  created_at = { type = "timestamp" }
+  created_at = { type = "number", represents = constants.DATABASE_TYPES.TIMESTAMP }
 }
 
 local Plugins = BaseDao:extend()

--- a/src/dao/schemas.lua
+++ b/src/dao/schemas.lua
@@ -1,5 +1,6 @@
 local rex = require "rex_pcre" -- Why? Lua has built in pattern which should do the job too
 local utils = require "kong.tools.utils"
+local constants = require "kong.constants"
 
 local LUA_TYPES = {
   boolean = true,
@@ -7,6 +8,16 @@ local LUA_TYPES = {
   number = true,
   table = true
 }
+
+local function get_type(type_val)
+  if type_val == constants.DATABASE_TYPES.ID then
+    return "string"
+  elseif type_val == constants.DATABASE_TYPES.ID then
+    return "number"
+  else
+    return type_val
+  end
+end
 
 --
 -- Schemas
@@ -38,7 +49,7 @@ function _M.validate(t, schema, is_update)
       errors = utils.add_error(errors, column, column.." is required")
 
     -- Check type if valid
-    elseif v.type ~= nil and t[column] ~= nil and type(t[column]) ~= v.type and LUA_TYPES[v.type] then
+    elseif v.type ~= nil and t[column] ~= nil and type(t[column]) ~= get_type(v.type) and LUA_TYPES[v.type] then
       errors = utils.add_error(errors, column, column.." is not a "..v.type)
 
     -- Check type if value is allowed in the enum

--- a/src/dao/schemas.lua
+++ b/src/dao/schemas.lua
@@ -9,20 +9,25 @@ local LUA_TYPES = {
   table = true
 }
 
-local function get_type(type_val)
-  if type_val == constants.DATABASE_TYPES.ID then
-    return "string"
-  elseif type_val == constants.DATABASE_TYPES.ID then
-    return "number"
-  else
-    return type_val
-  end
-end
+local LUA_TYPE_ALIASES = {
+  [constants.DATABASE_TYPES.ID] = "string",
+  [constants.DATABASE_TYPES.TIMESTAMP] = "number"
+}
 
 --
 -- Schemas
 --
 local _M = {}
+
+
+-- Returns the proper Lua type from a schema type, handling aliases
+-- @param {string} type_val The type of the schema property
+-- @return {string} A valid Lua type
+function _M.get_type(type_val)
+  local alias = LUA_TYPE_ALIASES[type_val]
+  return alias and alias or type_val
+end
+
 
 -- Validate a table against a given schema
 -- @param {table} t Table to validate
@@ -49,7 +54,7 @@ function _M.validate(t, schema, is_update)
       errors = utils.add_error(errors, column, column.." is required")
 
     -- Check type if valid
-    elseif v.type ~= nil and t[column] ~= nil and type(t[column]) ~= get_type(v.type) and LUA_TYPES[v.type] then
+    elseif v.type ~= nil and t[column] ~= nil and type(t[column]) ~= _M.get_type(v.type) and LUA_TYPES[v.type] then
       errors = utils.add_error(errors, column, column.." is not a "..v.type)
 
     -- Check type if value is allowed in the enum

--- a/src/plugins/ratelimiting/schema.lua
+++ b/src/plugins/ratelimiting/schema.lua
@@ -2,5 +2,5 @@ local constants = require "kong.constants"
 
 return {
   limit = { required = true, type = "number" },
-  period = { required = true, enum = constants.RATELIMIT.PERIODS }
+  period = { required = true, type = "string", enum = constants.RATELIMIT.PERIODS }
 }

--- a/src/plugins/tcplog/schema.lua
+++ b/src/plugins/tcplog/schema.lua
@@ -1,6 +1,6 @@
 return {
-  host = { required = true },
-  port = { required = true },
-  timeout = { required = false, default = 10000 },
-  keepalive = { required = false, default = 60000 }
+  host = { required = true, type = "string" },
+  port = { required = true, type = "number" },
+  timeout = { required = false, default = 10000, type = "number" },
+  keepalive = { required = false, default = 60000, type = "number" }
 }

--- a/src/plugins/udplog/schema.lua
+++ b/src/plugins/udplog/schema.lua
@@ -1,5 +1,5 @@
 return {
-  host = { required = true },
-  port = { required = true },
-  timeout = { required = false, default = 10000 }
+  host = { required = true, type = "string" },
+  port = { required = true, type = "number" },
+  timeout = { required = false, default = 10000, type = "number" }
 }


### PR DESCRIPTION
Addressing this issue: https://github.com/Mashape/kong/commit/bb12c8189b5bca5217046c1c2733c670c1ea782f#commitcomment-10298943

I am not happy because it introduces one more property in the schemas. In the early days we tried to fix this with convention but it didn't work out well because of edge-cases, but maybe we can stil try going through that path. 

To recap before we tried to fix this problem with convention and we tried to get everything that ended with `*id` and treat it as an UUID. This didn't always work well because some properties, like `accounts.provider_id`, are not UUIDs but custom strings.

So we decided to make `id` and `timestamp` data types, but they really are `string` and `number`. We have three options here:

* Fixing the convention problem, but it's not going to be scalable in the future
* Extending the types and make the **implicit** assumption that `id` is always going to be `string` and `timestamp` is always going to be a `number`.
* Introducing `represents` or something like that.