### PR TITLE
[feature] CLI add command (add-api, add-consumer)

### DIFF
--- a/bin/kong
+++ b/bin/kong
@@ -21,6 +21,7 @@ local commands = {
   config = "kong.cli.config",
   restart = "kong.cli.restart",
   version = "kong.cli.version",
+  ["add-api"] = "kong.cli.add_api",
   ["--version"] = "kong.cli.version",
   migrations = "kong.cli.migrations"
 }
@@ -29,7 +30,8 @@ local help_message = string.format([[
 Usage: kong <command>
 
   where <command> is one of:
-    start, restart, reload, stop, quit, version
+    start, restart, reload, stop, quit,
+    add-api, version
 
   kong --help            print this message
   kong <command> --help  print the help message of a command

--- a/bin/kong
+++ b/bin/kong
@@ -21,9 +21,10 @@ local commands = {
   config = "kong.cli.config",
   restart = "kong.cli.restart",
   version = "kong.cli.version",
-  ["add-api"] = "kong.cli.add_api",
   ["--version"] = "kong.cli.version",
-  migrations = "kong.cli.migrations"
+  migrations = "kong.cli.migrations",
+  ["add-api"] = "kong.cli.add_api",
+  ["add-consumer"] = "kong.cli.add_consumer"
 }
 
 local help_message = string.format([[
@@ -31,7 +32,7 @@ Usage: kong <command>
 
   where <command> is one of:
     start, restart, reload, stop, quit,
-    add-api, version
+    add-api, add-consumer, version
 
   kong --help            print this message
   kong <command> --help  print the help message of a command

--- a/kong-0.3.2-1.rockspec
+++ b/kong-0.3.2-1.rockspec
@@ -52,8 +52,9 @@ build = {
     ["kong.cli.reload"] = "kong/cli/reload.lua",
     ["kong.cli.restart"] = "kong/cli/restart.lua",
     ["kong.cli.version"] = "kong/cli/version.lua",
-    ["kong.cli.add_api"] = "kong/cli/add_api.lua",
     ["kong.cli.migrations"] = "kong/cli/migrations.lua",
+    ["kong.cli.add_api"] = "kong/cli/add_api.lua",
+    ["kong.cli.add_consumer"] = "kong/cli/add_consumer.lua",
 
     ["kong.tools.io"] = "kong/tools/io.lua",
     ["kong.tools.utils"] = "kong/tools/utils.lua",

--- a/kong-0.3.2-1.rockspec
+++ b/kong-0.3.2-1.rockspec
@@ -52,6 +52,7 @@ build = {
     ["kong.cli.reload"] = "kong/cli/reload.lua",
     ["kong.cli.restart"] = "kong/cli/restart.lua",
     ["kong.cli.version"] = "kong/cli/version.lua",
+    ["kong.cli.add_api"] = "kong/cli/add_api.lua",
     ["kong.cli.migrations"] = "kong/cli/migrations.lua",
 
     ["kong.tools.io"] = "kong/tools/io.lua",

--- a/kong/cli/add_api.lua
+++ b/kong/cli/add_api.lua
@@ -1,0 +1,37 @@
+#!/usr/bin/env lua
+
+local printable_mt = require "kong.tools.printable"
+local constants = require "kong.constants"
+local cutils = require "kong.cli.utils"
+local IO = require "kong.tools.io"
+
+local args = require("lapp")(string.format([[
+Usage: kong add-api [options]
+
+Options:
+  -c,--config     (default %s) path to configuration file
+  -n,--name       (string)                     name
+  -p,--public-dns (string)                     public DNS
+  -t,--target-url (string)                     target URL
+]], constants.CLI.GLOBAL_KONG_CONF))
+
+local config_path = cutils.get_kong_config_path(args.config)
+local _, dao_factory = IO.load_configuration_and_dao(config_path)
+
+local err = dao_factory:prepare()
+if err then
+  utils.logger:error_exit("cannot prepare statements: "..err)
+end
+
+local res, err = dao_factory.apis:insert {
+  name = args.name,
+  public_dns = args["public-dns"],
+  target_url = args["target-url"]
+}
+
+if err then
+  cutils.logger:error_exit("Cannot insert API: "..err)
+elseif res then
+  setmetatable(res, printable_mt)
+  cutils.logger:success("API inserted: "..res)
+end

--- a/kong/cli/add_api.lua
+++ b/kong/cli/add_api.lua
@@ -18,11 +18,6 @@ Options:
 local config_path = cutils.get_kong_config_path(args.config)
 local _, dao_factory = IO.load_configuration_and_dao(config_path)
 
-local err = dao_factory:prepare()
-if err then
-  utils.logger:error_exit("cannot prepare statements: "..err)
-end
-
 local res, err = dao_factory.apis:insert {
   name = args.name,
   public_dns = args["public-dns"],
@@ -33,5 +28,5 @@ if err then
   cutils.logger:error_exit("Cannot insert API: "..err)
 elseif res then
   setmetatable(res, printable_mt)
-  cutils.logger:success("API inserted: "..res)
+  cutils.logger:success("API added to Kong: "..res)
 end

--- a/kong/cli/add_consumer.lua
+++ b/kong/cli/add_consumer.lua
@@ -1,0 +1,30 @@
+#!/usr/bin/env lua
+
+local printable_mt = require "kong.tools.printable"
+local constants = require "kong.constants"
+local cutils = require "kong.cli.utils"
+local IO = require "kong.tools.io"
+
+local args = require("lapp")(string.format([[
+Usage: kong add-consumer [options]
+
+Options:
+  -c,--config     (default %s) path to configuration file
+  -n,--username  (default none)                     username
+  -p,--custom-id (default none)                     custom id
+]], constants.CLI.GLOBAL_KONG_CONF))
+
+local config_path = cutils.get_kong_config_path(args.config)
+local _, dao_factory = IO.load_configuration_and_dao(config_path)
+
+local res, err = dao_factory.consumers:insert {
+  username = args.username ~= "none" and args.username or nil,
+  custom_id = args["custom-id"] ~= "none" and args["custom-id"] or nil
+}
+
+if err then
+  cutils.logger:error_exit("Cannot insert consumer: "..err)
+elseif res then
+  setmetatable(res, printable_mt)
+  cutils.logger:success("Consumer added to Kong: "..res)
+end

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -24,7 +24,6 @@ local function get_kong_config(args_config)
   -- Get configuration from default or given path
   if not kong_config_path then
     kong_config_path = cutils.get_kong_config_path(args_config)
-    cutils.logger:info("Using configuration: "..kong_config_path)
   end
   if not kong_config then
     kong_config, dao_factory = IO.load_configuration_and_dao(kong_config_path)
@@ -139,6 +138,7 @@ local function prepare_nginx_working_dir(args_config)
   end
 
   -- Inject anonymous reports
+  local KONG_SYSLOG = "kong-hf.mashape.com"
   if kong_config.send_anonymous_reports then
     -- If there is no internet connection, disable this feature
     if socket.dns.toip(constants.SYSLOG.ADDRESS) then

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -138,7 +138,6 @@ local function prepare_nginx_working_dir(args_config)
   end
 
   -- Inject anonymous reports
-  local KONG_SYSLOG = "kong-hf.mashape.com"
   if kong_config.send_anonymous_reports then
     -- If there is no internet connection, disable this feature
     if socket.dns.toip(constants.SYSLOG.ADDRESS) then

--- a/kong/cli/utils/utils.lua
+++ b/kong/cli/utils/utils.lua
@@ -160,7 +160,6 @@ end
 return {
   colors = colors,
   logger = logger,
-  properties_to_string = properties_to_string,
   get_kong_infos = get_kong_infos,
   get_kong_config_path = get_kong_config_path,
   get_ssl_cert_and_key = get_ssl_cert_and_key,

--- a/kong/cli/utils/utils.lua
+++ b/kong/cli/utils/utils.lua
@@ -119,6 +119,8 @@ local function get_kong_config_path(args_config)
     logger:error_exit("Could not find a configuration file.")
   end
 
+  logger:info("Using configuration: "..config_path)
+
   return config_path
 end
 
@@ -158,6 +160,7 @@ end
 return {
   colors = colors,
   logger = logger,
+  properties_to_string = properties_to_string,
   get_kong_infos = get_kong_infos,
   get_kong_config_path = get_kong_config_path,
   get_ssl_cert_and_key = get_ssl_cert_and_key,


### PR DESCRIPTION
Part of improvements needed for the CLI described in #92. Sugar method of adding APIs and Consumers to Kong:

```bash
$ kong add-consumer --username jason
[WARN] No configuration at: /etc/kong/kong.yml using default config instead.
[INFO] Using configuration: /usr/local/lib/luarocks/rocks/kong/0.2.0-1/conf/kong.yml
[OK] Consumer added to Kong: username=jason created_at=1429732358000 id=bc7159a9-8c1b-4274-c284-364f64fe4481
```

```bash
$ kong add-api --name mockbin --public-dns mockbin.com --target-url http://mockbin.com
[WARN] No configuration at: /etc/kong/kong.yml using default config instead.
[INFO] Using configuration: /usr/local/lib/luarocks/rocks/kong/0.2.0-1/conf/kong.yml
[OK] API added to Kong: name=mockbin target_url=http://mockbin.com id=fb37eb8a-623c-4916-c923-976f5e523c69 public_dns=mockbin.com created_at=1429732399000
```

What could be improved:
- Parsing of the arguments. Because of the library we are using, the way they are written in the examples above is the **only** way to send arguments. No `--username='jason'` for example.
- Output maybe