### PR TITLE
Fixing auto-migration of DB

### DIFF
--- a/src/cli/utils/start.lua
+++ b/src/cli/utils/start.lua
@@ -70,7 +70,7 @@ function _M.start(args_config)
     cutils.logger:error_exit(err)
   elseif keyspace == nil then
     cutils.logger:log("Database not initialized. Running migrations...")
-    local migrations = require("kong.tools.migrations")(dao_factory)
+    local migrations = require("kong.tools.migrations")(dao_factory, cutils.get_luarocks_install_dir())
     migrations:migrate(function(migration, err)
       if err then
         cutils.logger:error_exit(err)


### PR DESCRIPTION
When installing Kong for the first time on Docker the auto-migration on `kong start` seems to be failing because the path to the migration file is wrong. This pull-request fixes this problem making the behavior of `kong start` identical to `kong migrations:up`.

@thibaultCha please review and merge - this needs to be into `0.1.0` release in order to have a working Docker distribution.