### PR TITLE
Feat/ports properties

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -12,7 +12,7 @@ nginx_working_dir: /usr/local/kong/
 
 # Ports
 proxy_port: 8000
-api_port: 8001
+admin_port: 8001
 
 # Specify the DAO to use
 database: cassandra
@@ -150,7 +150,7 @@ nginx: |
     }
 
     server {
-      listen {{api_port}};
+      listen {{admin_port}};
 
       location / {
         default_type application/json;
@@ -175,7 +175,7 @@ nginx: |
         return 200 'User-agent: *\nDisallow: /';
       }
 
-      # Do not remove
-      {{nginx_plus_status}}
+      # Do not remove, additional configuration placeholder for some plugins
+      # {{additional_configuration}}
     }
   }

--- a/kong.yml
+++ b/kong.yml
@@ -10,6 +10,10 @@ plugins_available:
 # Nginx prefix path directory
 nginx_working_dir: /usr/local/kong/
 
+# Ports
+proxy_port: 8000
+api_port: 8002
+
 # Specify the DAO to use
 database: cassandra
 
@@ -27,7 +31,7 @@ databases_available:
 send_anonymous_reports: true
 
 # Nginx Plus Status
-nginx_plus_status: false
+nginx_plus_status: true
 
 # Cache configuration
 cache:
@@ -103,7 +107,7 @@ nginx: |
     ';
 
     server {
-      listen 8000;
+      listen {{proxy_port}};
 
       location / {
         # Assigns the default MIME-type to be used for files where the
@@ -146,7 +150,7 @@ nginx: |
     }
 
     server {
-      listen 8001;
+      listen {{api_port}};
 
       location / {
         default_type application/json;

--- a/kong.yml
+++ b/kong.yml
@@ -12,7 +12,7 @@ nginx_working_dir: /usr/local/kong/
 
 # Ports
 proxy_port: 8000
-api_port: 8002
+api_port: 8001
 
 # Specify the DAO to use
 database: cassandra
@@ -31,7 +31,7 @@ databases_available:
 send_anonymous_reports: true
 
 # Nginx Plus Status
-nginx_plus_status: true
+nginx_plus_status: false
 
 # Cache configuration
 cache:
@@ -175,8 +175,7 @@ nginx: |
         return 200 'User-agent: *\nDisallow: /';
       }
 
-      # Do not remove the following comment
-      # plugin_configuration_placeholder
-
+      # Do not remove
+      {{nginx_plus_status}}
     }
   }

--- a/kong/cli/config.lua
+++ b/kong/cli/config.lua
@@ -28,8 +28,8 @@ local DEFAULT_ENV_VALUES = {
     ["keyspace: kong"] = "keyspace: kong_tests",
     ["lua_package_path ';;'"] = "lua_package_path './kong/?.lua;;'",
     ["error_log logs/error.log info"] = "error_log logs/error.log debug",
-    ["listen 8000"] = "listen 8100",
-    ["listen 8001"] = "listen 8101"
+    ["proxy_port: 8000"] = "proxy_port: 8100",
+    ["admin_port: 8001"] = "admin_port: 8101"
   },
   DEVELOPMENT = {
     ["nginx_working_dir: /usr/local/kong/"] = "nginx_working_dir: nginx_tmp",

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -16,18 +16,19 @@ local KONG_SYSLOG = "kong-hf.mashape.com"
 -- Retrieve the desired Kong config file, parse it and provides a DAO factory
 -- Will cache them for future retrieval
 -- @param args_config Path to the desired configuration (usually from the --config CLI argument)
--- @return Path to desired Kong config
 -- @return Parsed desired Kong configuration
+-- @return Path to desired Kong config
 -- @return Instanciated DAO factory
-local function get_kong_config_path(args_config)
+local function get_kong_config(args_config)
   -- Get configuration from default or given path
   if not kong_config_path then
     kong_config_path = cutils.get_kong_config_path(args_config)
+    cutils.logger:info("Using configuration: "..kong_config_path)
   end
   if not kong_config then
     kong_config, dao_factory = IO.load_configuration_and_dao(kong_config_path)
   end
-  return kong_config_path, kong_config, dao_factory
+  return kong_config, kong_config_path, dao_factory
 end
 
 -- Check if an executable (typically `nginx`) is a distribution of openresty
@@ -72,7 +73,7 @@ end
 -- Extract the nginx config from a Kong config file into an `nginx.conf` file
 -- @param args_config Path to the desired configuration (usually from the --config CLI argument)
 local function prepare_nginx_working_dir(args_config)
-  local _, kong_config = get_kong_config_path(args_config)
+  local kong_config = get_kong_config(args_config)
 
   -- Create nginx folder if needed
   local _, err = IO.path:mkdir(IO.path:join(kong_config.nginx_working_dir, "logs"))
@@ -85,10 +86,15 @@ local function prepare_nginx_working_dir(args_config)
 
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = kong_config.nginx
+  local nginx_inject = {
+    nginx_plus_status = kong_config.nginx_plus_status and "location /status { status; }" or "",
+    proxy_port = kong_config.proxy_port,
+    api_port = kong_config.api_port
+  }
 
-  -- Inject ports
-  for _, v in ipairs({ "proxy_port", "api_port" }) do
-    nginx_config = nginx_config:gsub("{{"..v.."}}", kong_config[v])
+  -- Inject properties
+  for k, v in pairs(nginx_inject) do
+    nginx_config = nginx_config:gsub("{{"..k.."}}", v)
   end
 
   -- Inject anonymous reports
@@ -102,13 +108,6 @@ local function prepare_nginx_working_dir(args_config)
     end
   end
 
-  -- Inject nginx plus status
-  if kong_config.nginx_plus_status then
-    local padding = "    "
-    local nginx_plus_status = padding.."location /status {\n"..padding.."  status;\n"..padding.."}"
-    nginx_config = nginx_config:gsub("plugin_configuration_placeholder", "plugin_configuration_placeholder\n"..nginx_plus_status)
-  end
-
   -- Write nginx config
   local ok, err = IO.write_to_file(IO.path:join(kong_config.nginx_working_dir, constants.CLI.NGINX_CONFIG), nginx_config)
   if not ok then
@@ -116,22 +115,10 @@ local function prepare_nginx_working_dir(args_config)
   end
 end
 
--- Prettifies table properties in a nice human readable way
--- @return The prettified string
-local function prettify_table_properties(t)
-  local result = ""
-  for k, v in pairs(t) do
-    result = result..k.."="..v.." "
-  end
-  return result == "" and result or result:sub(1, string.len(result) - 1)
-end
-
 -- Prepare the database keyspace if needed (run schema migrations)
 -- @param args_config Path to the desired configuration (usually from the --config CLI argument)
 local function prepare_database(args_config)
-  local _, kong_config, dao_factory = get_kong_config_path(args_config)
-
-  cutils.logger:info("database: "..kong_config.database.." "..prettify_table_properties(kong_config.databases_available[kong_config.database].properties))
+  local kong_config, _, dao_factory = get_kong_config(args_config)
 
   -- Migrate the DB if needed and possible
   local keyspace, err = dao_factory:get_migrations()
@@ -150,11 +137,33 @@ local function prepare_database(args_config)
   end
 end
 
+-- Prettifies table properties in a nice human readable way
+-- @return The prettified string
+local function prettify_table_properties(t)
+  local result = ""
+  for k, v in pairs(t) do
+    result = result..k.."="..v.." "
+  end
+  return result == "" and result or result:sub(1, string.len(result) - 1)
+end
+
 local _M = {}
 
 function _M.prepare_kong(args_config)
+  local kong_config, kong_config_path = get_kong_config(args_config)
+
   prepare_nginx_working_dir(args_config)
   prepare_database(args_config)
+
+  -- Print important informations
+  cutils.logger:info(string.format([[Proxy port...%s
+       API port.....%s
+       Database.....%s %s
+  ]],
+  kong_config.proxy_port,
+  kong_config.api_port,
+  kong_config.database,
+  prettify_table_properties(kong_config.databases_available[kong_config.database].properties)))
 end
 
 -- Send a signal to `nginx`. No signal will start the process
@@ -168,11 +177,9 @@ function _M.send_signal(args_config, signal)
   local nginx_path = find_nginx()
   if not nginx_path then
     cutils.logger:error_exit(string.format("Kong cannot find an 'nginx' executable.\nMake sure it is in your $PATH or in one of the following directories:\n%s", table.concat(NGINX_SEARCH_PATHS, "\n")))
-  else
-    cutils.logger:info("nginx: "..nginx_path)
   end
 
-  local kong_config_path, kong_config = get_kong_config_path(args_config)
+  local kong_config, kong_config_path = get_kong_config(args_config)
 
   -- Build nginx signal command
   local cmd = string.format("KONG_CONF=%s %s -p %s -c %s -g 'pid %s;' %s",
@@ -190,7 +197,7 @@ end
 -- @param args_config Path to the desired configuration (usually from the --config CLI argument)
 function _M.is_running(args_config)
   -- Get configuration from default or given path
-  local _, kong_config = get_kong_config_path(args_config)
+  local kong_config = get_kong_config(args_config)
 
   local pid_file = IO.path:join(kong_config.nginx_working_dir, constants.CLI.NGINX_PID)
 

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -87,14 +87,22 @@ local function prepare_nginx_working_dir(args_config)
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = kong_config.nginx
   local nginx_inject = {
-    nginx_plus_status = kong_config.nginx_plus_status and "location /status { status; }" or "",
     proxy_port = kong_config.proxy_port,
-    api_port = kong_config.api_port
+    admin_port = kong_config.admin_port
   }
 
   -- Inject properties
   for k, v in pairs(nginx_inject) do
     nginx_config = nginx_config:gsub("{{"..k.."}}", v)
+  end
+
+  -- Inject additional configurations
+  nginx_inject = {
+    nginx_plus_status = kong_config.nginx_plus_status and "location /status { status; }" or nil
+  }
+
+  for _, v in pairs(nginx_inject) do
+    nginx_config = nginx_config:gsub("# {{additional_configuration}}", "# {{additional_configuration}}\n    "..v)
   end
 
   -- Inject anonymous reports
@@ -161,7 +169,7 @@ function _M.prepare_kong(args_config)
        Database.....%s %s
   ]],
   kong_config.proxy_port,
-  kong_config.api_port,
+  kong_config.admin_port,
   kong_config.database,
   prettify_table_properties(kong_config.databases_available[kong_config.database].properties)))
 end

--- a/kong/cli/utils/utils.lua
+++ b/kong/cli/utils/utils.lua
@@ -18,7 +18,7 @@ for _, v in ipairs({"red", "green", "yellow", "blue"}) do
   colors[v] = function(str) return ansicolors("%{"..v.."}"..str.."%{reset}") end
 end
 
-function trim(s)
+local function trim(s)
   return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
@@ -106,28 +106,21 @@ local function get_luarocks_install_dir()
 end
 
 local function get_kong_config_path(args_config)
+  local config_path = args_config
+
   -- Use the rock's config if no config at default location
-  if not IO.file_exists(args_config) then
-    logger:warn("No configuration at: "..args_config.." using default config instead.")
-    args_config = IO.path:join(get_luarocks_config_dir(), "kong.yml")
+  if not IO.file_exists(config_path) then
+    logger:warn("No configuration at: "..config_path.." using default config instead.")
+    config_path = IO.path:join(get_luarocks_config_dir(), "kong.yml")
   end
 
   -- Make sure the configuration file really exists
-  if not IO.file_exists(args_config) then
-    logger:warn("No configuration at: "..args_config)
+  if not IO.file_exists(config_path) then
+    logger:warn("No configuration at: "..config_path)
     logger:error_exit("Could not find a configuration file.")
   end
 
-  logger:info("configuration: "..args_config)
-
-  -- TODO: validate configuration
-  --[[local status, res = pcall(require, "kong.dao."..config.database..".factory")
-    if not status then
-      logger:error("Erroneous config")
-      os.exit(1)
-    end]]
-
-  return args_config
+  return config_path
 end
 
 return {

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -47,6 +47,10 @@ plugins_available:
 # Nginx prefix path directory
 nginx_working_dir: /usr/local/kong/
 
+# Ports
+proxy_port: 8000
+admin_port: 8001
+
 # Specify the DAO to use
 database: cassandra
 
@@ -140,7 +144,7 @@ nginx: |
     ';
 
     server {
-      listen 8000;
+      listen {{proxy_port}};
 
       location / {
         # Assigns the default MIME-type to be used for files where the
@@ -183,7 +187,7 @@ nginx: |
     }
 
     server {
-      listen 8001;
+      listen {{admin_port}};
 
       location / {
         default_type application/json;
@@ -208,9 +212,8 @@ nginx: |
         return 200 'User-agent: *\nDisallow: /';
       }
 
-      # Do not remove the following comment
-      # plugin_configuration_placeholder
-
+      # Do not remove, additional configuration placeholder for some plugins
+      # {{additional_configuration}}
     }
   }
 ]], configuration)


### PR DESCRIPTION
#120 

```
MA_kong|feat/ports-properties ⇒ kong start
[WARN] No configuration at: /etc/kong/kong.yml using default config instead.
[INFO] Using configuration: /usr/local/lib/luarocks/rocks/kong/0.2.0-1/conf/kong.yml
[INFO] Proxy port...8000
       API port.....8001
       Database.....cassandra keepalive=60000 hosts=127.0.0.1 port=9042 timeout=1000 keyspace=kong
[OK] Started
```