### PR TITLE
[chore] versions.sh became useless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: erlang
 
 env:
+  global:
+    - CASSANDRA_VERSION=2.1.5
   matrix:
     - LUA=lua5.1
 

--- a/.travis/setup_cassandra.sh
+++ b/.travis/setup_cassandra.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source ./versions.sh
-
 CASSANDRA_BASE=apache-cassandra-$CASSANDRA_VERSION
 
 sudo rm -rf /var/lib/cassandra/*

--- a/.travis/setup_kong.sh
+++ b/.travis/setup_kong.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source ./versions.sh
-
 sudo apt-get update
 
 # Installing dependencies required to build development rocks

--- a/versions.sh
+++ b/versions.sh
@@ -1,2 +1,0 @@
-# Travis only
-CASSANDRA_VERSION=2.1.5


### PR DESCRIPTION
it has 0 value if it's not used in both travis and the package build anymore. It should have been removed when changing this.