### PR TITLE
[feature] cascade delete of plugins_configurations. fix #107

### DIFF
--- a/kong/dao/cassandra/consumers.lua
+++ b/kong/dao/cassandra/consumers.lua
@@ -1,6 +1,7 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
-local constants = require "kong.constants"
 local stringy = require "stringy"
+local constants = require "kong.constants"
+local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 
 local function check_custom_id_and_username(value, consumer_t)
   if (consumer_t.custom_id == nil or stringy.strip(consumer_t.custom_id) == "")
@@ -54,6 +55,38 @@ function Consumers:new(properties)
   }
 
   Consumers.super.new(self, properties)
+end
+
+-- @override
+function Consumers:delete(consumer_id)
+  local ok, err = Consumers.super.delete(self, consumer_id)
+  if not ok then
+    return err
+  end
+
+  -- delete all related plugins configurations
+  local plugins_dao = PluginsConfigurations(self._properties)
+  local query, args_keys, errors = plugins_dao:_build_where_query(plugins_dao._queries.select.query, {
+    consumer_id = consumer_id
+  })
+  if errors then
+    return nil, errors
+  end
+
+  for _, rows, page, err in plugins_dao:_execute_kong_query({query=query, args_keys=args_keys}, {consumer_id=consumer_id}, {auto_paging=true}) do
+    if err then
+      return nil, err
+    end
+
+    for _, row in ipairs(rows) do
+      local ok_del_plugin, err = plugins_dao:delete(row.id)
+      if not ok_del_plugin then
+        return nil, err
+      end
+    end
+  end
+
+  return ok
 end
 
 return Consumers

--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -121,7 +121,7 @@ function PluginsConfigurations:find_distinct()
   end
 
   local result = {}
-  for k,_ in pairs(distinct_names) do
+  for k, _ in pairs(distinct_names) do
     table.insert(result, k)
   end
 

--- a/kong/tools/faker.lua
+++ b/kong/tools/faker.lua
@@ -53,7 +53,7 @@ Faker.FIXTURES = {
     { name = "keyauth", value = { key_names = { "apikey" }}, __api = 1 },
     { name = "tcplog", value = { host = "127.0.0.1", port = 7777 }, __api = 1 },
     { name = "udplog", value = { host = "127.0.0.1", port = 8888 }, __api = 1 },
-    { name = "filelog", value = { }, __api = 1 },
+    { name = "filelog", value = {}, __api = 1 },
     -- API 2
     { name = "basicauth", value = {}, __api = 2 },
     -- API 3
@@ -73,9 +73,9 @@ Faker.FIXTURES = {
     -- API 6
     { name = "cors", value = {}, __api = 6 },
     -- API 7
-    { name = "cors", value = { origin = "example.com", 
-                               methods = "GET", 
-                               headers = "origin, type, accepts", 
+    { name = "cors", value = { origin = "example.com",
+                               methods = "GET",
+                               headers = "origin, type, accepts",
                                exposed_headers = "x-auth-token",
                                max_age = 23,
                                credentials = true }, __api = 7 }

--- a/spec/integration/admin_api/admin_api_spec.lua
+++ b/spec/integration/admin_api/admin_api_spec.lua
@@ -106,106 +106,145 @@ describe("Admin API", function()
 
   end)
 
-  for i, v in ipairs(ENDPOINTS) do
-    describe("#"..v.collection.." entity", function()
+  describe("POST", function()
+    for i, v in ipairs(ENDPOINTS) do
+      describe(v.collection.." entity", function()
 
-      it("should not create on POST with invalid parameters", function()
-        if v.collection ~= "consumers" then
-          local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", {})
-          assert.are.equal(400, status)
-          assert.are.equal(v.error_message, response)
-        end
-      end)
-
-      it("should create an entity from valid paremeters", function()
-        -- Replace the IDs
-        for k, p in pairs(v.entity) do
-          if type(p) == "function" then
-            v.entity[k] = p()
+        it("should not create with invalid parameters", function()
+          if v.collection ~= "consumers" then
+            local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", {})
+            assert.are.equal(400, status)
+            assert.are.equal(v.error_message, response)
           end
-        end
+        end)
 
-        local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity)
-        local body = cjson.decode(response)
-        assert.are.equal(201, status)
-        assert.truthy(body)
+        it("should create an entity from valid paremeters", function()
+          -- Replace the IDs
+          for k, p in pairs(v.entity) do
+            if type(p) == "function" then
+              v.entity[k] = p()
+            end
+          end
 
-        -- Save the ID for later use
-        created_ids[v.collection] = body.id
+          local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity)
+          local body = cjson.decode(response)
+          assert.are.equal(201, status)
+          assert.truthy(body)
+
+          -- Save the ID for later use
+          created_ids[v.collection] = body.id
+        end)
+
+        it("should not create when the content-type is wrong", function()
+          local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity, { ["content-type"] = "application/json"})
+          assert.are.equal(415, status)
+          assert.are.equal("{\"message\":\"Unsupported Content-Type. Use \\\"application\\/x-www-form-urlencoded\\\"\"}\n", response)
+        end)
+
       end)
+    end
+  end)
 
-      it("should GET all entities", function()
-        local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/")
-        local body = cjson.decode(response)
-        assert.are.equal(200, status)
-        assert.truthy(body.data)
-        --assert.truthy(body.total)
-        --assert.are.equal(v.total, body.total)
-        assert.are.equal(v.total, table.getn(body.data))
+  describe("GET", function()
+    for i, v in ipairs(ENDPOINTS) do
+      describe(v.collection.." entity", function()
+
+        it("should return not retrieve any entity with an invalid parameter", function()
+          local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection].."blah")
+          local body = cjson.decode(response)
+          assert.are.equal(404, status)
+          assert.truthy(body)
+          assert.are.equal('{"id":"'..created_ids[v.collection]..'blah is an invalid uuid"}\n', response)
+        end)
+
+        it("should retrieve all entities", function()
+          local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/")
+          local body = cjson.decode(response)
+          assert.are.equal(200, status)
+          assert.truthy(body.data)
+          --assert.truthy(body.total)
+          --assert.are.equal(v.total, body.total)
+          assert.are.equal(v.total, table.getn(body.data))
+        end)
+
+        it("should retrieve one entity", function()
+          local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection])
+          local body = cjson.decode(response)
+          assert.are.equal(200, status)
+          assert.truthy(body)
+          assert.are.equal(created_ids[v.collection], body.id)
+        end)
+
       end)
+    end
+  end)
 
-      it("should GET one entity", function()
-        local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection])
-        local body = cjson.decode(response)
-        assert.are.equal(200, status)
-        assert.truthy(body)
-        assert.are.equal(created_ids[v.collection], body.id)
+  describe("PUT", function()
+    for i, v in ipairs(ENDPOINTS) do
+      describe(v.collection.." entity", function()
+
+        it("should not update when the content-type is wrong", function()
+          local response, status, headers = http_client.put(kWebURL.."/"..v.collection.."/"..created_ids[v.collection], body, { ["content-type"] = "application/x-www-form-urlencoded"})
+          assert.are.equal(415, status)
+          assert.are.equal("{\"message\":\"Unsupported Content-Type. Use \\\"application\\/json\\\"\"}\n", response)
+        end)
+
+        it("should update an entity if valid parameters", function()
+          local data = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection])
+          local body = cjson.decode(data)
+
+          -- Create new body
+          for k,v in pairs(v.update_fields) do
+            body[k] = v
+          end
+
+          local response, status, headers = http_client.put(kWebURL.."/"..v.collection.."/"..created_ids[v.collection], body)
+          local new_body = cjson.decode(response)
+          assert.are.equal(200, status)
+          assert.truthy(new_body)
+          assert.are.equal(created_ids[v.collection], new_body.id)
+
+          for k,v in pairs(v.update_fields) do
+            assert.are.equal(v, new_body[k])
+          end
+
+          assert.are.same(body, new_body)
+        end)
+
       end)
+    end
+  end)
 
-      it("should return not found on GET", function()
-        local response, status, headers = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection].."blah")
-        local body = cjson.decode(response)
-        assert.are.equal(404, status)
-        assert.truthy(body)
-        assert.are.equal('{"id":"'..created_ids[v.collection]..'blah is an invalid uuid"}\n', response)
-      end)
+  -- Tests on DELETE must run in that order:
+  --  1. plugins_configurations
+  --  2. APIs/Consumers
+  -- Since deleting APIs and Consumers delete related plugins_configurations.
+  describe("DELETE", function()
+    describe("plugins_configurations", function()
 
-      it("should update a created entity on PUT", function()
-        local data = http_client.get(kWebURL.."/"..v.collection.."/"..created_ids[v.collection])
-        local body = cjson.decode(data)
-
-        -- Create new body
-        for k,v in pairs(v.update_fields) do
-          body[k] = v
-        end
-
-        local response, status, headers = http_client.put(kWebURL.."/"..v.collection.."/"..created_ids[v.collection], body)
-        local new_body = cjson.decode(response)
-        assert.are.equal(200, status)
-        assert.truthy(new_body)
-        assert.are.equal(created_ids[v.collection], new_body.id)
-
-        for k,v in pairs(v.update_fields) do
-          assert.are.equal(v, new_body[k])
-        end
-
-        assert.are.same(body, new_body)
-      end)
-
-      it("should not update when the content-type is wrong", function()
-        local response, status, headers = http_client.put(kWebURL.."/"..v.collection.."/"..created_ids[v.collection], body, { ["content-type"] = "application/x-www-form-urlencoded"})
-        assert.are.equal(415, status)
-        assert.are.equal("{\"message\":\"Unsupported Content-Type. Use \\\"application\\/json\\\"\"}\n", response)
-      end)
-
-      it("should not save when the content-type is wrong", function()
-        local response, status, headers = http_client.post(kWebURL.."/"..v.collection.."/", v.entity, { ["content-type"] = "application/json"})
-        assert.are.equal(415, status)
-        assert.are.equal("{\"message\":\"Unsupported Content-Type. Use \\\"application\\/x-www-form-urlencoded\\\"\"}\n", response)
-      end)
-
-    end)
-  end
-
-  for i,v in ipairs(ENDPOINTS) do
-    describe("#"..v.collection, function()
-
-      it("should delete an entity on DELETE", function()
-        local response, status, headers = http_client.delete(kWebURL.."/"..v.collection.."/"..created_ids[v.collection])
+      it("should delete a plugin_configuration", function()
+        local response, status, headers = http_client.delete(kWebURL.."/plugins_configurations/"..created_ids.plugins_configurations)
         assert.are.equal(204, status)
       end)
 
     end)
-  end
 
+    describe("APIs", function()
+
+      it("should delete an API", function()
+        local response, status, headers = http_client.delete(kWebURL.."/apis/"..created_ids.apis)
+        assert.are.equal(204, status)
+      end)
+
+    end)
+
+    describe("Consumers", function()
+
+      it("should delete a Consumer", function()
+        local response, status, headers = http_client.delete(kWebURL.."/consumers/"..created_ids.consumers)
+        assert.are.equal(204, status)
+      end)
+
+    end)
+  end)
 end)


### PR DESCRIPTION
This proposes a way to delete all `plugins_configurations` related to `Consumers` or `APIs` when deleting one of the two later.

`:delete()` is simply overridden to iterate over all related `plugins_configuration` and delete them one by one.

Caveats:
- I am very unhappy with how painful it is to use one DAO inside another
DAO. To avoid what would appear to be a cycling reference I rather opted
for instanciating a new DAO inside of the `delete` method.
- It is painful to perform a paginated query through the base_dao.
- It is even more painful to perform a find_by_keys query as a paginated
  query.