### PR TITLE
Resolver "ipv6" setting

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -66,7 +66,7 @@ nginx: |
   }
 
   http {
-    resolver {{dns_resolver}};
+    resolver {{dns_resolver}} ipv6=off;
     charset UTF-8;
 
     access_log logs/access.log;

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -310,6 +310,12 @@ function _M.send_signal(args_config, signal)
     stop_dnsmasq(kong_config) -- If the start failed, then stop dnsmasq
   end
 
+  if signal == STOP and success then
+    if IO.file_exists(kong_config.pid_file) then
+      os.execute("while [ -f "..kong_config.pid_file.." ]; do sleep 0.1; done")
+    end
+  end
+
   return success
 end
 

--- a/kong/dao/cassandra/factory.lua
+++ b/kong/dao/cassandra/factory.lua
@@ -20,34 +20,11 @@ local KeyAuthCredentials = require "kong.dao.cassandra.keyauth_credentials"
 
 local CassandraFactory = Object:extend()
 
-local LOCALHOST = "localhost"
-local LOCALHOST_IP = "127.0.0.1"
-
--- Converts every occurence of "localhost" to "127.0.0.1"
--- @param host can either be a string or an array of hosts
-local function normalize_localhost(host)
-  if type(host) == "table" then
-    for i, v in ipairs(host) do
-      if v == LOCALHOST then
-        host[i] = LOCALHOST_IP
-      end
-    end
-  elseif host == LOCALHOST then
-    host = LOCALHOST_IP
-  end
-  return host
-end
-
 -- Instanciate a Cassandra DAO.
 -- @param properties Cassandra properties
 function CassandraFactory:new(properties)
   self.type = "cassandra"
   self._properties = properties
-
-  -- Convert localhost to 127.0.0.1
-  -- This is because nginx doesn't resolve the /etc/hosts file but /etc/resolv.conf
-  -- And it may cause errors like "host not found" for "localhost"
-  self._properties.hosts = normalize_localhost(self._properties.hosts)
 
   self.apis = Apis(properties)
   self.consumers = Consumers(properties)

--- a/kong/plugins/httplog/log.lua
+++ b/kong/plugins/httplog/log.lua
@@ -10,14 +10,9 @@ local _M = {}
 -- @return `payload` http payload
 local function generate_post_payload(method, parsed_url, message)
   local body = cjson.encode(message);
-  local payload = string.format([[
-%s %s HTTP/1.1
-Host: %s
-Connection: Keep-Alive
-Content-Type: application/json
-Content-Length: %s
-
-%s]], method:upper(), parsed_url.path, parsed_url.host, string.len(body), body)
+  local payload = string.format(
+    "%s %s HTTP/1.1\r\nHost: %s\r\nConnection: Keep-Alive\r\nContent-Type: application/json\r\nContent-Length: %s\r\n\r\n%s", 
+    method:upper(), parsed_url.path, parsed_url.host, string.len(body), body)
   return payload
 end
 

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -107,10 +107,7 @@ function _M.start_http_server(port, ...)
     function(port)
       local socket = require "socket"
       local server = assert(socket.bind("*", port))
-      local client, err = server:accept()
-      if not err then
-        client:settimeout(3)
-      end
+      local client = server:accept()
 
       local lines = {}
       local line

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -106,7 +106,7 @@ nginx: |
   }
 
   http {
-    resolver {{dns_resolver}};
+    resolver {{dns_resolver}} ipv6=off;
     charset UTF-8;
 
     access_log logs/access.log;

--- a/spec/unit/tools/timestamp_spec.lua
+++ b/spec/unit/tools/timestamp_spec.lua
@@ -35,6 +35,13 @@ describe("Timestamp", function()
   end)
 
   it("should give the same timestamps table for the same time", function()
+    -- Wait til the beginning of a new second before starting the test
+    -- to avoid ending up in an edge case when the second is about to end
+    local now = os.time()
+    while os.time() < now + 1 do
+      -- Nothing
+    end
+
     local timestamps_one = timestamp.get_timestamps()
     local timestamps_two = timestamp.get_timestamps(timestamp.get_utc())
     assert.truthy(timestamps_one)


### PR DESCRIPTION
Disabling the `ipv6` in the resolver to handle connections to ipv6 addresses from Lua. Plus some clean up.