### PR TITLE
[refactor] drop pcre regexes for lua patterns

### DIFF
--- a/kong-0.2.1-1.rockspec
+++ b/kong-0.2.1-1.rockspec
@@ -12,19 +12,22 @@ description = {
 }
 dependencies = {
   "lua ~> 5.1",
+  "luasec ~> 0.5-2",
 
   "uuid ~> 0.2-1",
   "luatz ~> 0.3-1",
   "yaml ~> 1.1.1-1",
-  "luasec ~> 0.5-2",
   "lapis ~> 1.1.0-1",
   "stringy ~> 0.4-1",
   "cassandra ~> 0.5-7",
+  "multipart ~> 0.1-2",
   "lua-path ~> 0.2.3-1",
   "lua-cjson ~> 2.1.0-1",
-  "luasocket ~> 2.0.2-5",
   "ansicolors ~> 1.0.2-3",
-  "multipart ~> 0.1-2"
+
+  "luasocket ~> 2.0.2-5",
+  "lrexlib-pcre ~> 2.7.2-1",
+  "lua-llthreads2 ~> 0.1.3-1"
 }
 build = {
   type = "builtin",

--- a/kong-0.2.1-1.rockspec
+++ b/kong-0.2.1-1.rockspec
@@ -24,7 +24,6 @@ dependencies = {
   "lua-cjson ~> 2.1.0-1",
   "luasocket ~> 2.0.2-5",
   "ansicolors ~> 1.0.2-3",
-  "lrexlib-pcre ~> 2.7.2-1",
   "multipart ~> 0.1-2"
 }
 build = {

--- a/kong/dao/cassandra/apis.lua
+++ b/kong/dao/cassandra/apis.lua
@@ -2,20 +2,11 @@ local BaseDao = require "kong.dao.cassandra.base_dao"
 local constants = require "kong.constants"
 local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 
-local function is_valid_public_dns(str)
-  -- check the format
-  local pattern1 = "[A-Za-z0-9%-]*%.*[A-Za-z0-9%-]*%.[A-Za-z0-9][A-Za-z0-9]+$"
-  -- check all characters are alphanumeric
-  local pattern2 = "^[%w%.%-]*$"
-  -- both checks need to be true to be a valid public_dns
-  return str:match(pattern1) and str:match(pattern2)
-end
-
 local SCHEMA = {
   id = { type = constants.DATABASE_TYPES.ID },
   name = { type = "string", unique = true, queryable = true, default = function(api_t) return api_t.public_dns end },
   public_dns = { type = "string", required = true, unique = true, queryable = true,
-                 func = is_valid_public_dns },
+                 regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])" },
   target_url = { type = "string", required = true },
   created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }

--- a/kong/dao/cassandra/apis.lua
+++ b/kong/dao/cassandra/apis.lua
@@ -2,11 +2,20 @@ local BaseDao = require "kong.dao.cassandra.base_dao"
 local constants = require "kong.constants"
 local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 
+local function is_valid_public_dns(str)
+  -- check the format
+  local pattern1 = "[A-Za-z0-9%-]*%.*[A-Za-z0-9%-]*%.[A-Za-z0-9][A-Za-z0-9]+$"
+  -- check all characters are alphanumeric
+  local pattern2 = "^[%w%.%-]*$"
+  -- both checks need to be true to be a valid public_dns
+  return str:match(pattern1) and str:match(pattern2)
+end
+
 local SCHEMA = {
   id = { type = constants.DATABASE_TYPES.ID },
   name = { type = "string", unique = true, queryable = true, default = function(api_t) return api_t.public_dns end },
   public_dns = { type = "string", required = true, unique = true, queryable = true,
-                 regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])" },
+                 func = is_valid_public_dns },
   target_url = { type = "string", required = true },
   created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
 }

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -14,7 +14,6 @@ local stringy = require "stringy"
 local Object = require "classic"
 local utils = require "kong.tools.utils"
 local uuid = require "uuid"
-local rex = require "rex_pcre"
 
 local cassandra_constants = require "cassandra.constants"
 local error_types = constants.DATABASE_ERROR_TYPES
@@ -183,9 +182,10 @@ function BaseDao:_close_session(session)
   end
 end
 
-local pattern = "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+local x = "%x"
+local uuid_pattern = "^"..table.concat({ x:rep(8), x:rep(4), x:rep(4), x:rep(4), x:rep(12) }, '%-').."$"
 local function is_valid_uuid(uuid)
-  return rex.match(uuid, pattern) ~= nil
+  return uuid and uuid:match(uuid_pattern) ~= nil
 end
 
 -- Build the array of arguments to pass to lua-resty-cassandra :execute method.

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -182,8 +182,8 @@ function BaseDao:_close_session(session)
   end
 end
 
-local x = "%x"
-local uuid_pattern = "^"..table.concat({ x:rep(8), x:rep(4), x:rep(4), x:rep(4), x:rep(12) }, '%-').."$"
+local digit = "[0-9a-f]"
+local uuid_pattern = "^"..table.concat({ digit:rep(8), digit:rep(4), digit:rep(4), digit:rep(4), digit:rep(12) }, '%-').."$"
 local function is_valid_uuid(uuid)
   return uuid and uuid:match(uuid_pattern) ~= nil
 end

--- a/kong/dao/schemas.lua
+++ b/kong/dao/schemas.lua
@@ -66,6 +66,12 @@ function _M.validate(t, schema, is_update)
         errors = utils.add_error(errors, column, string.format("\"%s\" is not allowed. Allowed values are: \"%s\"", t[column], table.concat(v.enum, "\", \"")))
       end
 
+    -- Check field against a regex if specified
+    elseif t[column] ~= nil and v.regex then
+      if not ngx.re.match(t[column], v.regex) then
+        errors = utils.add_error(errors, column, column.." has an invalid value")
+      end
+
     -- Check field against a custom function
     elseif v.func and type(v.func) == "function" then
       local ok, err = v.func(t[column], t)
@@ -102,7 +108,7 @@ function _M.validate(t, schema, is_update)
   end
 
   -- Check for unexpected fields in the entity
-  for k,v in pairs(t) do
+  for k, v in pairs(t) do
     if schema[k] == nil then
       errors = utils.add_error(errors, k, k.." is an unknown field")
     end

--- a/kong/dao/schemas.lua
+++ b/kong/dao/schemas.lua
@@ -1,4 +1,3 @@
-local rex = require "rex_pcre"
 local utils = require "kong.tools.utils"
 local constants = require "kong.constants"
 
@@ -65,12 +64,6 @@ function _M.validate(t, schema, is_update)
 
       if not found then
         errors = utils.add_error(errors, column, string.format("\"%s\" is not allowed. Allowed values are: \"%s\"", t[column], table.concat(v.enum, "\", \"")))
-      end
-
-    -- Check field against a regex if specified
-    elseif t[column] ~= nil and v.regex then
-      if not rex.match(t[column], v.regex) then
-        errors = utils.add_error(errors, column, column.." has an invalid value")
       end
 
     -- Check field against a custom function

--- a/kong/tools/faker.lua
+++ b/kong/tools/faker.lua
@@ -29,9 +29,9 @@ Faker.FIXTURES = {
     { name = "API TESTS 3", public_dns = "test3.com", target_url = "http://mockbin.com" },
     { name = "API TESTS 4", public_dns = "test4.com", target_url = "http://mockbin.com" },
     { name = "API TESTS 5", public_dns = "test5.com", target_url = "http://mockbin.com" },
-
     { name = "API TESTS 6", public_dns = "cors1.com", target_url = "http://mockbin.com" },
     { name = "API TESTS 7", public_dns = "cors2.com", target_url = "http://mockbin.com" },
+    { name = "API TESTS 8 (logging)", public_dns = "logging.com", target_url = "http://mockbin.com" },
 
     { name = "API TESTS 8 (dns)", public_dns = "dns1.com", target_url = "http://127.0.0.1:7771" },
     { name = "API TESTS 9 (dns)", public_dns = "dns2.com", target_url = "http://localhost:7771" },
@@ -53,9 +53,6 @@ Faker.FIXTURES = {
   plugin_configuration = {
     -- API 1
     { name = "keyauth", value = { key_names = { "apikey" }}, __api = 1 },
-    { name = "tcplog", value = { host = "127.0.0.1", port = 7777 }, __api = 1 },
-    { name = "udplog", value = { host = "127.0.0.1", port = 8888 }, __api = 1 },
-    { name = "filelog", value = {}, __api = 1 },
     -- API 2
     { name = "basicauth", value = {}, __api = 2 },
     -- API 3
@@ -80,7 +77,11 @@ Faker.FIXTURES = {
                                headers = "origin, type, accepts",
                                exposed_headers = "x-auth-token",
                                max_age = 23,
-                               credentials = true }, __api = 7 }
+                               credentials = true }, __api = 7 },
+    -- API 8
+    { name = "tcplog", value = { host = "127.0.0.1", port = 7777 }, __api = 8 },
+    { name = "udplog", value = { host = "127.0.0.1", port = 8888 }, __api = 8 },
+    { name = "filelog", value = {}, __api = 8 },
   }
 }
 

--- a/kong/tools/io.lua
+++ b/kong/tools/io.lua
@@ -1,7 +1,7 @@
-local constants = require "kong.constants"
-local path = require("path").new("/")
 local yaml = require "yaml"
+local path = require("path").new("/")
 local stringy = require "stringy"
+local constants = require "kong.constants"
 
 local _M = {}
 

--- a/spec/integration/proxy/realip_spec.lua
+++ b/spec/integration/proxy/realip_spec.lua
@@ -5,7 +5,6 @@ local yaml = require "yaml"
 local IO = require "kong.tools.io"
 local stringy = require "stringy"
 local uuid = require "uuid"
-local rex = require "rex_pcre"
 
 -- This is important to seed the UUID generator
 uuid.seed()
@@ -29,10 +28,16 @@ describe("Real IP", function()
     local uuid,_ = string.gsub(uuid(), "-", "")
 
     -- Making the request
-    local response, status, headers = http_client.get(STUB_GET_URL, {apikey = "apikey123"}, {host = "test1.com", ["X-Forwarded-For"] = "4.4.4.4, 1.1.1.1, 5.5.5.5", file_log_uuid = uuid})
+    local response, status = http_client.get(STUB_GET_URL, nil,
+      {
+        host = "logging.com",
+        ["X-Forwarded-For"] = "4.4.4.4, 1.1.1.1, 5.5.5.5",
+        file_log_uuid = uuid
+      }
+    )
     assert.are.equal(200, status)
 
-    -- Reading the log file and finding the entry
+    -- Reading the log file and finding the line with the entry
     local configuration = yaml.load(IO.read_file(TEST_CONF))
     assert.truthy(configuration)
     local error_log = IO.read_file(configuration.nginx_working_dir.."/logs/error.log")
@@ -46,18 +51,11 @@ describe("Real IP", function()
     end
     assert.truthy(line)
 
-    -- Matching the Json
-    local iterator, iter_err = rex.gmatch(line, "\\s+({.+})\\s+")
-    if not iterator then
-      error(iter_err)
-    end
-    local m, err = iterator()
-    if err then
-      error(err)
-    end
-    assert.truthy(m)
+    -- Retrieve the JSON part of the line
+    local json_str = line:match("(%{.*%})")
+    assert.truthy(json_str)
 
-    local log_message = cjson.decode(m)
+    local log_message = cjson.decode(json_str)
     assert.are.same("4.4.4.4", log_message.ip)
     assert.are.same(uuid, log_message.request.headers.file_log_uuid)
   end)

--- a/spec/ngx_stub.lua
+++ b/spec/ngx_stub.lua
@@ -1,7 +1,41 @@
 local reg = require "rex_pcre"
 
 _G.ngx = {
+  time = function() return os.time() end, -- cassandra.lua
   re = {
     match = reg.match
-  }
+  },
+  -- Builds a querystring from a table, separated by `&`
+  -- @param tab The key/value parameters
+  -- @param key The parent key if the value is multi-dimensional (optional)
+  -- @return a string representing the built querystring
+  encode_args = function(tab, key)
+    local query = {}
+    local keys = {}
+
+    for k in pairs(tab) do
+      keys[#keys+1] = k
+    end
+
+    table.sort(keys)
+
+    for _, name in ipairs(keys) do
+      local value = tab[name]
+      if key then
+        name = string.format("%s[%s]", tostring(key), tostring(name))
+      end
+      if type(value) == "table" then
+        query[#query+1] = build_query(value, name)
+      else
+        value = tostring(value)
+        if value ~= "" then
+          query[#query+1] = string.format("%s=%s", name, value)
+        else
+          query[#query+1] = name
+        end
+      end
+    end
+
+    return table.concat(query, "&")
+  end
 }

--- a/spec/ngx_stub.lua
+++ b/spec/ngx_stub.lua
@@ -1,0 +1,7 @@
+local reg = require "rex_pcre"
+
+_G.ngx = {
+  re = {
+    match = reg.match
+  }
+}

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -13,6 +13,8 @@ local TEST_CONF_FILE = "kong_TEST.yml"
 local TEST_PROXY_URL = "http://localhost:8100"
 local TEST_API_URL = "http://localhost:8101"
 
+require "spec.ngx_stub"
+
 local _M = {}
 
 _M.API_URL = TEST_API_URL

--- a/spec/unit/schemas_spec.lua
+++ b/spec/unit/schemas_spec.lua
@@ -19,7 +19,6 @@ describe("Schemas", function()
     local schema = {
       string = { type = "string", required = true, immutable = true },
       table = { type = "table" },
-      url = { regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])" },
       date = { default = 123456, immutable = true },
       allowed = { enum = { "hello", "world" }},
       boolean_val = { type = "boolean" },
@@ -41,7 +40,7 @@ describe("Schemas", function()
     }
 
     it("should confirm a valid entity is valid", function()
-      local values = { string = "mockbin entity", url = "mockbin.com" }
+      local values = { string = "mockbin entity" }
 
       local valid, err = validate(values, schema)
       assert.falsy(err)
@@ -49,7 +48,7 @@ describe("Schemas", function()
     end)
 
     it("should invalidate entity if required property is missing", function()
-      local values = { url = "mockbin.com" }
+      local values = { table = {"mockbin.com"} }
 
       local valid, err = validate(values, schema)
       assert.falsy(valid)
@@ -94,7 +93,7 @@ describe("Schemas", function()
 
     it("should set default values if those are variables or functions specified in the validator", function()
       -- Variables
-      local values = { string = "mockbin entity", url = "mockbin.com" }
+      local values = { string = "mockbin entity" }
 
       local valid, err = validate(values, schema)
       assert.falsy(err)
@@ -102,7 +101,7 @@ describe("Schemas", function()
       assert.are.same(123456, values.date)
 
       -- Functions
-      local values = { string = "mockbin entity", url = "mockbin.com" }
+      local values = { string = "mockbin entity" }
 
       local valid, err = validate(values, schema)
       assert.falsy(err)
@@ -112,7 +111,7 @@ describe("Schemas", function()
 
     it("should override default values if specified", function()
       -- Variables
-      local values = { string = "mockbin entity", url = "mockbin.com", date = 654321 }
+      local values = { string = "mockbin entity", date = 654321 }
 
       local valid, err = validate(values, schema)
       assert.falsy(err)
@@ -120,7 +119,7 @@ describe("Schemas", function()
       assert.are.same(654321, values.date)
 
       -- Functions
-      local values = { string = "mockbin entity", url = "mockbin.com", default = "abcdef" }
+      local values = { string = "mockbin entity", default = "abcdef" }
 
       local valid, err = validate(values, schema)
       assert.falsy(err)
@@ -128,17 +127,8 @@ describe("Schemas", function()
       assert.are.same("abcdef", values.default)
     end)
 
-    it("should validate a field against a regex", function()
-      local values = { string = "mockbin entity", url = "mockbin_!" }
-
-      local valid, err = validate(values, schema)
-      assert.falsy(valid)
-      assert.truthy(err)
-      assert.are.same("url has an invalid value", err.url)
-    end)
-
     it("should return error when unexpected values are included in the schema", function()
-      local values = { string = "mockbin entity", url = "mockbin.com", unexpected = "abcdef" }
+      local values = { string = "mockbin entity", unexpected = "abcdef" }
 
       local valid, err = validate(values, schema)
       assert.falsy(valid)
@@ -146,7 +136,7 @@ describe("Schemas", function()
     end)
 
     it("should be able to return multiple errors at once", function()
-      local values = { url = "mockbin.com", unexpected = "abcdef" }
+      local values = { unexpected = "abcdef" }
 
       local valid, err = validate(values, schema)
       assert.falsy(valid)

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -31,7 +31,7 @@ describe("Static files", function()
 
   describe("Configuration", function()
 
-    it("should parse a correct configuration", function()
+    it("should equal to this template to make sure no errors are pushed in the default config", function()
       local configuration = IO.read_file(spec_helper.DEFAULT_CONF_FILE)
 
       assert.are.same([[

--- a/spec/unit/tools/faker_spec.lua
+++ b/spec/unit/tools/faker_spec.lua
@@ -2,7 +2,7 @@ local uuid = require "uuid"
 local Faker = require "kong.tools.faker"
 local DaoError = require "kong.dao.error"
 
-describe("Faker #tools", function()
+describe("Faker", function()
 
   local ENTITIES_TYPES = { "api", "consumer", "basicauth_credential", "keyauth_credential", "plugin_configuration" }
 
@@ -78,7 +78,7 @@ describe("Faker #tools", function()
     it("should be possible to add some random entities complementing the default hard-coded ones", function()
       faker:seed(2000)
       assert.spy(faker.insert_from_table).was.called(2)
-      assert.spy(insert_spy).was.called(8027) -- 3*2000 + base entities
+      assert.spy(insert_spy).was.called(8028) -- 3*2000 + base entities
     end)
 
     it("should create relations between entities_to_insert and inserted entities", function()

--- a/spec/unit/tools/http_client_spec.lua
+++ b/spec/unit/tools/http_client_spec.lua
@@ -1,6 +1,8 @@
 local cjson = require "cjson"
 local http_client = require "kong.tools.http_client"
 
+require "spec.ngx_stub"
+
 describe("HTTP Client", function()
 
   describe("GET", function()


### PR DESCRIPTION
Following the discussion we had in #167, this PR removes the need for patterns everywhere accross Kong. 

- **This PR does not yet remove the installation of perl nor pcre during the package building or the travis-ci setup.** We will do it if we decide to merge this. For the time being, this PR only shows what would change by using patterns.
- There should be no major performance drawback by using patterns instead of Perl regexps as we are not doing heavy text processing **at all** (at least the core and current plugins). And lua patterns can also be nicer than Perl regexps for some use cases.
- As a side effect, regexes are assumed to disappear entirely once those are removed, and the `regex` field in schemas is not supported anymore. One now needs to use `func` and use Lua patterns.

Finally, I would say I really like the idea of lightening the crazy amount of dependencies Kong requires, but I am not yet 100% sure about that one. pcre is recommended by openresty [here](http://openresty.org/#Installation) (sure, we can probably drop it if we don't use it), but future plugins might eventually want to use Perl regexps, which this will be preventing. However, plugins (and the core) could still use powerful lua pattern libraries ([LPeg](http://www.inf.puc-rio.br/~roberto/lpeg/)) if they feel the need.

I think it's a discussion we should have before merging this @montanaflynn @thefosk.