### PR TITLE
[refactor] dao prepare

### DIFF
--- a/kong/cli/db.lua
+++ b/kong/cli/db.lua
@@ -38,11 +38,6 @@ if args.command == "seed" then
     cutils.logger:error_exit(err)
   end
 
-  local err = dao_factory:prepare()
-  if err then
-    cutils.logger:error(err)
-  end
-
   local faker = Faker(dao_factory)
   faker:seed(args.random and args.number or nil)
   cutils.logger:success("Populated")

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -87,7 +87,7 @@ end
 function BaseDao:_check_unique(statement, t, is_updating)
   local results, err = self:_execute(statement, t)
   if err then
-    return false, "Error during UNIQUE check: "..err
+    return false, "Error during UNIQUE check: "..err.message
   elseif results and #results > 0 then
     if not is_updating then
       return false
@@ -118,7 +118,7 @@ end
 function BaseDao:_check_foreign(statement, t)
   local results, err = self:_execute(statement, t)
   if err then
-    return false, "Error during FOREIGN check: "..err
+    return false, "Error during FOREIGN check: "..err.message
   elseif not results or #results == 0 then
     return false
   else

--- a/kong/dao/cassandra/factory.lua
+++ b/kong/dao/cassandra/factory.lua
@@ -61,25 +61,29 @@ function CassandraFactory:drop()
   ]]
 end
 
--- Prepare all statements in collection._queries and put them in collection._statements.
+-- Prepare all statements in collection._queries and put them in statements cache
 -- Should be called with only a collection and will recursively call itself for nested statements.
 -- @param collection A collection with a ._queries property
-local function prepare_collection(collection, queries, statements)
-  if not queries then queries = collection._queries end
-  if not statements then statements = collection._statements end
+local function prepare_collection(collection, collection_queries)
+  if not collection_queries then collection_queries = collection._queries end
 
-  for stmt_name, query in pairs(queries) do
-    if type(query) == "table" and query.query == nil then
-      collection._statements[stmt_name] = {}
-      prepare_collection(collection, query, collection._statements[stmt_name])
+  for stmt_name, collection_query in pairs(collection_queries) do
+    if type(collection_query) == "table" and collection_query.query == nil then
+      -- Nested queries, let's recurse to prepare them too
+      prepare_collection(collection, collection_query)
     else
-      local q = stringy.strip(query.query)
-      q = string.format(q, "")
-      local kong_stmt, err = collection:prepare_kong_statement(q, query.params)
+      -- _queries can contain strings or tables with string + keys of parameters to bind
+      local query_to_prepare
+      if type(collection_query) == "string" then
+        query_to_prepare = collection_query
+      elseif collection_query.query then
+        query_to_prepare = collection_query.query
+      end
+
+      local _, err = collection:prepare_kong_statement(query_to_prepare, collection_query.params)
       if err then
         error(err)
       end
-      statements[stmt_name] = kong_stmt
     end
   end
 end

--- a/kong/dao/cassandra/factory.lua
+++ b/kong/dao/cassandra/factory.lua
@@ -5,10 +5,10 @@ local stringy = require "stringy"
 local Object = require "classic"
 
 local Apis = require "kong.dao.cassandra.apis"
-local RateLimitingMetrics = require "kong.dao.cassandra.ratelimiting_metrics"
-local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 local Consumers = require "kong.dao.cassandra.consumers"
+local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 local BasicAuthCredentials = require "kong.dao.cassandra.basicauth_credentials"
+local RateLimitingMetrics = require "kong.dao.cassandra.ratelimiting_metrics"
 local KeyAuthCredentials = require "kong.dao.cassandra.keyauth_credentials"
 
 local CassandraFactory = Object:extend()
@@ -43,21 +43,21 @@ function CassandraFactory:new(properties)
   self._properties.hosts = normalize_localhost(self._properties.hosts)
 
   self.apis = Apis(properties)
-  self.ratelimiting_metrics = RateLimitingMetrics(properties)
-  self.plugins_configurations = PluginsConfigurations(properties)
   self.consumers = Consumers(properties)
+  self.plugins_configurations = PluginsConfigurations(properties)
   self.basicauth_credentials = BasicAuthCredentials(properties)
+  self.ratelimiting_metrics = RateLimitingMetrics(properties)
   self.keyauth_credentials = KeyAuthCredentials(properties)
 end
 
 function CassandraFactory:drop()
   return self:execute_queries [[
     TRUNCATE apis;
-    TRUNCATE ratelimiting_metrics;
-    TRUNCATE plugins_configurations;
     TRUNCATE consumers;
+    TRUNCATE plugins_configurations;
     TRUNCATE basicauth_credentials;
     TRUNCATE keyauth_credentials;
+    TRUNCATE ratelimiting_metrics;
   ]]
 end
 
@@ -88,9 +88,9 @@ end
 -- @return error if any
 function CassandraFactory:prepare()
   for _, collection in ipairs({ self.apis,
-                                self.ratelimiting_metrics,
-                                self.plugins_configurations,
                                 self.consumers,
+                                self.plugins_configurations,
+                                self.ratelimiting_metrics,
                                 self.basicauth_credentials,
                                 self.keyauth_credentials }) do
     local status, err = pcall(function() prepare_collection(collection) end)

--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -102,7 +102,7 @@ function PluginsConfigurations:find_distinct()
 
   -- Execute query
   local distinct_names = {}
-  for _, rows, page, err in session:execute(self._statements.select.query, nil, {auto_paging=true}) do
+  for _, rows, page, err in session:execute(self._queries.select.query, nil, {auto_paging=true}) do
     if err then
       return nil, err
     end

--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -102,7 +102,7 @@ function PluginsConfigurations:find_distinct()
 
   -- Execute query
   local distinct_names = {}
-  for _, rows, page, err in session:execute(self._queries.select.query, nil, {auto_paging=true}) do
+  for _, rows, page, err in session:execute(string.format(self._queries.select.query, ""), nil, {auto_paging=true}) do
     if err then
       return nil, err
     end

--- a/kong/dao/cassandra/ratelimiting_metrics.lua
+++ b/kong/dao/cassandra/ratelimiting_metrics.lua
@@ -6,24 +6,18 @@ local RateLimitingMetrics = BaseDao:extend()
 
 function RateLimitingMetrics:new(properties)
   self._queries = {
-    increment_counter = {
-      query = [[ UPDATE ratelimiting_metrics SET value = value + 1 WHERE api_id = ? AND
-                                                            identifier = ? AND
-                                                            period_date = ? AND
-                                                            period = ?; ]]
-    },
-    select_one = {
-      query = [[ SELECT * FROM ratelimiting_metrics WHERE api_id = ? AND
-                                             identifier = ? AND
-                                             period_date = ? AND
-                                             period = ?; ]]
-    },
-    delete = {
-      query = [[ DELETE FROM ratelimiting_metrics WHERE api_id = ? AND
-                                           identifier = ? AND
-                                           period_date = ? AND
-                                           period = ?; ]]
-    }
+    increment_counter = [[ UPDATE ratelimiting_metrics SET value = value + 1 WHERE api_id = ? AND
+                            identifier = ? AND
+                            period_date = ? AND
+                            period = ?; ]],
+    select_one = [[ SELECT * FROM ratelimiting_metrics WHERE api_id = ? AND
+                      identifier = ? AND
+                      period_date = ? AND
+                      period = ?; ]],
+    delete = [[ DELETE FROM ratelimiting_metrics WHERE api_id = ? AND
+                  identifier = ? AND
+                  period_date = ? AND
+                  period = ?; ]]
   }
 
   RateLimitingMetrics.super.new(self, properties)
@@ -34,7 +28,7 @@ function RateLimitingMetrics:increment(api_id, identifier, current_timestamp)
   local batch = cassandra.BatchStatement(cassandra.batch_types.COUNTER)
 
   for period, period_date in pairs(periods) do
-    batch:add(self._statements.increment_counter.query, {
+    batch:add(self._queries.increment_counter, {
       cassandra.uuid(api_id),
       identifier,
       cassandra.timestamp(period_date),
@@ -48,7 +42,7 @@ end
 function RateLimitingMetrics:find_one(api_id, identifier, current_timestamp, period)
   local periods = timestamp.get_timestamps(current_timestamp)
 
-  local metric, err = RateLimitingMetrics.super._execute(self, self._statements.select_one, {
+  local metric, err = RateLimitingMetrics.super._execute(self, self._queries.select_one, {
     cassandra.uuid(api_id),
     identifier,
     cassandra.timestamp(periods[period]),
@@ -71,19 +65,19 @@ end
 
 -- Unsuported
 function RateLimitingMetrics:insert()
-  error("ratelimiting_metrics:insert() not supported")
+  error("ratelimiting_metrics:insert() not supported", 2)
 end
 
 function RateLimitingMetrics:update()
-  error("ratelimiting_metrics:update() not supported")
+  error("ratelimiting_metrics:update() not supported", 2)
 end
 
 function RateLimitingMetrics:find()
-  error("ratelimiting_metrics:find() not supported")
+  error("ratelimiting_metrics:find() not supported", 2)
 end
 
 function RateLimitingMetrics:find_by_keys()
-  error("ratelimiting_metrics:find_by_keys() not supported")
+  error("ratelimiting_metrics:find_by_keys() not supported", 2)
 end
 
 return RateLimitingMetrics

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -139,7 +139,8 @@ function _M.init()
   -- Loading configuration
   configuration, dao = IO.load_configuration_and_dao(os.getenv("KONG_CONF"))
 
-  -- Initializing DAO
+  -- Prepare all collections' statements. Even if optional, this call is useful to check
+  -- all statements are valid in advance.
   local err = dao:prepare()
   if err then
     error(err)

--- a/spec/integration/cli/start_spec.lua
+++ b/spec/integration/cli/start_spec.lua
@@ -3,7 +3,7 @@ local utils = require "kong.tools.utils"
 local yaml = require "yaml"
 local IO = require "kong.tools.io"
 
-local TEST_CONF = "kong_TEST.yml"
+local TEST_CONF = spec_helper.get_env().conf_file
 local SERVER_CONF = "kong_TEST_SERVER.yml"
 
 local function replace_conf_property(key, value)

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -97,7 +97,13 @@ function _M.prepare_db(conf_file)
     error(err)
   end
 
-  -- 3. Seed DB with our default data. This will throw any necessary error
+  -- 3. Prepare
+  local err = env.dao_factory:prepare()
+  if err then
+    error(err)
+  end
+
+  -- 4. Seed DB with our default data. This will throw any necessary error
   env.faker:seed()
 end
 

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -90,13 +90,8 @@ function _M.prepare_db(conf_file)
     end
   end)
 
-  -- 2. Prepare statements
-  local err = env.dao_factory:prepare()
-  if err then
-    error(err)
-  end
-
-  -- 3. Drop just to be sure
+  -- 2. Drop just to be sure if the test suite previously crashed for ex
+  --    Otherwise we might try to insert already existing data.
   local err = env.dao_factory:drop()
   if err then
     error(err)

--- a/spec/unit/dao/cassandra_spec.lua
+++ b/spec/unit/dao/cassandra_spec.lua
@@ -11,27 +11,27 @@ local uuid = require "uuid"
 -- Raw session for double-check purposes
 local session
 -- Load everything we need from the spec_helper
-local env = spec_helper.get_env()
+local env = spec_helper.get_env() -- test environment
 local faker = env.faker
 local dao_factory = env.dao_factory
 local configuration = env.configuration
 configuration.cassandra = configuration.databases_available[configuration.database].properties
 
--- An utility function to apply tests on each collection
-local function describe_all_collections(tests_cb)
+-- An utility function to apply tests on core collections.
+local function describe_core_collections(tests_cb)
   for type, dao in pairs({ api = dao_factory.apis,
                            consumer = dao_factory.consumers,
-                           keyauth_credential = dao_factory.keyauth_credentials,
-                           basicauth_credential = dao_factory.basicauth_credentials,
                            plugin_configuration = dao_factory.plugins_configurations }) do
 
-    local collection = type=="plugin_configuration" and "plugins_configurations" or type.."s"
+    local collection = type == "plugin_configuration" and "plugins_configurations" or type.."s"
     describe(collection, function()
       tests_cb(type, collection)
     end)
   end
 end
 
+-- An utility function to test if an object is a DaoError.
+-- Naming is due to luassert extensibility's restrictions
 local function daoError(state, arguments)
   local stub_err = DaoError("", "")
   return getmetatable(stub_err) == getmetatable(arguments[1])
@@ -43,12 +43,12 @@ say:set("assertion.daoError.negative", "Expected %s\nto not be a DaoError")
 assert:register("assertion", "daoError", daoError, "assertion.daoError.positive", "assertion.daoError.negative")
 
 -- Let's go
-describe("Cassandra DAO #dao #cassandra", function()
+describe("Cassandra DAO", function()
 
   setup(function()
     spec_helper.prepare_db()
 
-    -- Create a session to verify the dao's behaviour
+    -- Create a parallel session to verify the dao's behaviour
     session = cassandra.new()
     session:set_timeout(configuration.cassandra.timeout)
 
@@ -67,28 +67,9 @@ describe("Cassandra DAO #dao #cassandra", function()
     spec_helper.reset_db()
   end)
 
-  describe("Factory", function()
+  describe("Collections schemas", function()
 
-    it("should raise an error if cannot connect to Cassandra", function()
-      pending("Stubbing :prepare for now")
-      local new_factory = CassandraFactory({ hosts = "127.0.0.1",
-                                             port = 45678,
-                                             timeout = 1000,
-                                             keyspace = configuration.cassandra.keyspace
-      })
-
-      local err = new_factory:prepare()
-      assert.truthy(err)
-      assert.is_daoError(err)
-      assert.True(err.database)
-      assert.are.same("connection refused", err.message)
-    end)
-
-  end)
-
-  describe("Schemas", function()
-
-    describe_all_collections(function(type, collection)
+    describe_core_collections(function(type, collection)
 
       it("should have statements for all unique and foreign schema fields", function()
         for column, schema_field in pairs(dao_factory[collection]._schema) do
@@ -104,580 +85,702 @@ describe("Cassandra DAO #dao #cassandra", function()
     end)
   end)
 
-  describe(":insert()", function()
+  describe("Factory", function()
 
-    describe("APIs", function()
+    describe(":prepare()", function()
 
-      it("should insert in DB and add generated values", function()
-        local api_t = faker:fake_entity("api")
-        local api, err = dao_factory.apis:insert(api_t)
+      it("should prepare all queries in collection's _queries", function()
+        local new_factory = CassandraFactory({ hosts = "127.0.0.1",
+                                               port = 9042,
+                                               timeout = 1000,
+                                               keyspace = configuration.cassandra.keyspace
+        })
+
+        local err = new_factory:prepare()
         assert.falsy(err)
-        assert.truthy(api.id)
-        assert.truthy(api.created_at)
+
+        -- assert collections have prepared statements
+        for _, collection in ipairs({ "apis", "consumers" }) do
+          for k, v in pairs(new_factory[collection]._queries) do
+            local cache_key
+            if type(v) == "string" then
+              cache_key = v
+            elseif v.query then
+              cache_key = v.query
+            end
+
+            if cache_key then
+              assert.truthy(new_factory[collection]._statements_cache[cache_key])
+            end
+          end
+        end
       end)
 
-      it("should not insert an invalid api", function()
-        -- Nil
-        local api, err = dao_factory.apis:insert()
-        assert.falsy(api)
-        assert.truthy(err)
-        assert.True(err.schema)
-        assert.are.same("Cannot insert a nil element", err.message)
+      it("should raise an error if cannot connect to Cassandra", function()
+        local new_factory = CassandraFactory({ hosts = "127.0.0.1",
+                                               port = 45678,
+                                               timeout = 1000,
+                                               keyspace = configuration.cassandra.keyspace
+        })
 
-        -- Invalid schema UNIQUE error (already existing API name)
-        local api_rows, err = session:execute("SELECT * FROM apis LIMIT 1;")
-        assert.falsy(err)
-        local api_t = faker:fake_entity("api")
-        api_t.name = api_rows[1].name
-
-        local api, err = dao_factory.apis:insert(api_t)
+        local err = new_factory:prepare()
         assert.truthy(err)
         assert.is_daoError(err)
-        assert.True(err.unique)
-        assert.are.same("name already exists with value "..api_t.name, err.message.name)
-        assert.falsy(api)
-
-        -- Duplicated name
-        local apis, err = session:execute("SELECT * FROM apis")
-        assert.falsy(err)
-        assert.truthy(#apis > 0)
-
-        local api_t = faker:fake_entity("api")
-        api_t.name = apis[1].name
-        local api, err = dao_factory.apis:insert(api_t)
-        assert.falsy(api)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.unique)
-        assert.are.same("name already exists with value "..api_t.name, err.message.name)
+        assert.True(err.database)
+        assert.are.same("connection refused", err.message)
       end)
 
     end)
+  end) -- describe Factory
 
-    describe("Consumers", function()
+  --
+  -- Core DAO Collections (consumers, apis, plugins_configurations)
+  --
 
-      it("should insert an consumer in DB and add generated values", function()
-        local consumer_t = faker:fake_entity("consumer")
-        local consumer, err = dao_factory.consumers:insert(consumer_t)
-        assert.falsy(err)
-        assert.truthy(consumer.id)
-        assert.truthy(consumer.created_at)
+  describe("DAO Collections", function()
+
+    describe(":insert()", function()
+
+      describe("APIs", function()
+
+        it("should insert in DB and add generated values", function()
+          local api_t = faker:fake_entity("api")
+          local api, err = dao_factory.apis:insert(api_t)
+          assert.falsy(err)
+          assert.truthy(api.id)
+          assert.truthy(api.created_at)
+        end)
+
+        it("should not insert an invalid api", function()
+          -- Nil
+          local api, err = dao_factory.apis:insert()
+          assert.falsy(api)
+          assert.truthy(err)
+          assert.True(err.schema)
+          assert.are.same("Cannot insert a nil element", err.message)
+
+          -- Invalid schema UNIQUE error (already existing API name)
+          local api_rows, err = session:execute("SELECT * FROM apis LIMIT 1;")
+          assert.falsy(err)
+          local api_t = faker:fake_entity("api")
+          api_t.name = api_rows[1].name
+
+          local api, err = dao_factory.apis:insert(api_t)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.unique)
+          assert.are.same("name already exists with value "..api_t.name, err.message.name)
+          assert.falsy(api)
+
+          -- Duplicated name
+          local apis, err = session:execute("SELECT * FROM apis")
+          assert.falsy(err)
+          assert.truthy(#apis > 0)
+
+          local api_t = faker:fake_entity("api")
+          api_t.name = apis[1].name
+          local api, err = dao_factory.apis:insert(api_t)
+          assert.falsy(api)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.unique)
+          assert.are.same("name already exists with value "..api_t.name, err.message.name)
+        end)
+
       end)
 
-    end)
+      describe("Consumers", function()
 
-    describe("KeyAuthCredentials", function()
+        it("should insert an consumer in DB and add generated values", function()
+          local consumer_t = faker:fake_entity("consumer")
+          local consumer, err = dao_factory.consumers:insert(consumer_t)
+          assert.falsy(err)
+          assert.truthy(consumer.id)
+          assert.truthy(consumer.created_at)
+        end)
 
-      it("should not insert in DB if consumer does not exist", function()
-        -- Without an consumer_id, it's a schema error
-        local app_t = faker:fake_entity("keyauth_credential")
-        app_t.consumer_id = nil
-        local app, err = dao_factory.keyauth_credentials:insert(app_t)
-        assert.falsy(app)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.schema)
-        assert.are.same("consumer_id is required", err.message.consumer_id)
-
-        -- With an invalid consumer_id, it's a FOREIGN error
-        local app_t = faker:fake_entity("keyauth_credential")
-        app_t.consumer_id = uuid()
-
-        local app, err = dao_factory.keyauth_credentials:insert(app_t)
-        assert.falsy(app)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.foreign)
-        assert.are.same("consumer_id "..app_t.consumer_id.." does not exist", err.message.consumer_id)
       end)
 
-      it("should insert in DB and add generated values", function()
-        local consumers, err = session:execute("SELECT * FROM consumers")
-        assert.falsy(err)
-        assert.truthy(#consumers > 0)
+      describe("Plugin Configurations", function()
 
-        local app_t = faker:fake_entity("keyauth_credential")
-        app_t.consumer_id = consumers[1].id
+        it("should not insert in DB if invalid", function()
+          -- Without an api_id, it's a schema error
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(plugin)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.schema)
+          assert.are.same("api_id is required", err.message.api_id)
 
-        local app, err = dao_factory.keyauth_credentials:insert(app_t)
-        assert.falsy(err)
-        assert.truthy(app.id)
-        assert.truthy(app.created_at)
-      end)
+          -- With an invalid api_id, it's an FOREIGN error
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          plugin_t.api_id = uuid()
 
-    end)
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(plugin)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.foreign)
+          assert.are.same("api_id "..plugin_t.api_id.." does not exist", err.message.api_id)
 
-    describe("Plugin Configurations", function()
+          -- With invalid api_id and consumer_id, it's an EXISTS error
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          plugin_t.api_id = uuid()
+          plugin_t.consumer_id = uuid()
 
-      it("should not insert in DB if invalid", function()
-        -- Without an api_id, it's a schema error
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(plugin)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.schema)
-        assert.are.same("api_id is required", err.message.api_id)
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(plugin)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.foreign)
+          assert.are.same("api_id "..plugin_t.api_id.." does not exist", err.message.api_id)
+          assert.are.same("consumer_id "..plugin_t.consumer_id.." does not exist", err.message.consumer_id)
+        end)
 
-        -- With an invalid api_id, it's an FOREIGN error
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        plugin_t.api_id = uuid()
+        it("should insert a plugin configuration in DB and add generated values", function()
+          local api_t = faker:fake_entity("api")
+          local api, err = dao_factory.apis:insert(api_t)
+          assert.falsy(err)
 
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(plugin)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.foreign)
-        assert.are.same("api_id "..plugin_t.api_id.." does not exist", err.message.api_id)
+          local consumers, err = session:execute("SELECT * FROM consumers")
+          assert.falsy(err)
+          assert.True(#consumers > 0)
 
-        -- With invalid api_id and consumer_id, it's an EXISTS error
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        plugin_t.api_id = uuid()
-        plugin_t.consumer_id = uuid()
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          plugin_t.api_id = api.id
+          plugin_t.consumer_id = consumers[1].id
 
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(plugin)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.foreign)
-        assert.are.same("api_id "..plugin_t.api_id.." does not exist", err.message.api_id)
-        assert.are.same("consumer_id "..plugin_t.consumer_id.." does not exist", err.message.consumer_id)
-      end)
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(err)
+          assert.truthy(plugin)
+          assert.truthy(plugin.consumer_id)
+        end)
 
-      it("should insert a plugin configuration in DB and add generated values", function()
-        local api_t = faker:fake_entity("api")
-        local api, err = dao_factory.apis:insert(api_t)
-        assert.falsy(err)
+        it("should not insert twice a plugin with same api_id, consumer_id and name", function()
+          -- Insert a new API for a fresh start
+          local api, err = dao_factory.apis:insert(faker:fake_entity("api"))
+          assert.falsy(err)
+          assert.truthy(api.id)
 
-        local consumers, err = session:execute("SELECT * FROM consumers")
-        assert.falsy(err)
-        assert.True(#consumers > 0)
+          local consumers, err = session:execute("SELECT * FROM consumers")
+          assert.falsy(err)
+          assert.True(#consumers > 0)
 
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        plugin_t.api_id = api.id
-        plugin_t.consumer_id = consumers[1].id
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          plugin_t.api_id = api.id
+          plugin_t.consumer_id = consumers[#consumers].id
 
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(err)
-        assert.truthy(plugin)
-        assert.truthy(plugin.consumer_id)
-      end)
+          -- This should work
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(err)
+          assert.truthy(plugin)
 
-      it("should not insert twice a plugin with same api_id, consumer_id and name", function()
-        -- Insert a new API for a fresh start
-        local api, err = dao_factory.apis:insert(faker:fake_entity("api"))
-        assert.falsy(err)
-        assert.truthy(api.id)
+          -- This should fail
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(plugin)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.unique)
+          assert.are.same("Plugin already exists", err.message)
+        end)
 
-        local consumers, err = session:execute("SELECT * FROM consumers")
-        assert.falsy(err)
-        assert.True(#consumers > 0)
+        it("should not insert a plugin if this plugin doesn't exist (not installed)", function()
+          local plugin_t = faker:fake_entity("plugin_configuration")
+          plugin_t.name = "world domination plugin"
 
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        plugin_t.api_id = api.id
-        plugin_t.consumer_id = consumers[#consumers].id
+          -- This should fail
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(plugin)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.are.same("Plugin \"world domination plugin\" not found", err.message.value)
+        end)
 
-        -- This should work
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(err)
-        assert.truthy(plugin)
+        it("should validate a plugin value schema", function()
+          -- Success
+          -- Insert a new API for a fresh start
+          local api, err = dao_factory.apis:insert(faker:fake_entity("api"))
+          assert.falsy(err)
+          assert.truthy(api.id)
 
-        -- This should fail
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(plugin)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.unique)
-        assert.are.same("Plugin already exists", err.message)
-      end)
+          local consumers, err = session:execute("SELECT * FROM consumers")
+          assert.falsy(err)
+          assert.True(#consumers > 0)
 
-      it("should not insert a plugin if this plugin doesn't exist (not installed)", function()
-        local plugin_t = faker:fake_entity("plugin_configuration")
-        plugin_t.name = "world domination plugin"
-
-        -- This should fail
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.falsy(plugin)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.are.same("Plugin \"world domination plugin\" not found", err.message.value)
-      end)
-
-      it("should validate a plugin value schema", function()
-        -- Success
-        -- Insert a new API for a fresh start
-        local api, err = dao_factory.apis:insert(faker:fake_entity("api"))
-        assert.falsy(err)
-        assert.truthy(api.id)
-
-        local consumers, err = session:execute("SELECT * FROM consumers")
-        assert.falsy(err)
-        assert.True(#consumers > 0)
-
-        local plugin_t =  {
-          api_id = api.id,
-          consumer_id = consumers[#consumers].id,
-          name = "keyauth",
-          value = {
-            key_names = { "x-kong-key" }
+          local plugin_t =  {
+            api_id = api.id,
+            consumer_id = consumers[#consumers].id,
+            name = "keyauth",
+            value = {
+              key_names = { "x-kong-key" }
+            }
           }
-        }
+
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.falsy(err)
+          assert.truthy(plugin)
+
+          local ok, err = dao_factory.plugins_configurations:delete(plugin.id)
+          assert.True(ok)
+          assert.falsy(err)
+
+          -- Failure
+          plugin_t.name = "ratelimiting"
+          plugin_t.value = { period = "hello" }
+          local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.truthy(err.schema)
+          assert.are.same("\"hello\" is not allowed. Allowed values are: \"second\", \"minute\", \"hour\", \"day\", \"month\", \"year\"", err.message["value.period"])
+          assert.falsy(plugin)
+        end)
+
+      end)
+    end) -- describe :insert()
+
+    describe(":update()", function()
+
+      describe_core_collections(function(type, collection)
+
+        it("should return nil if no entity was found to update in DB", function()
+          local t = faker:fake_entity(type)
+          t.id = uuid()
+
+          -- Remove immutable fields
+          for k,v in pairs(dao_factory[collection]._schema) do
+            if v.immutable and not v.required then
+              t[k] = nil
+            end
+          end
+
+          -- No entity to update
+          local entity, err = dao_factory[collection]:update(t)
+          assert.falsy(entity)
+          assert.falsy(err)
+        end)
+
+      end)
+
+      describe("APIs", function()
+
+        -- Cassandra sets to NULL unset fields specified in an UPDATE query
+        -- https://issues.apache.org/jira/browse/CASSANDRA-7304
+        it("should update in DB without setting to NULL unset fields", function()
+          local apis, err = session:execute("SELECT * FROM apis")
+          assert.falsy(err)
+          assert.True(#apis > 0)
+
+          local api_t = apis[1]
+          api_t.name = api_t.name.." updated"
+
+          -- This should not set those values to NULL in DB
+          api_t.created_at = nil
+          api_t.public_dns = nil
+          api_t.target_url = nil
+
+          local api, err = dao_factory.apis:update(api_t)
+          assert.falsy(err)
+          assert.truthy(api)
+
+          local apis, err = session:execute("SELECT * FROM apis WHERE name = '"..api_t.name.."'")
+          assert.falsy(err)
+          assert.are.same(1, #apis)
+          assert.truthy(apis[1].id)
+          assert.truthy(apis[1].created_at)
+          assert.truthy(apis[1].public_dns)
+          assert.truthy(apis[1].target_url)
+          assert.are.same(api_t.name, apis[1].name)
+        end)
+
+        it("should prevent the update if the UNIQUE check fails", function()
+          local apis, err = session:execute("SELECT * FROM apis")
+          assert.falsy(err)
+          assert.True(#apis > 0)
+
+          local api_t = apis[1]
+          api_t.name = api_t.name.." unique update attempt"
+
+          -- Should not work because UNIQUE check fails
+          api_t.public_dns = apis[2].public_dns
+
+          local api, err = dao_factory.apis:update(api_t)
+          assert.falsy(api)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.unique)
+          assert.are.same("public_dns already exists with value "..api_t.public_dns, err.message.public_dns)
+        end)
+
+      end)
+
+      describe("Consumers", function()
+
+        it("should update in DB if entity can be found", function()
+          local consumers, err = session:execute("SELECT * FROM consumers")
+          assert.falsy(err)
+          assert.True(#consumers > 0)
+
+          local consumer_t = consumers[1]
+
+          -- Should be correctly updated in DB
+          consumer_t.custom_id = consumer_t.custom_id.."updated"
+
+          local consumer, err = dao_factory.consumers:update(consumer_t)
+          assert.falsy(err)
+          assert.truthy(consumer)
+
+          local consumers, err = session:execute("SELECT * FROM consumers WHERE custom_id = '"..consumer_t.custom_id.."'")
+          assert.falsy(err)
+          assert.True(#consumers == 1)
+          assert.are.same(consumer_t.name, consumers[1].name)
+        end)
+
+      end)
+
+      describe("Plugin Configurations", function()
+
+        it("should update in DB if entity can be found", function()
+          local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations")
+          assert.falsy(err)
+          assert.True(#plugins_configurations > 0)
+
+          local plugin_conf_t = plugins_configurations[1]
+          plugin_conf_t.value = cjson.decode(plugin_conf_t.value)
+          plugin_conf_t.enabled = false
+          local plugin_conf, err = dao_factory.plugins_configurations:update(plugin_conf_t)
+          assert.falsy(err)
+          assert.truthy(plugin_conf)
+
+          local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations WHERE id = ?", { cassandra.uuid(plugin_conf_t.id) })
+          assert.falsy(err)
+          assert.are.same(1, #plugins_configurations)
+        end)
+
+      end)
+    end) -- describe :update()
+
+    describe(":delete()", function()
+
+      setup(function()
+        spec_helper.drop_db()
+        spec_helper.seed_db(nil, 100)
+      end)
+
+      describe_core_collections(function(type, collection)
+
+        it("should return false if there was nothing to delete", function()
+          local ok, err = dao_factory[collection]:delete(uuid())
+          assert.is_not_true(ok)
+          assert.falsy(err)
+        end)
+
+        it("should delete an entity if it can be found", function()
+          local entities, err = session:execute("SELECT * FROM "..collection)
+          assert.falsy(err)
+          assert.truthy(entities)
+          assert.True(#entities > 0)
+
+          local success, err = dao_factory[collection]:delete(entities[1].id)
+          assert.falsy(err)
+          assert.True(success)
+
+          local entities, err = session:execute("SELECT * FROM "..collection.." WHERE id = "..entities[1].id )
+          assert.falsy(err)
+          assert.truthy(entities)
+          assert.are.same(0, #entities)
+        end)
+
+      end)
+    end) -- describe :delete()
+
+    describe(":find()", function()
+
+      setup(function()
+        spec_helper.drop_db()
+        spec_helper.seed_db(nil, 100)
+      end)
+
+      describe_core_collections(function(type, collection)
+
+        it("should find entities", function()
+          local entities, err = session:execute("SELECT * FROM "..collection)
+          assert.falsy(err)
+          assert.truthy(entities)
+          assert.True(#entities > 0)
+
+          local results, err = dao_factory[collection]:find()
+          assert.falsy(err)
+          assert.truthy(results)
+          assert.are.same(#entities, #results)
+        end)
+
+        it("should allow pagination", function()
+          -- 1st page
+          local rows_1, err = dao_factory[collection]:find(2)
+          assert.falsy(err)
+          assert.truthy(rows_1)
+          assert.are.same(2, #rows_1)
+          assert.truthy(rows_1.next_page)
+
+          -- 2nd page
+          local rows_2, err = dao_factory[collection]:find(2, rows_1.next_page)
+          assert.falsy(err)
+          assert.truthy(rows_2)
+          assert.are.same(2, #rows_2)
+        end)
+
+      end)
+    end) -- describe :find()
+
+    describe(":find_one()", function()
+
+      describe_core_collections(function(type, collection)
+
+        it("should find one entity by id", function()
+          local entities, err = session:execute("SELECT * FROM "..collection)
+          assert.falsy(err)
+          assert.truthy(entities)
+          assert.True(#entities > 0)
+
+          local result, err = dao_factory[collection]:find_one(entities[1].id)
+          assert.falsy(err)
+          assert.truthy(result)
+        end)
+
+        it("should handle an invalid uuid value", function()
+          local result, err = dao_factory[collection]:find_one("abcd")
+          assert.falsy(result)
+          assert.True(err.invalid_type)
+          assert.are.same("abcd is an invalid uuid", err.message.id)
+        end)
+
+      end)
+
+      describe("Plugin Configurations", function()
+
+        it("should deserialize the table property", function()
+          local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations")
+          assert.falsy(err)
+          assert.truthy(plugins_configurations)
+          assert.True(#plugins_configurations > 0)
+
+          local plugin_t = plugins_configurations[1]
+
+          local result, err = dao_factory.plugins_configurations:find_one(plugin_t.id)
+          assert.falsy(err)
+          assert.truthy(result)
+          assert.are.same("table", type(result.value))
+        end)
+
+      end)
+    end) -- describe :find_one()
+
+    describe(":find_by_keys()", function()
+
+      describe_core_collections(function(type, collection)
+
+        it("should refuse non queryable keys", function()
+          local results, err = session:execute("SELECT * FROM "..collection)
+          assert.falsy(err)
+          assert.truthy(results)
+          assert.True(#results > 0)
+
+          local t = results[1]
+
+          local results, err = dao_factory[collection]:find_by_keys(t)
+          assert.truthy(err)
+          assert.is_daoError(err)
+          assert.True(err.schema)
+          assert.falsy(results)
+
+          -- All those fields are indeed non queryable
+          for k,v in pairs(err.message) do
+            assert.is_not_true(dao_factory[collection]._schema[k].queryable)
+          end
+        end)
+
+        it("should handle empty search fields", function()
+          local results, err = dao_factory[collection]:find_by_keys({})
+          assert.falsy(err)
+          assert.truthy(results)
+          assert.True(#results > 0)
+        end)
+
+        it("should handle nil search fields", function()
+          local results, err = dao_factory[collection]:find_by_keys(nil)
+          assert.falsy(err)
+          assert.truthy(results)
+          assert.True(#results > 0)
+        end)
+
+        it("should query an entity by its queryable fields", function()
+          local results, err = session:execute("SELECT * FROM "..collection)
+          assert.falsy(err)
+          assert.truthy(results)
+          assert.True(#results > 0)
+
+          local t = results[1]
+          local q = {}
+
+          -- Remove nonqueryable fields
+          for k, schema_field in pairs(dao_factory[collection]._schema) do
+            if schema_field.queryable then
+              q[k] = t[k]
+            elseif schema_field.type == "table" then
+              t[k] = cjson.decode(t[k])
+            end
+          end
+
+          local results, err = dao_factory[collection]:find_by_keys(q)
+          assert.falsy(err)
+          assert.truthy(results)
+
+          -- in case of plugins configurations
+          if t.consumer_id == constants.DATABASE_NULL_ID then
+            t.consumer_id = nil
+          end
+
+          assert.are.same(t, results[1])
+        end)
+
+      end)
+    end) -- describe :find_by_keys()
+
+    --
+    -- Plugins configuration additional behaviour
+    --
+
+    describe("Plugin Configurations", function()
+      local api_id
+      local inserted_plugin
+
+      setup(function()
+        spec_helper.drop_db()
+        spec_helper.seed_db(nil, 100)
+      end)
+
+      it("should find distinct plugins configurations", function()
+        pending("Waiting for driver fix #50")
+        local res, err = dao_factory.plugins_configurations:find_distinct()
+
+        assert.falsy(err)
+        assert.truthy(res)
+
+        assert.are.same(6, #res)
+        assert.truthy(utils.array_contains(res, "keyauth"))
+        assert.truthy(utils.array_contains(res, "basicauth"))
+        assert.truthy(utils.array_contains(res, "ratelimiting"))
+        assert.truthy(utils.array_contains(res, "tcplog"))
+        assert.truthy(utils.array_contains(res, "udplog"))
+        assert.truthy(utils.array_contains(res, "filelog"))
+      end)
+
+      it("should insert a plugin and set the consumer_id to a 'null' uuid if none is specified", function()
+        -- Since we want to specifically select plugins configurations which have _no_ consumer_id sometimes, we cannot rely on using
+        -- NULL (and thus, not inserting the consumer_id column for the row). To fix this, we use a predefined, nullified uuid...
+
+        -- Create an API
+        local api_t = faker:fake_entity("api")
+        local api, err = dao_factory.apis:insert(api_t)
+        assert.falsy(err)
+
+        local plugin_t = faker:fake_entity("plugin_configuration")
+        plugin_t.api_id = api.id
 
         local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
         assert.falsy(err)
         assert.truthy(plugin)
+        assert.falsy(plugin.consumer_id)
 
-        local ok, err = dao_factory.plugins_configurations:delete(plugin.id)
-        assert.True(ok)
-        assert.falsy(err)
-
-        -- Failure
-        plugin_t.name = "ratelimiting"
-        plugin_t.value = { period = "hello" }
-        local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.truthy(err.schema)
-        assert.are.same("\"hello\" is not allowed. Allowed values are: \"second\", \"minute\", \"hour\", \"day\", \"month\", \"year\"", err.message["value.period"])
-        assert.falsy(plugin)
+        -- for next test
+        api_id = api.id
+        inserted_plugin = plugin
+        inserted_plugin.consumer_id = nil
       end)
 
-    end)
-  end)
-
-  describe(":update()", function()
-
-    describe_all_collections(function(type, collection)
-
-      it("should return nil if no entity was found to update in DB", function()
-        local t = faker:fake_entity(type)
-        t.id = uuid()
-
-        -- Remove immutable fields
-        for k,v in pairs(dao_factory[collection]._schema) do
-          if v.immutable and not v.required then
-            t[k] = nil
-          end
-        end
-
-        -- No entity to update
-        local entity, err = dao_factory[collection]:update(t)
-        assert.falsy(entity)
-        assert.falsy(err)
-      end)
-
-    end)
-
-    describe("APIs", function()
-
-      -- Cassandra sets to NULL unset fields specified in an UPDATE query
-      -- https://issues.apache.org/jira/browse/CASSANDRA-7304
-      it("should update in DB without setting to NULL unset fields", function()
-        local apis, err = session:execute("SELECT * FROM apis")
-        assert.falsy(err)
-        assert.True(#apis > 0)
-
-        local api_t = apis[1]
-        api_t.name = api_t.name.." updated"
-
-        -- This should not set those values to NULL in DB
-        api_t.created_at = nil
-        api_t.public_dns = nil
-        api_t.target_url = nil
-
-        local api, err = dao_factory.apis:update(api_t)
-        assert.falsy(err)
-        assert.truthy(api)
-
-        local apis, err = session:execute("SELECT * FROM apis WHERE name = '"..api_t.name.."'")
-        assert.falsy(err)
-        assert.are.same(1, #apis)
-        assert.truthy(apis[1].id)
-        assert.truthy(apis[1].created_at)
-        assert.truthy(apis[1].public_dns)
-        assert.truthy(apis[1].target_url)
-        assert.are.same(api_t.name, apis[1].name)
-      end)
-
-      it("should prevent the update if the UNIQUE check fails", function()
-        local apis, err = session:execute("SELECT * FROM apis")
-        assert.falsy(err)
-        assert.True(#apis > 0)
-
-        local api_t = apis[1]
-        api_t.name = api_t.name.." unique update attempt"
-
-        -- Should not work because UNIQUE check fails
-        api_t.public_dns = apis[2].public_dns
-
-        local api, err = dao_factory.apis:update(api_t)
-        assert.falsy(api)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.unique)
-        assert.are.same("public_dns already exists with value "..api_t.public_dns, err.message.public_dns)
-      end)
-
-    end)
-
-    describe("Consumers", function()
-
-      it("should update in DB if entity can be found", function()
-        local consumers, err = session:execute("SELECT * FROM consumers")
-        assert.falsy(err)
-        assert.True(#consumers > 0)
-
-        local consumer_t = consumers[1]
-
-        -- Should be correctly updated in DB
-        consumer_t.custom_id = consumer_t.custom_id.."updated"
-
-        local consumer, err = dao_factory.consumers:update(consumer_t)
-        assert.falsy(err)
-        assert.truthy(consumer)
-
-        local consumers, err = session:execute("SELECT * FROM consumers WHERE custom_id = '"..consumer_t.custom_id.."'")
-        assert.falsy(err)
-        assert.True(#consumers == 1)
-        assert.are.same(consumer_t.name, consumers[1].name)
-      end)
-
-    end)
-
-    describe("Plugin Configurations", function()
-
-      it("should update in DB if entity can be found", function()
-        local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations")
-        assert.falsy(err)
-        assert.True(#plugins_configurations > 0)
-
-        local plugin_conf_t = plugins_configurations[1]
-        plugin_conf_t.value = cjson.decode(plugin_conf_t.value)
-        plugin_conf_t.enabled = false
-        local plugin_conf, err = dao_factory.plugins_configurations:update(plugin_conf_t)
-        assert.falsy(err)
-        assert.truthy(plugin_conf)
-
-        local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations WHERE id = ?", { cassandra.uuid(plugin_conf_t.id) })
-        assert.falsy(err)
-        assert.are.same(1, #plugins_configurations)
-      end)
-
-    end)
-  end)
-
-  describe(":delete()", function()
-
-    setup(function()
-      spec_helper.drop_db()
-      spec_helper.seed_db(nil, 100)
-    end)
-
-    describe_all_collections(function(type, collection)
-
-      it("should return false if there was nothing to delete", function()
-        local ok, err = dao_factory[collection]:delete(uuid())
-        assert.is_not_true(ok)
-        assert.falsy(err)
-      end)
-
-      it("should delete an entity if it can be found", function()
-        local entities, err = session:execute("SELECT * FROM "..collection)
-        assert.falsy(err)
-        assert.truthy(entities)
-        assert.True(#entities > 0)
-
-        local success, err = dao_factory[collection]:delete(entities[1].id)
-        assert.falsy(err)
-        assert.True(success)
-
-        local entities, err = session:execute("SELECT * FROM "..collection.." WHERE id = "..entities[1].id )
-        assert.falsy(err)
-        assert.truthy(entities)
-        assert.are.same(0, #entities)
-      end)
-
-    end)
-  end)
-
-  describe(":find()", function()
-
-    setup(function()
-      spec_helper.drop_db()
-      spec_helper.seed_db(nil, 100)
-    end)
-
-    describe_all_collections(function(type, collection)
-
-      it("should find entities", function()
-        local entities, err = session:execute("SELECT * FROM "..collection)
-        assert.falsy(err)
-        assert.truthy(entities)
-        assert.True(#entities > 0)
-
-        local results, err = dao_factory[collection]:find()
-        assert.falsy(err)
-        assert.truthy(results)
-        assert.are.same(#entities, #results)
-      end)
-
-      it("should allow pagination", function()
-        -- 1st page
-        local rows_1, err = dao_factory[collection]:find(2)
-        assert.falsy(err)
-        assert.truthy(rows_1)
-        assert.are.same(2, #rows_1)
-        assert.truthy(rows_1.next_page)
-
-        -- 2nd page
-        local rows_2, err = dao_factory[collection]:find(2, rows_1.next_page)
-        assert.falsy(err)
-        assert.truthy(rows_2)
-        assert.are.same(2, #rows_2)
-      end)
-
-    end)
-  end)
-
-  describe(":find_one()", function()
-
-    describe_all_collections(function(type, collection)
-
-      it("should find one entity by id", function()
-        local entities, err = session:execute("SELECT * FROM "..collection)
-        assert.falsy(err)
-        assert.truthy(entities)
-        assert.True(#entities > 0)
-
-        local result, err = dao_factory[collection]:find_one(entities[1].id)
-        assert.falsy(err)
-        assert.truthy(result)
-      end)
-
-      it("should handle an invalid uuid value", function()
-        local result, err = dao_factory[collection]:find_one("abcd")
-        assert.falsy(result)
-        assert.True(err.invalid_type)
-        assert.are.same("abcd is an invalid uuid", err.message.id)
-      end)
-
-    end)
-
-    describe("Plugin Configurations", function()
-
-      it("should deserialize the table property", function()
-        local plugins_configurations, err = session:execute("SELECT * FROM plugins_configurations")
-        assert.falsy(err)
-        assert.truthy(plugins_configurations)
-        assert.True(#plugins_configurations > 0)
-
-        local plugin_t = plugins_configurations[1]
-
-        local result, err = dao_factory.plugins_configurations:find_one(plugin_t.id)
-        assert.falsy(err)
-        assert.truthy(result)
-        assert.are.same("table", type(result.value))
-      end)
-
-    end)
-  end)
-
-  describe(":find_by_keys()", function()
-
-    describe_all_collections(function(type, collection)
-
-      it("should refuse non queryable keys", function()
-        local results, err = session:execute("SELECT * FROM "..collection)
-        assert.falsy(err)
-        assert.truthy(results)
-        assert.True(#results > 0)
-
-        local t = results[1]
-
-        local results, err = dao_factory[collection]:find_by_keys(t)
-        assert.truthy(err)
-        assert.is_daoError(err)
-        assert.True(err.schema)
-        assert.falsy(results)
-
-        -- All those fields are indeed non queryable
-        for k,v in pairs(err.message) do
-          assert.is_not_true(dao_factory[collection]._schema[k].queryable)
-        end
-      end)
-
-      it("should handle empty search fields", function()
-        local results, err = dao_factory[collection]:find_by_keys({})
-        assert.falsy(err)
-        assert.truthy(results)
-        assert.True(#results > 0)
-      end)
-
-      it("should handle nil search fields", function()
-        local results, err = dao_factory[collection]:find_by_keys(nil)
-        assert.falsy(err)
-        assert.truthy(results)
-        assert.True(#results > 0)
-      end)
-
-      it("should query an entity by its queryable fields", function()
-        local results, err = session:execute("SELECT * FROM "..collection)
-        assert.falsy(err)
-        assert.truthy(results)
-        assert.True(#results > 0)
-
-        local t = results[1]
-        local q = {}
-
-        -- Remove nonqueryable fields
-        for k, schema_field in pairs(dao_factory[collection]._schema) do
-          if schema_field.queryable then
-            q[k] = t[k]
-          elseif schema_field.type == "table" then
-            t[k] = cjson.decode(t[k])
-          end
-        end
-
-        local results, err = dao_factory[collection]:find_by_keys(q)
-        assert.falsy(err)
-        assert.truthy(results)
-
-        -- in case of plugins configurations
-        if t.consumer_id == constants.DATABASE_NULL_ID then
-          t.consumer_id = nil
-        end
-
-        assert.are.same(t, results[1])
-      end)
-
-    end)
-
-    describe("KeyAuthCredentials", function()
-
-      it("should find an KeyAuth Credential by public_key", function()
-        local app, err = dao_factory.keyauth_credentials:find_by_keys {
-          key = "user122"
+      it("should select a plugin configuration by 'null' uuid consumer_id and remove the column", function()
+        -- Now we should be able to select this plugin
+        local rows, err = dao_factory.plugins_configurations:find_by_keys {
+          api_id = api_id,
+          consumer_id = constants.DATABASE_NULL_ID
         }
         assert.falsy(err)
-        assert.truthy(app)
+        assert.truthy(rows[1])
+        assert.are.same(inserted_plugin, rows[1])
+        assert.falsy(rows[1].consumer_id)
       end)
 
-      it("should handle empty strings", function()
-        local apps, err = dao_factory.keyauth_credentials:find_by_keys {
-          key = ""
-        }
-        assert.falsy(err)
-        assert.are.same({}, apps)
-      end)
+    end) -- describe plugins configurations
+  end) -- describe DAO Collections
 
+  --
+  -- KeyAuth plugin collection
+  --
+
+  describe("KeyAuthCredentials", function()
+
+    it("should not insert in DB if consumer does not exist", function()
+      -- Without an consumer_id, it's a schema error
+      local app_t = faker:fake_entity("keyauth_credential")
+      app_t.consumer_id = nil
+      local app, err = dao_factory.keyauth_credentials:insert(app_t)
+      assert.falsy(app)
+      assert.truthy(err)
+      assert.is_daoError(err)
+      assert.True(err.schema)
+      assert.are.same("consumer_id is required", err.message.consumer_id)
+
+      -- With an invalid consumer_id, it's a FOREIGN error
+      local app_t = faker:fake_entity("keyauth_credential")
+      app_t.consumer_id = uuid()
+
+      local app, err = dao_factory.keyauth_credentials:insert(app_t)
+      assert.falsy(app)
+      assert.truthy(err)
+      assert.is_daoError(err)
+      assert.True(err.foreign)
+      assert.are.same("consumer_id "..app_t.consumer_id.." does not exist", err.message.consumer_id)
+    end)
+
+    it("should insert in DB and add generated values", function()
+      local consumers, err = session:execute("SELECT * FROM consumers")
+      assert.falsy(err)
+      assert.truthy(#consumers > 0)
+
+      local app_t = faker:fake_entity("keyauth_credential")
+      app_t.consumer_id = consumers[1].id
+
+      local app, err = dao_factory.keyauth_credentials:insert(app_t)
+      assert.falsy(err)
+      assert.truthy(app.id)
+      assert.truthy(app.created_at)
+    end)
+
+    it("should find an KeyAuth Credential by public_key", function()
+      local app, err = dao_factory.keyauth_credentials:find_by_keys {
+        key = "user122"
+      }
+      assert.falsy(err)
+      assert.truthy(app)
+    end)
+
+    it("should handle empty strings", function()
+      local apps, err = dao_factory.keyauth_credentials:find_by_keys {
+        key = ""
+      }
+      assert.falsy(err)
+      assert.are.same({}, apps)
     end)
 
   end)
+
+  --
+  -- Rate Limiting plugin collection
+  --
 
   describe("Rate Limiting Metrics", function()
-    pending()
     local ratelimiting_metrics = dao_factory.ratelimiting_metrics
-
     local api_id = uuid()
     local identifier = uuid()
 
@@ -774,68 +877,5 @@ describe("Cassandra DAO #dao #cassandra", function()
       assert.has_error(ratelimiting_metrics.find_by_keys, "ratelimiting_metrics:find_by_keys() not supported")
     end)
 
-  end)
-
-  describe("Plugin Configurations", function()
-    local api_id
-    local inserted_plugin
-
-    setup(function()
-      spec_helper.drop_db()
-      spec_helper.seed_db(nil, 100)
-    end)
-
-    it("should find distinct plugins configurations", function()
-      pending("Waiting for driver fix #50")
-      local res, err = dao_factory.plugins_configurations:find_distinct()
-
-      assert.falsy(err)
-      assert.truthy(res)
-
-      assert.are.same(6, #res)
-      assert.truthy(utils.array_contains(res, "keyauth"))
-      assert.truthy(utils.array_contains(res, "basicauth"))
-      assert.truthy(utils.array_contains(res, "ratelimiting"))
-      assert.truthy(utils.array_contains(res, "tcplog"))
-      assert.truthy(utils.array_contains(res, "udplog"))
-      assert.truthy(utils.array_contains(res, "filelog"))
-    end)
-
-    it("should insert a plugin and set the consumer_id to a 'null' uuid if none is specified", function()
-      -- Since we want to specifically select plugins configurations which have _no_ consumer_id sometimes, we cannot rely on using
-      -- NULL (and thus, not inserting the consumer_id column for the row). To fix this, we use a predefined, nullified
-      -- uuid...
-
-      -- Create an API
-      local api_t = faker:fake_entity("api")
-      local api, err = dao_factory.apis:insert(api_t)
-      assert.falsy(err)
-
-      local plugin_t = faker:fake_entity("plugin_configuration")
-      plugin_t.api_id = api.id
-
-      local plugin, err = dao_factory.plugins_configurations:insert(plugin_t)
-      assert.falsy(err)
-      assert.truthy(plugin)
-      assert.falsy(plugin.consumer_id)
-
-      -- for next test
-      api_id = api.id
-      inserted_plugin = plugin
-      inserted_plugin.consumer_id = nil
-    end)
-
-    it("should select a plugin configuration by 'null' uuid consumer_id and remove the column", function()
-      -- Now we should be able to select this plugin
-      local rows, err = dao_factory.plugins_configurations:find_by_keys {
-        api_id = api_id,
-        consumer_id = constants.DATABASE_NULL_ID
-      }
-      assert.falsy(err)
-      assert.truthy(rows[1])
-      assert.are.same(inserted_plugin, rows[1])
-      assert.falsy(rows[1].consumer_id)
-    end)
-
-  end)
+  end) -- describe rate limiting metrics
 end)

--- a/spec/unit/dao/cassandra_spec.lua
+++ b/spec/unit/dao/cassandra_spec.lua
@@ -661,7 +661,6 @@ describe("Cassandra DAO", function()
       end)
 
       it("should find distinct plugins configurations", function()
-        pending("Waiting for driver fix #50")
         local res, err = dao_factory.plugins_configurations:find_distinct()
 
         assert.falsy(err)

--- a/spec/unit/dao/cassandra_spec.lua
+++ b/spec/unit/dao/cassandra_spec.lua
@@ -70,6 +70,7 @@ describe("Cassandra DAO #dao #cassandra", function()
   describe("Factory", function()
 
     it("should raise an error if cannot connect to Cassandra", function()
+      pending("Stubbing :prepare for now")
       local new_factory = CassandraFactory({ hosts = "127.0.0.1",
                                              port = 45678,
                                              timeout = 1000,
@@ -674,6 +675,7 @@ describe("Cassandra DAO #dao #cassandra", function()
   end)
 
   describe("Rate Limiting Metrics", function()
+    pending()
     local ratelimiting_metrics = dao_factory.ratelimiting_metrics
 
     local api_id = uuid()
@@ -784,6 +786,7 @@ describe("Cassandra DAO #dao #cassandra", function()
     end)
 
     it("should find distinct plugins configurations", function()
+      pending("Waiting for driver fix #50")
       local res, err = dao_factory.plugins_configurations:find_distinct()
 
       assert.falsy(err)


### PR DESCRIPTION
This PR started as an improvement for developing #147, but it's also useful to fix #11. It's a small refactor, to avoid having to call `:prepare` every time a DAO is instantiated.

###### Changes:
- The DAO factory does not need to call `:prepare` at startup anymore. Statements will be dynamically prepared if they were not already. This is a step towards fixing #11, and having a more usable DAO
- split cassandra "core collections" and "plugins collections" tests

###### Notes:
- `:prepare` is still called in `kong.lua` when Kong starts, as a simple way of checking all statements are valid. `:prepare` might disappear in the future.
- An improvement will be to prepare the Rate Limiting plugin statements so they are prepared **before** being inserted in batch statements. For now, they are batched as plain strings.