### PR TITLE
Real IP and OpenResty build options

### DIFF
--- a/.travis/setup_openresty.sh
+++ b/.travis/setup_openresty.sh
@@ -6,7 +6,7 @@ sudo apt-get update && sudo apt-get install libreadline-dev libncurses5-dev libp
 
 curl http://openresty.org/download/$OPENRESTY_BASE.tar.gz | tar xz
 cd $OPENRESTY_BASE
-./configure
+./configure --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module
 make && sudo make install
 cd $TRAVIS_BUILD_DIR
 rm -rf $OPENRESTY_BASE

--- a/kong.yml
+++ b/kong.yml
@@ -67,6 +67,10 @@ nginx: |
     proxy_busy_buffers_size 256k;
     proxy_ssl_server_name on;
 
+    # IP Address
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 0.0.0.0/0;
+
     # Other Settings
     client_max_body_size 128m;
     underscores_in_headers on;

--- a/kong.yml
+++ b/kong.yml
@@ -70,6 +70,7 @@ nginx: |
     # IP Address
     real_ip_header X-Forwarded-For;
     set_real_ip_from 0.0.0.0/0;
+    real_ip_recursive on;
 
     # Other Settings
     client_max_body_size 128m;

--- a/spec/integration/proxy/log_spec.lua
+++ b/spec/integration/proxy/log_spec.lua
@@ -2,8 +2,16 @@ local spec_helper = require "spec.spec_helpers"
 local http_client = require "kong.tools.http_client"
 local Threads = require "llthreads2.ex"
 local cjson = require "cjson"
+local yaml = require "yaml"
+local IO = require "kong.tools.io"
+local uuid = require "uuid"
+local rex = require "rex_pcre"
+
+-- This is important to seed the UUID generator
+uuid.seed()
 
 local STUB_GET_URL = spec_helper.STUB_GET_URL
+local TEST_CONF = "kong_TEST.yml"
 
 local function start_tcp_server()
   local thread = Threads.new({
@@ -85,21 +93,41 @@ describe("Logging Plugins #proxy", function()
       assert.are.same("127.0.0.1", log_message.ip)
     end)
 
-    it("should log to file", function()
-      local thread = start_udp_server() -- Starting the mock TCP server
+    it("should log to file", function() 
+      local uuid,_ = string.gsub(uuid(), "-", "")
 
       -- Making the request
-      local response, status, headers = http_client.get(STUB_GET_URL, {apikey = "apikey123"}, {host = "test.com"})
+      local response, status, headers = http_client.get(STUB_GET_URL, {apikey = "apikey123"}, {host = "test.com", file_log_uuid = uuid})
       assert.are.equal(200, status)
 
-      -- Getting back the TCP server input
-      local ok, res = thread:join()
-      assert.truthy(ok)
-      assert.truthy(res)
+      -- Reading the log file and finding the entry
+      local configuration = yaml.load(IO.read_file(TEST_CONF))
+      assert.truthy(configuration)
+      local error_log = IO.read_file(configuration.nginx_working_dir.."/logs/error.log")
+      local line
+      local lines = stringy.split(error_log, "\n")
+      for _, v in ipairs(lines) do
+        if string.find(v, uuid) then
+          line = v
+          break
+        end
+      end
+      assert.truthy(line)
 
-      -- Making sure it's alright
-      local log_message = cjson.decode(res)
+      -- Matching the Json 
+      local iterator, iter_err = rex.gmatch(line, "\\s+({.+})\\s+")
+      if not iterator then
+        error(iter_err)
+      end
+      local m, err = iterator()
+      if err then
+        error(err)
+      end
+      assert.truthy(m)
+
+      local log_message = cjson.decode(m)
       assert.are.same("127.0.0.1", log_message.ip)
+      assert.are.same(uuid, log_message.request.headers.file_log_uuid)
     end)
 
   end)

--- a/spec/integration/proxy/realip_spec.lua
+++ b/spec/integration/proxy/realip_spec.lua
@@ -1,0 +1,69 @@
+local spec_helper = require "spec.spec_helpers"
+local http_client = require "kong.tools.http_client"
+local Threads = require "llthreads2.ex"
+local cjson = require "cjson"
+local yaml = require "yaml"
+local IO = require "kong.tools.io"
+local uuid = require "uuid"
+local rex = require "rex_pcre"
+
+-- This is important to seed the UUID generator
+uuid.seed()
+
+local STUB_GET_URL = spec_helper.STUB_GET_URL
+local TEST_CONF = "kong_TEST.yml"
+
+describe("Logging Plugins #proxy", function()
+
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+    spec_helper.reset_db()
+  end)
+
+  describe("Invalid API", function()
+
+    it("should log to file", function()
+      local uuid,_ = string.gsub(uuid(), "-", "")
+
+      -- Making the request
+      local response, status, headers = http_client.get(STUB_GET_URL, {apikey = "apikey123"}, {host = "test.com", ["X-Forwarded-For"] = "4.4.4.4, 1.1.1.1, 5.5.5.5", file_log_uuid = uuid})
+      assert.are.equal(200, status)
+
+      -- Reading the log file and finding the entry
+      local configuration = yaml.load(IO.read_file(TEST_CONF))
+      assert.truthy(configuration)
+      local error_log = IO.read_file(configuration.nginx_working_dir.."/logs/error.log")
+      local line
+      local lines = stringy.split(error_log, "\n")
+      for _, v in ipairs(lines) do
+        if string.find(v, uuid) then
+          line = v
+          break
+        end
+      end
+      assert.truthy(line)
+
+      -- Matching the Json 
+      local iterator, iter_err = rex.gmatch(line, "\\s+({.+})\\s+")
+      if not iterator then
+        error(iter_err)
+      end
+      local m, err = iterator()
+      if err then
+        error(err)
+      end
+      assert.truthy(m)
+
+      local log_message = cjson.decode(m)
+      assert.are.same("4.4.4.4", log_message.ip)
+      assert.are.same(uuid, log_message.request.headers.file_log_uuid)
+    end)
+
+  end)
+
+end)


### PR DESCRIPTION
This pull request fixes #109 and also enables different configuration options for OpenResty.

OpenResty needs to be recompiled with the following arguments:

```
--with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module
```

For OS X you also want to enable:
```
--with-cc-opt="-I/usr/local/include" --with-ld-opt="-L/usr/local/lib"
```

This will enable:

* ipv6 support
* real ip module
* SSL support
* stub status module that can be used to retrieve nginx connections status


> If your system environment is modern enough, then you almost always want to enable the PCRE JIT support and IPv6 support in your NGINX by passing the --with-pcre-jit and --with-ipv6 options to the ./configure script.

The core team also needs to recompile OpenResty with those modules on their computers @thibaultCha 
