### PR TITLE
Split plugins tables from core tables

### DIFF
--- a/database/migrations/cassandra/2015-01-12-175310_init_schema.lua
+++ b/database/migrations/cassandra/2015-01-12-175310_init_schema.lua
@@ -52,36 +52,6 @@ local Migration = {
       CREATE INDEX IF NOT EXISTS ON plugins_configurations(name);
       CREATE INDEX IF NOT EXISTS ON plugins_configurations(api_id);
       CREATE INDEX IF NOT EXISTS ON plugins_configurations(consumer_id);
-
-      CREATE TABLE IF NOT EXISTS basicauth_credentials(
-        id uuid,
-        consumer_id uuid,
-        username text,
-        password text,
-        created_at timestamp,
-        PRIMARY KEY (id)
-      );
-
-      CREATE INDEX IF NOT EXISTS ON basicauth_credentials(username);
-
-      CREATE TABLE IF NOT EXISTS keyauth_credentials(
-        id uuid,
-        consumer_id uuid,
-        key text,
-        created_at timestamp,
-        PRIMARY KEY (id)
-      );
-
-      CREATE INDEX IF NOT EXISTS ON keyauth_credentials(key);
-
-      CREATE TABLE IF NOT EXISTS ratelimiting_metrics(
-        api_id uuid,
-        identifier text,
-        period text,
-        period_date timestamp,
-        value counter,
-        PRIMARY KEY ((api_id, identifier, period_date, period))
-      );
     ]]
   end,
 

--- a/database/migrations/cassandra/2015-04-24-154530_plugins.lua
+++ b/database/migrations/cassandra/2015-04-24-154530_plugins.lua
@@ -1,0 +1,46 @@
+local Migration = {
+  name = "2015-04-24-154530_plugins",
+  up = function(options)
+    return [[
+      CREATE TABLE IF NOT EXISTS basicauth_credentials(
+        id uuid,
+        consumer_id uuid,
+        username text,
+        password text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON basicauth_credentials(username);
+
+      CREATE TABLE IF NOT EXISTS keyauth_credentials(
+        id uuid,
+        consumer_id uuid,
+        key text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON keyauth_credentials(key);
+
+      CREATE TABLE IF NOT EXISTS ratelimiting_metrics(
+        api_id uuid,
+        identifier text,
+        period text,
+        period_date timestamp,
+        value counter,
+        PRIMARY KEY ((api_id, identifier, period_date, period))
+      );
+    ]]
+  end,
+
+  down = function(options)
+    return [[
+      DROP TABLE basicauth_credentials;
+      DROP TABLE keyauth_credentials;
+      DROP TABLE ratelimiting_metrics;
+    ]]
+  end
+}
+
+return Migration

--- a/kong/cli/migrations.lua
+++ b/kong/cli/migrations.lua
@@ -77,7 +77,7 @@ elseif args.command == "down" then
     if err then
       cutils.logger:error_exit(err)
     elseif migration then
-      cutils.logger:success("Rollbacked to: "..cutils.colors.yellow(migration.name))
+      cutils.logger:success("Rollbacked: "..cutils.colors.yellow(migration.name))
     else
       cutils.logger:success("No migration to rollback")
     end


### PR DESCRIPTION
It's the least we can do to keep the core and the plugins tables
separate before releasing 0.2.0.