### PR TITLE
fix: reused DAO sockets don't set the keyspace. fix #170

### DIFF
--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -157,7 +157,7 @@ function BaseDao:_open_session()
     return nil, DaoError(err, error_types.DATABASE)
   end
 
-  if times == 0 or not times then
+  if times == 0 then
     ok, err = session:set_keyspace(self._properties.keyspace)
     if not ok then
       return nil, DaoError(err, error_types.DATABASE)


### PR DESCRIPTION
DAO sockets now take advantage of the connection pool and if they are
coming from it (meaning they've been used before), they don't set their
keyspace anymore.