### PR TITLE
[feature] default key_names to "apikey"

### DIFF
--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -1,16 +1,17 @@
 local constants = require "kong.constants"
 local BaseDao = require "kong.dao.cassandra.base_dao"
 local cjson = require "cjson"
+local utils = require "kong.tools.utils"
 
 local function load_value_schema(plugin_t)
   if plugin_t.name then
-    local status, plugin_schema = pcall(require, "kong.plugins."..plugin_t.name..".schema")
-    if status then
+    local loaded, plugin_schema = utils.load_module_if_exists("kong.plugins."..plugin_t.name..".schema")
+    if loaded then
       return plugin_schema
+    else
+      return nil, "Plugin \""..(plugin_t.name and plugin_t.name or "").."\" not found"
     end
   end
-
-  return nil, "Plugin \""..(plugin_t.name and plugin_t.name or "").."\" not found"
 end
 
 local SCHEMA = {

--- a/kong/plugins/keyauth/schema.lua
+++ b/kong/plugins/keyauth/schema.lua
@@ -1,4 +1,22 @@
+local utils = require "kong.tools.utils"
+
+local function default_key_names(t)
+  if not t.key_names then
+    return {"apikey"}
+  end
+end
+
+local function validate_key_names(t)
+  if type(t) == "table" and not utils.is_array(t) then
+    local printable_mt = require "kong.tools.printable"
+    setmetatable(t, printable_mt)
+    return false, "key_names must be an array. '"..t.."' is a table. Lua tables must have integer indexes starting at 1."
+  end
+
+  return true
+end
+
 return {
-  key_names = { required = true, type = "table" },
+  key_names = { required = true, type = "table", default = default_key_names, func = validate_key_names },
   hide_credentials = { type = "boolean", default = false }
 }

--- a/kong/plugins/request_transformer/schema.lua
+++ b/kong/plugins/request_transformer/schema.lua
@@ -1,14 +1,14 @@
 return {
-  add = { require = "false", type = "table", schema = {
-      form = { required = false, type = "table" },
-      headers = { required = false, type = "table" },
-      querystring = { required = false, type = "table" }
+  add = { type = "table", schema = {
+      form = { type = "table" },
+      headers = { type = "table" },
+      querystring = { type = "table" }
     }
   },
-  remove = { require = "false", type = "table", schema = {
-      form = { required = false, type = "table" },
-      headers = { required = false, type = "table" },
-      querystring = { required = false, type = "table" }
+  remove = { type = "table", schema = {
+      form = { type = "table" },
+      headers = { type = "table" },
+      querystring = { type = "table" }
     }
   }
 }

--- a/kong/plugins/tcplog/schema.lua
+++ b/kong/plugins/tcplog/schema.lua
@@ -1,6 +1,6 @@
 return {
   host = { required = true, type = "string" },
   port = { required = true, type = "number" },
-  timeout = { required = false, default = 10000, type = "number" },
-  keepalive = { required = false, default = 60000, type = "number" }
+  timeout = { default = 10000, type = "number" },
+  keepalive = { default = 60000, type = "number" }
 }

--- a/kong/plugins/udplog/schema.lua
+++ b/kong/plugins/udplog/schema.lua
@@ -1,5 +1,5 @@
 return {
   host = { required = true, type = "string" },
   port = { required = true, type = "number" },
-  timeout = { required = false, default = 10000, type = "number" }
+  timeout = { default = 10000, type = "number" }
 }

--- a/spec/unit/schemas_spec.lua
+++ b/spec/unit/schemas_spec.lua
@@ -382,6 +382,25 @@ describe("Schemas", function()
         assert.are.same("number", type(values.sub_schema.sub_field_number))
       end)
 
+      it("should instanciate a sub-value if sub-schema has a `default` value and do that before `required`", function()
+        local function validate_value(value)
+          if not value.some_property then
+            return false, "value.some_property must not be empty"
+          end
+          return true
+        end
+
+        local schema = {
+          value = { type = "table", schema = {some_property={default="hello"}}, func = validate_value, required = true }
+        }
+
+        local obj = {}
+        local valid, err = validate(obj, schema)
+        assert.falsy(err)
+        assert.True(valid)
+        assert.are.same("hello", obj.value.some_property)
+      end)
+
     end)
   end)
 end)


### PR DESCRIPTION
A few tweaks in the schema validator and now sub-schemas get auto-vivified if they have a `default` value in it. `required` and custom `func` checks now happen after it.