### PR TITLE
Fix/server-header

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -117,7 +117,8 @@ nginx: |
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass $backend_url;
-
+        proxy_pass_header Server;
+        
         # Add additional response headers
         header_filter_by_lua 'kong.exec_plugins_header_filter()';
 

--- a/kong.yml
+++ b/kong.yml
@@ -118,7 +118,7 @@ nginx: |
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass $backend_url;
         proxy_pass_header Server;
-        
+
         # Add additional response headers
         header_filter_by_lua 'kong.exec_plugins_header_filter()';
 

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -154,6 +154,7 @@ nginx: |
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass $backend_url;
+        proxy_pass_header Server;
 
         # Add additional response headers
         header_filter_by_lua 'kong.exec_plugins_header_filter()';


### PR DESCRIPTION
Without this directive nginx appends it's own server header for everything going through the proxy. By adding `proxy_pass_header Server;` to the nginx conf it will keep any `Server` header from from the target and not add `Server: openresty/1.7.10.2` to all proxied responses.

Before:

![screen shot 2015-04-26 at 7 13 47 am](https://cloud.githubusercontent.com/assets/24260/7339834/f9675ee2-ec30-11e4-8d31-18245700ab9e.png)

After:

![screen shot 2015-04-26 at 7 17 54 am](https://cloud.githubusercontent.com/assets/24260/7339835/f9cb3444-ec30-11e4-95e6-1bdf370442bf.png)
