### PR TITLE
dnsmasq integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - bash .travis/setup_openresty.sh
   - export PATH=$PATH:/usr/local/openresty/nginx/sbin
   - bash .travis/setup_cassandra.sh
+  - bash .travis/setup_dnsmasq.sh
 
 install:
   - sudo make install

--- a/.travis/setup_dnsmasq.sh
+++ b/.travis/setup_dnsmasq.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo apt-get update && sudo apt-get install dnsmasq sudo
+echo -e "user=root" | sudo tee /etc/dnsmasq.conf

--- a/kong.yml
+++ b/kong.yml
@@ -13,6 +13,7 @@ nginx_working_dir: /usr/local/kong/
 
 proxy_port: 8000
 admin_api_port: 8001
+dnsmasq_port: 8053
 
 # Specify the DAO to use
 database: cassandra
@@ -49,7 +50,7 @@ nginx: |
   }
 
   http {
-    resolver 8.8.8.8;
+    resolver {{dns_resolver}};
     charset UTF-8;
 
     access_log logs/access.log;

--- a/kong/cli/quit.lua
+++ b/kong/cli/quit.lua
@@ -19,7 +19,7 @@ if not running then
 end
 
 -- Send 'quit' signal (graceful shutdown)
-if signal.send_signal(args.config, "quit") then
+if signal.send_signal(args.config, signal.QUIT) then
   cutils.logger:success("Stopped")
 else
   cutils.logger:error_exit("Could not gracefully stop Kong")

--- a/kong/cli/reload.lua
+++ b/kong/cli/reload.lua
@@ -20,7 +20,7 @@ end
 
 signal.prepare_kong(args.config)
 
-if signal.send_signal(args.config, "reload") then
+if signal.send_signal(args.config, signal.RELOAD) then
   cutils.logger:success("Reloaded")
 else
   cutils.logger:error_exit("Could not reload Kong")

--- a/kong/cli/restart.lua
+++ b/kong/cli/restart.lua
@@ -16,7 +16,7 @@ Options:
 ]], constants.CLI.GLOBAL_KONG_CONF))
 
 if signal.is_running(args.config) then
-  if not signal.send_signal(args.config, "stop") then
+  if not signal.send_signal(args.config, signal.STOP) then
     cutils.logger:error_exit("Could not stop Kong")
   end
 end

--- a/kong/cli/stop.lua
+++ b/kong/cli/stop.lua
@@ -19,7 +19,7 @@ if not running then
 end
 
 -- Send 'stop' signal (fast shutdown)
-if signal.send_signal(args.config, "stop") then
+if signal.send_signal(args.config, signal.STOP) then
   cutils.logger:success("Stopped")
 else
   cutils.logger:error_exit("Could not stop Kong")

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -8,7 +8,8 @@ return {
   CLI = {
     GLOBAL_KONG_CONF = "/etc/kong/kong.yml",
     NGINX_CONFIG = "nginx.conf",
-    NGINX_PID = "kong.pid"
+    NGINX_PID = "kong.pid",
+    DNSMASQ_PID = "dnsmasq.pid",
   },
   DATABASE_NULL_ID = "00000000-0000-0000-0000-000000000000",
   DATABASE_ERROR_TYPES = {

--- a/kong/tools/faker.lua
+++ b/kong/tools/faker.lua
@@ -33,6 +33,9 @@ Faker.FIXTURES = {
     { name = "API TESTS 6", public_dns = "cors1.com", target_url = "http://mockbin.com" },
     { name = "API TESTS 7", public_dns = "cors2.com", target_url = "http://mockbin.com" },
 
+    { name = "API TESTS 8 (dns)", public_dns = "dns1.com", target_url = "http://127.0.0.1:7771" },
+    { name = "API TESTS 9 (dns)", public_dns = "dns2.com", target_url = "http://localhost:7771" },
+
     -- DEVELOPMENT APIs. Please do not use those in tests
     { name = "API DEV 1", public_dns = "dev.com", target_url = "http://mockbin.com" },
   },

--- a/spec/integration/proxy/dns_spec.lua
+++ b/spec/integration/proxy/dns_spec.lua
@@ -1,0 +1,59 @@
+local spec_helper = require "spec.spec_helpers"
+local http_client = require "kong.tools.http_client"
+local Threads = require "llthreads2.ex"
+
+local STUB_GET_URL = spec_helper.STUB_GET_URL
+
+local function start_tcp_server()
+  local thread = Threads.new({
+    function()
+      local socket = require "socket"
+      local server = assert(socket.bind("*", 7771))
+      local client = server:accept()
+      local line, err = client:receive()
+      local message = "{\"ok\": true}"
+      if not err then client:send("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "..string.len(message).."\r\n\r\n"..message) end
+      client:close()
+      return line
+    end;
+  })
+
+  thread:start()
+  return thread;
+end
+
+describe("DNS", function()
+
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+    spec_helper.reset_db()
+  end)
+
+  describe("DNS", function()
+
+    it("should work when calling local IP", function()
+      local thread = start_tcp_server() -- Starting the mock TCP server
+    
+      local response, status = http_client.get(spec_helper.STUB_GET_URL, nil, { host = "dns1.com" })
+      assert.are.equal(200, status)
+
+      thread:join() -- Wait til it exists
+    end)
+
+    it("should work when calling local hostname", function()
+      local thread = start_tcp_server() -- Starting the mock TCP server
+    
+      local response, status = http_client.get(spec_helper.STUB_GET_URL, nil, { host = "dns2.com" })
+      assert.are.equal(200, status)
+
+      thread:join() -- Wait til it exists
+    end)
+
+  end)
+
+end)

--- a/spec/integration/proxy/realip_spec.lua
+++ b/spec/integration/proxy/realip_spec.lua
@@ -1,6 +1,5 @@
 local spec_helper = require "spec.spec_helpers"
 local http_client = require "kong.tools.http_client"
-local Threads = require "llthreads2.ex"
 local cjson = require "cjson"
 local yaml = require "yaml"
 local IO = require "kong.tools.io"

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -58,7 +58,7 @@ function _M.start_kong(conf_file, skip_wait)
   end
 
   if not skip_wait then
-    os.execute("while ! [ -f "..env.configuration.pid_file.." ]; do sleep 1; done")
+    os.execute("while ! [ -f "..env.configuration.pid_file.." ]; do sleep 0.5; done")
   end
 
   return result, exit_code
@@ -72,7 +72,7 @@ function _M.stop_kong(conf_file)
     error("spec_helper cannot stop kong: "..result)
   end
 
-  os.execute("while [ -f "..env.configuration.pid_file.." ]; do sleep 1; done")
+  os.execute("while [ -f "..env.configuration.pid_file.." ]; do sleep 0.5; done")
 
   return result, exit_code
 end

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -50,6 +50,7 @@ nginx_working_dir: /usr/local/kong/
 
 proxy_port: 8000
 admin_api_port: 8001
+dnsmasq_port: 8053
 
 # Specify the DAO to use
 database: cassandra
@@ -86,7 +87,7 @@ nginx: |
   }
 
   http {
-    resolver 8.8.8.8;
+    resolver {{dns_resolver}};
     charset UTF-8;
 
     access_log logs/access.log;

--- a/spec/unit/tools/faker_spec.lua
+++ b/spec/unit/tools/faker_spec.lua
@@ -78,7 +78,7 @@ describe("Faker #tools", function()
     it("should be possible to add some random entities complementing the default hard-coded ones", function()
       faker:seed(2000)
       assert.spy(faker.insert_from_table).was.called(2)
-      assert.spy(insert_spy).was.called(8025) -- 3*2000 + base entities
+      assert.spy(insert_spy).was.called(8027) -- 3*2000 + base entities
     end)
 
     it("should create relations between entities_to_insert and inserted entities", function()

--- a/spec/unit/tools/io_spec.lua
+++ b/spec/unit/tools/io_spec.lua
@@ -1,0 +1,37 @@
+local IO = require "kong.tools.io"
+
+local TEST_FILE = "/tmp/test_file"
+
+describe("IO", function()
+
+  before_each(function()
+    os.remove(TEST_FILE)
+  end)
+
+  it("should detect existing commands", function()
+    assert.truthy(IO.cmd_exists("hash"))
+    assert.falsy(IO.cmd_exists("hashasdasd"))
+  end)
+
+  it("should write and read from files", function()
+    assert.truthy(IO.write_to_file(TEST_FILE, "this is a test"))
+    assert.are.same("this is a test", IO.read_file(TEST_FILE))
+  end)
+
+  it("should detect existing files", function()
+    assert.falsy(IO.file_exists(TEST_FILE))
+    IO.write_to_file(TEST_FILE, "Test")
+    assert.truthy(IO.cmd_exists(TEST_FILE))
+  end)
+
+  it("should execute an OS command", function()
+    local res, code = IO.os_execute("echo \"Hello\"")
+    assert.are.same(0, code)
+    assert.truthy("Hello", res)
+
+    local res, code = IO.os_execute("asdasda \"Hello\"")
+    assert.are.same(127, code)
+    assert.are.same("/bin/bash: asdasda: command not found", res)
+  end)
+  
+end)

--- a/spec/unit/tools/syslog_spec.lua
+++ b/spec/unit/tools/syslog_spec.lua
@@ -66,6 +66,8 @@ describe("Syslog", function()
     assert.truthy(has_hostname)
     assert.truthy(has_cores)
     assert.truthy(has_hello)
+
+    thread:join() -- wait til it exists
   end)
 
 end)


### PR DESCRIPTION
This pull request fixes issue #182, #163 and #127.

The nginx [`resolver`](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) property specifies which DNS server nginx will use when resolving addresses.

The problem with the resolver is that by design nginx doesn't follow the system settings including the `/etc/hosts` file. In order to have a proper DNS resolution that respects the system DNS settings a new dependency needs to be introduces: [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html). 

dnsmasq is a DNS server that runs locally, can listen on a port (I decided to use `8053` for Kong), and can provide DNS resolution reading both `/etc/hosts` file and `resolv.conf`. It is the same dependency that we use for the official Kong Dockerfile (https://github.com/Mashape/docker-kong/blob/master/Dockerfile#L17).

I have been searching for another solution but everybody seems to be using dnsmasq for this use-case.

So this now works, and if in the future a better way to handle this issue will be found, I will be more than happy to remove the dependency to dnsmasq (which works very well by the way). 

I will also update the distributions in a future commit to include dnsmasq as a dependency.