### PR TITLE
[fix] friendlier 'API not found' error message

### DIFF
--- a/kong/resolver/handler.lua
+++ b/kong/resolver/handler.lua
@@ -1,21 +1,29 @@
+-- Kong resolver core-plugin
+--
+-- This core-plugin is executed before any other, and allows to map a Host header
+-- to an API added to Kong. If the API was found, it will set the $backend_url variable
+-- allowing nginx to proxy the request as defined in the nginx configuration.
+--
+-- Executions: 'access', 'header_filter'
+
 local access = require "kong.resolver.access"
 local header_filter = require "kong.resolver.header_filter"
 local BasePlugin = require "kong.plugins.base_plugin"
 
-local CoreHandler = BasePlugin:extend()
+local ResolverHandler = BasePlugin:extend()
 
-function CoreHandler:new()
-  CoreHandler.super.new(self, "resolver")
+function ResolverHandler:new()
+  ResolverHandler.super.new(self, "resolver")
 end
 
-function CoreHandler:access(conf)
-  CoreHandler.super.access(self)
+function ResolverHandler:access(conf)
+  ResolverHandler.super.access(self)
   access.execute(conf)
 end
 
-function CoreHandler:header_filter(conf)
-  CoreHandler.super.header_filter(self)
+function ResolverHandler:header_filter(conf)
+  ResolverHandler.super.header_filter(self)
   header_filter.execute(conf)
 end
 
-return CoreHandler
+return ResolverHandler

--- a/spec/integration/proxy/resolver_spec.lua
+++ b/spec/integration/proxy/resolver_spec.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 
 local STUB_GET_URL = spec_helper.STUB_GET_URL
 
-describe("Resolver #proxy", function()
+describe("Resolver", function()
 
   setup(function()
     spec_helper.prepare_db()
@@ -17,32 +17,37 @@ describe("Resolver #proxy", function()
     spec_helper.reset_db()
   end)
 
-  describe("Invalid API", function()
+  describe("Inexistent API", function()
 
-    it("should return API not found when the API is missing", function()
-      local response, status, headers = http_client.get(spec_helper.PROXY_URL)
+    it("should return Not Found when the API is not in Kong", function()
+      local response, status, headers = http_client.get(spec_helper.STUB_GET_URL, nil, { host = "foo.com" })
       local body = cjson.decode(response)
       assert.are.equal(404, status)
-      assert.are.equal("API not found", body.message)
+      assert.are.equal('API not found with Host: "foo.com"', body.message)
     end)
 
   end)
 
   describe("Existing API", function()
 
-    it("should return API found when the API has been created", function()
-      local response, status, headers = http_client.get(STUB_GET_URL, {}, {host = "test4.com"})
+    it("should return Success when the API is in Kong", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, nil, { host = "test4.com"})
       assert.are.equal(200, status)
     end)
 
-    it("should return correct server header", function()
-      local response, status, headers = http_client.get(STUB_GET_URL, {}, {host = "test4.com"})
+    it("should return Success when the Host header is not trimmed", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, nil, { host = "   test4.com  "})
+      assert.are.equal(200, status)
+    end)
+
+    it("should return the correct Server header", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, nil, { host = "test4.com"})
       assert.are.equal("cloudflare-nginx", headers.server)
     end)
 
-    it("should return correct via header", function()
-      local response, status, headers = http_client.get(STUB_GET_URL, {}, {host = "test4.com"})
-      assert.are.equal("kong/"..constants.VERSION, headers.via)
+    it("should return the correct Via header", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, nil, { host = "test4.com"})
+      assert.are.equal(constants.NAME.."/"..constants.VERSION, headers.via)
     end)
 
   end)


### PR DESCRIPTION
- 'API not found with host %s' is the new error message, allowing the
  user to better understand what is happening
- Minor changes to the resolver plugin: no need to strip the header +
  tests