### PR TITLE
[feature] Plugin DAOs

### DIFF
--- a/kong-0.3.2-1.rockspec
+++ b/kong-0.3.2-1.rockspec
@@ -82,13 +82,10 @@ build = {
     ["kong.dao.schemas.plugins_configurations"] = "kong/dao/schemas/plugins_configurations.lua",
     ["kong.dao.cassandra.factory"] = "kong/dao/cassandra/factory.lua",
     ["kong.dao.cassandra.base_dao"] = "kong/dao/cassandra/base_dao.lua",
+    ["kong.dao.cassandra.migrations"] = "kong/dao/cassandra/migrations.lua",
     ["kong.dao.cassandra.apis"] = "kong/dao/cassandra/apis.lua",
     ["kong.dao.cassandra.consumers"] = "kong/dao/cassandra/consumers.lua",
     ["kong.dao.cassandra.plugins_configurations"] = "kong/dao/cassandra/plugins_configurations.lua",
-    ["kong.dao.cassandra.migrations"] = "kong/dao/cassandra/migrations.lua",
-    ["kong.dao.cassandra.ratelimiting_metrics"] = "kong/dao/cassandra/ratelimiting_metrics.lua",
-    ["kong.dao.cassandra.basicauth_credentials"] = "kong/dao/cassandra/basicauth_credentials.lua",
-    ["kong.dao.cassandra.keyauth_credentials"] = "kong/dao/cassandra/keyauth_credentials.lua",
 
     ["kong.plugins.base_plugin"] = "kong/plugins/base_plugin.lua",
 
@@ -96,11 +93,13 @@ build = {
     ["kong.plugins.basicauth.access"] = "kong/plugins/basicauth/access.lua",
     ["kong.plugins.basicauth.schema"] = "kong/plugins/basicauth/schema.lua",
     ["kong.plugins.basicauth.api"] = "kong/plugins/basicauth/api.lua",
+    ["kong.plugins.basicauth.daos"] = "kong/plugins/basicauth/daos.lua",
 
     ["kong.plugins.keyauth.handler"] = "kong/plugins/keyauth/handler.lua",
     ["kong.plugins.keyauth.access"] = "kong/plugins/keyauth/access.lua",
     ["kong.plugins.keyauth.schema"] = "kong/plugins/keyauth/schema.lua",
     ["kong.plugins.keyauth.api"] = "kong/plugins/keyauth/api.lua",
+    ["kong.plugins.keyauth.daos"] = "kong/plugins/keyauth/daos.lua",
 
     ["kong.plugins.tcplog.handler"] = "kong/plugins/tcplog/handler.lua",
     ["kong.plugins.tcplog.log"] = "kong/plugins/tcplog/log.lua",
@@ -122,7 +121,8 @@ build = {
     ["kong.plugins.ratelimiting.handler"] = "kong/plugins/ratelimiting/handler.lua",
     ["kong.plugins.ratelimiting.access"] = "kong/plugins/ratelimiting/access.lua",
     ["kong.plugins.ratelimiting.schema"] = "kong/plugins/ratelimiting/schema.lua",
-    
+    ["kong.plugins.ratelimiting.daos"] = "kong/plugins/ratelimiting/daos.lua",
+
     ["kong.plugins.requestsizelimiting.handler"] = "kong/plugins/requestsizelimiting/handler.lua",
     ["kong.plugins.requestsizelimiting.access"] = "kong/plugins/requestsizelimiting/access.lua",
     ["kong.plugins.requestsizelimiting.schema"] = "kong/plugins/requestsizelimiting/schema.lua",

--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -99,7 +99,7 @@ function _M.post(params, dao_collection, success)
   if err then
     return app_helpers.yield_error(err)
   else
-    if success then success(utils.table_copy(data)) end
+    if success then success(utils.deep_copy(data)) end
     return responses.send_HTTP_CREATED(data)
   end
 end

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -159,16 +159,16 @@ end
 -- @param args_config Path to the desired configuration (usually from the --config CLI argument)
 local function prepare_database(args_config)
   local _, _, dao_factory = get_kong_config(args_config)
+  local migrations = require("kong.tools.migrations")(dao_factory, cutils.get_luarocks_install_dir())
 
   -- Migrate the DB if needed and possible
-  local keyspace, err = dao_factory.migrations:get_migrations()
+  local keyspace, err = migrations:get_migrations()
   if err then
     cutils.logger:error_exit(err)
   elseif keyspace == nil then
     cutils.logger:info("Database not initialized. Running migrations...")
   end
 
-  local migrations = require("kong.tools.migrations")(dao_factory, cutils.get_luarocks_install_dir())
   migrations:migrate(function(migration, err)
     if err then
       cutils.logger:error_exit(err)

--- a/kong/dao/cassandra/apis.lua
+++ b/kong/dao/cassandra/apis.lua
@@ -1,6 +1,5 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
 local apis_schema = require "kong.dao.schemas.apis"
-local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 
 local Apis = BaseDao:extend()
 
@@ -41,7 +40,8 @@ function Apis:new(properties)
         args_keys = { "public_dns" },
         query = [[ SELECT id FROM apis WHERE public_dns = ?; ]]
       }
-    }
+    },
+    drop = "TRUNCATE apis;"
   }
 
   Apis.super.new(self, properties)
@@ -70,7 +70,7 @@ function Apis:delete(api_id)
   end
 
   -- delete all related plugins configurations
-  local plugins_dao = PluginsConfigurations(self._properties)
+  local plugins_dao = self._factory.plugins_configurations
   local query, args_keys, errors = plugins_dao:_build_where_query(plugins_dao._queries.select.query, {
     api_id = api_id
   })
@@ -94,4 +94,4 @@ function Apis:delete(api_id)
   return ok
 end
 
-return Apis
+return { apis = Apis }

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -587,4 +587,10 @@ function BaseDao:delete(id)
   return self:_execute_kong_query(self._queries.delete, { id = id })
 end
 
+function BaseDao:drop()
+  if self._queries.drop then
+    return self:_execute_kong_query(self._queries.drop)
+  end
+end
+
 return BaseDao

--- a/kong/dao/cassandra/consumers.lua
+++ b/kong/dao/cassandra/consumers.lua
@@ -1,6 +1,5 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
 local consumers_schema = require "kong.dao.schemas.consumers"
-local PluginsConfigurations = require "kong.dao.cassandra.plugins_configurations"
 
 local Consumers = BaseDao:extend()
 
@@ -36,7 +35,8 @@ function Consumers:new(properties)
         args_keys = { "username" },
         query = [[ SELECT id FROM consumers WHERE username = ?; ]]
       }
-    }
+    },
+    drop = "TRUNCATE consumers;"
   }
 
   Consumers.super.new(self, properties)
@@ -50,7 +50,7 @@ function Consumers:delete(consumer_id)
   end
 
   -- delete all related plugins configurations
-  local plugins_dao = PluginsConfigurations(self._properties)
+  local plugins_dao = self._factory.plugins_configurations
   local query, args_keys, errors = plugins_dao:_build_where_query(plugins_dao._queries.select.query, {
     consumer_id = consumer_id
   })
@@ -74,4 +74,4 @@ function Consumers:delete(consumer_id)
   return ok
 end
 
-return Consumers
+return { consumers = Consumers }

--- a/kong/dao/cassandra/migrations.lua
+++ b/kong/dao/cassandra/migrations.lua
@@ -62,4 +62,4 @@ function Migrations:delete_migration(migration_name)
     { cassandra.list({ migration_name }) })
 end
 
-return Migrations
+return { migrations = Migrations }

--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -44,7 +44,8 @@ function PluginsConfigurations:new(properties)
         args_keys = { "consumer_id" },
         query = [[ SELECT id FROM consumers WHERE id = ?; ]]
       }
-    }
+    },
+    drop = "TRUNCATE plugins_configurations;"
   }
 
   PluginsConfigurations.super.new(self, properties)
@@ -108,4 +109,4 @@ function PluginsConfigurations:find_distinct()
   return result, nil
 end
 
-return PluginsConfigurations
+return { plugins_configurations = PluginsConfigurations }

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -123,12 +123,12 @@ end
 -- To be called by nginx's init_by_lua directive.
 -- Execution:
 --   - load the configuration from the path computed by the CLI
---   - instanciate the DAO
---     - prepare the statements
+--   - instanciate the DAO Factory
 --   - load the used plugins
 --     - load all plugins if used and installed
 --     - sort the plugins by priority
 --     - load the resolver
+--   - prepare DB statements
 --
 -- If any error during the initialization of the DAO or plugins,
 -- it will be thrown and needs to be catched in init_by_lua.
@@ -136,15 +136,15 @@ function _M.init()
   -- Loading configuration
   configuration, dao = IO.load_configuration_and_dao(os.getenv("KONG_CONF"))
 
+  -- Initializing plugins
+  plugins = init_plugins()
+
   -- Prepare all collections' statements. Even if optional, this call is useful to check
   -- all statements are valid in advance.
   local err = dao:prepare()
   if err then
     error(err)
   end
-
-  -- Initializing plugins
-  plugins = init_plugins()
 end
 
 -- Calls `init_worker()` on eveyr loaded plugin

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -65,9 +65,10 @@ local function load_plugin_conf(api_id, consumer_id, plugin_name)
 end
 
 local function init_plugins()
-  configuration.plugins_available = configuration.plugins_available and configuration.plugins_available or {}
+  -- TODO: this should be handled with other default config values
+  configuration.plugins_available = configuration.plugins_available or {}
 
-  print("Discovering used plugins. Please wait..")
+  print("Discovering used plugins")
   local db_plugins, err = dao.plugins_configurations:find_distinct()
   if err then
     error(err)
@@ -80,69 +81,57 @@ local function init_plugins()
     end
   end
 
-  local unsorted_plugins = {} -- It's a multivalue table: k1 = {v1, v2, v3}, k2 = {...}
+  local loaded_plugins = {}
 
   for _, v in ipairs(configuration.plugins_available) do
-    local loaded, mod = utils.load_module_if_exists("kong.plugins."..v..".handler")
+    local loaded, plugin_handler_mod = utils.load_module_if_exists("kong.plugins."..v..".handler")
     if not loaded then
       error("The following plugin has been enabled in the configuration but is not installed on the system: "..v)
     else
       print("Loading plugin: "..v)
-      local plugin_handler = mod()
-      local priority = plugin_handler.PRIORITY and plugin_handler.PRIORITY or 0
-
-      -- Add plugin to the right priority
-      local list = unsorted_plugins[priority]
-      if not list then list = {} end -- The list is required in case more plugins share the same priority level
-      table.insert(list, {
+      table.insert(loaded_plugins, {
         name = v,
-        handler = plugin_handler
+        handler = plugin_handler_mod()
       })
-      unsorted_plugins[priority] = list
     end
   end
 
-  local result = {}
+  table.sort(loaded_plugins, function(a, b)
+    local priority_a = a.handler.PRIORITY or 0
+    local priority_b = b.handler.PRIORITY or 0
+    return priority_a > priority_b
+  end)
 
-  -- Now construct the final ordered plugin list
   -- resolver is always the first plugin as it is the one retrieving any needed information
-  table.insert(result, {
+  table.insert(loaded_plugins, 1, {
     resolver = true,
     name = "resolver",
     handler = require("kong.resolver.handler")()
   })
 
   if configuration.send_anonymous_reports then
-    table.insert(result, {
+    table.insert(loaded_plugins, 1, {
       reports = true,
       name = "reports",
       handler = require("kong.reports.handler")()
     })
   end
 
-  -- Add the plugins in a sorted order
-  for _, v in utils.sort_table_iter(unsorted_plugins, utils.sort.descending) do -- In descending order
-    if v then
-      for _, p in ipairs(v) do
-        table.insert(result, p)
-      end
-    end
-  end
-
-  return result
+  return loaded_plugins
 end
 
 -- To be called by nginx's init_by_lua directive.
 -- Execution:
---   - load the configuration from the apth computed by the CLI
+--   - load the configuration from the path computed by the CLI
 --   - instanciate the DAO
 --     - prepare the statements
 --   - load the used plugins
 --     - load all plugins if used and installed
---     - load the resolver
 --     - sort the plugins by priority
+--     - load the resolver
 --
--- If any error during the initialization of the DAO or plugins, it will be thrown and needs to be catched in init_by_lua.
+-- If any error during the initialization of the DAO or plugins,
+-- it will be thrown and needs to be catched in init_by_lua.
 function _M.init()
   -- Loading configuration
   configuration, dao = IO.load_configuration_and_dao(os.getenv("KONG_CONF"))
@@ -158,8 +147,8 @@ function _M.init()
   plugins = init_plugins()
 end
 
+-- Calls `init_worker()` on eveyr loaded plugin
 function _M.exec_plugins_init_worker()
-   -- Calling the Init handler
   for _, plugin in ipairs(plugins) do
     plugin.handler:init_worker()
   end
@@ -182,7 +171,7 @@ function _M.exec_plugins_certificate()
   return
 end
 
--- Calls plugins_access() on every loaded plugin
+-- Calls `access()` on every loaded plugin
 function _M.exec_plugins_access()
   -- Setting a property that will be available for every plugin
   ngx.ctx.started_at = timestamp.get_utc()
@@ -218,7 +207,7 @@ function _M.exec_plugins_access()
   ngx.ctx.proxy_started_at = timestamp.get_utc() -- Setting a property that will be available for every plugin
 end
 
--- Calls header_filter() on every loaded plugin
+-- Calls `header_filter()` on every loaded plugin
 function _M.exec_plugins_header_filter()
   ngx.ctx.proxy_ended_at = timestamp.get_utc() -- Setting a property that will be available for every plugin
 
@@ -234,7 +223,7 @@ function _M.exec_plugins_header_filter()
   end
 end
 
--- Calls body_filter() on every loaded plugin
+-- Calls `body_filter()` on every loaded plugin
 function _M.exec_plugins_body_filter()
   if not ngx.ctx.stop_phases then
     for _, plugin in ipairs(plugins) do
@@ -246,7 +235,7 @@ function _M.exec_plugins_body_filter()
   end
 end
 
--- Calls log() on every loaded plugin
+-- Calls `log()` on every loaded plugin
 function _M.exec_plugins_log()
   if not ngx.ctx.stop_phases then
     -- Creating the log variable that will be serialized

--- a/kong/plugins/base_plugin.lua
+++ b/kong/plugins/base_plugin.lua
@@ -6,7 +6,7 @@ function BasePlugin:new(name)
 end
 
 function BasePlugin:init_worker()
-  ngx.log(ngx.DEBUG, " executing plugin \""..self._name.."\": init_worker")
+  --ngx.log(ngx.DEBUG, " executing plugin \""..self._name.."\": init_worker")
 end
 
 function BasePlugin:certificate()

--- a/kong/plugins/basicauth/daos.lua
+++ b/kong/plugins/basicauth/daos.lua
@@ -1,12 +1,11 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
-local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = constants.DATABASE_TYPES.ID },
-  consumer_id = { type = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  id = { type = "id" },
+  consumer_id = { type = "id", required = true, foreign = true, queryable = true },
   username = { type = "string", required = true, unique = true, queryable = true },
   password = { type = "string" },
-  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = "timestamp" }
 }
 
 local BasicAuthCredentials = BaseDao:extend()
@@ -47,10 +46,11 @@ function BasicAuthCredentials:new(properties)
         args_keys = { "username" },
         query = [[ SELECT id FROM basicauth_credentials WHERE username = ?; ]]
       }
-    }
+    },
+    drop = "TRUNCATE basicauth_credentials;"
   }
 
   BasicAuthCredentials.super.new(self, properties)
 end
 
-return BasicAuthCredentials
+return { basicauth_credentials = BasicAuthCredentials }

--- a/kong/plugins/keyauth/daos.lua
+++ b/kong/plugins/keyauth/daos.lua
@@ -1,16 +1,15 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
-local constants = require "kong.constants"
 
 local SCHEMA = {
-  id = { type = constants.DATABASE_TYPES.ID },
-  consumer_id = { type = constants.DATABASE_TYPES.ID, required = true, foreign = true, queryable = true },
+  id = { type = "id" },
+  consumer_id = { type = "id", required = true, foreign = true, queryable = true },
   key = { type = "string", required = true, unique = true, queryable = true },
-  created_at = { type = constants.DATABASE_TYPES.TIMESTAMP }
+  created_at = { type = "timestamp" }
 }
 
-local KeyAuthCredentials = BaseDao:extend()
+local KeyAuth = BaseDao:extend()
 
-function KeyAuthCredentials:new(properties)
+function KeyAuth:new(properties)
   self._schema = SCHEMA
   self._queries = {
     insert = {
@@ -46,10 +45,11 @@ function KeyAuthCredentials:new(properties)
         args_keys = { "key" },
         query = [[ SELECT id FROM keyauth_credentials WHERE key = ?; ]]
       }
-    }
+    },
+    drop = "TRUNCATE keyauth_credentials;"
   }
 
-  KeyAuthCredentials.super.new(self, properties)
+  KeyAuth.super.new(self, properties)
 end
 
-return KeyAuthCredentials
+return { keyauth_credentials = KeyAuth }

--- a/kong/plugins/ratelimiting/daos.lua
+++ b/kong/plugins/ratelimiting/daos.lua
@@ -17,7 +17,8 @@ function RateLimitingMetrics:new(properties)
     delete = [[ DELETE FROM ratelimiting_metrics WHERE api_id = ? AND
                   identifier = ? AND
                   period_date = ? AND
-                  period = ?; ]]
+                  period = ?; ]],
+    drop = "TRUNCATE ratelimiting_metrics;"
   }
 
   RateLimitingMetrics.super.new(self, properties)
@@ -80,4 +81,4 @@ function RateLimitingMetrics:find_by_keys()
   error("ratelimiting_metrics:find_by_keys() not supported", 2)
 end
 
-return RateLimitingMetrics
+return { ratelimiting_metrics = RateLimitingMetrics }

--- a/kong/tools/io.lua
+++ b/kong/tools/io.lua
@@ -132,7 +132,7 @@ function _M.load_configuration_and_dao(configuration_path)
 
   -- Instanciate the DAO Factory along with the configuration
   local DaoFactory = require("kong.dao."..configuration.database..".factory")
-  local dao_factory = DaoFactory(dao_config.properties)
+  local dao_factory = DaoFactory(dao_config.properties, configuration.plugins_available)
 
   return configuration, dao_factory
 end

--- a/kong/tools/migrations.lua
+++ b/kong/tools/migrations.lua
@@ -7,6 +7,8 @@ local Migrations = Object:extend()
 function Migrations:new(dao, migrations_path)
   local path = migrations_path and migrations_path or "."
 
+  dao:load_daos(require("kong.dao.cassandra.migrations"))
+
   self.dao = dao
   self.options = { keyspace = dao._properties.keyspace }
   self.migrations_path = IO.path:join(path, "database", "migrations")
@@ -48,6 +50,10 @@ return Migration
       callback(interface, file_path, file_name, k)
     end
   end
+end
+
+function Migrations:get_migrations()
+  return self.dao.migrations:get_migrations()
 end
 
 -- Execute all migrations UP

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -8,38 +8,6 @@ function _M.table_size(t)
   return res
 end
 
-function _M.is_empty(t)
-  return next(t) == nil
-end
-
-_M.sort = {
-  descending = function(a, b) return a > b end,
-  ascending = function(a, b) return a < b end
-}
-
-function _M.sort_table_iter(t, f)
-  local a = {}
-  for n in pairs(t) do table.insert(a, n) end
-  table.sort(a, f)
-  local i = 0
-  local iter = function ()
-    i = i + 1
-    if a[i] == nil then return nil
-    else return a[i], t[a[i]]
-    end
-  end
-  return iter
-end
-
-function _M.reverse_table(arr)
-  -- this could be O(n/2)
-  local reversed = {}
-  for _, i in ipairs(arr) do
-    table.insert(reversed, 1, i)
-  end
-  return reversed
-end
-
 function _M.table_contains(arr, val)
   for _, v in pairs(arr) do
     if v == val then
@@ -58,19 +26,18 @@ function _M.is_array(t)
   return true
 end
 
-function _M.table_copy(orig)
-    local orig_type = type(orig)
-    local copy
-    if orig_type == 'table' then
-        copy = {}
-        for orig_key, orig_value in next, orig, nil do
-            copy[_M.table_copy(orig_key)] = _M.table_copy(orig_value)
-        end
-        setmetatable(copy, _M.table_copy(getmetatable(orig)))
-    else -- number, string, boolean, etc
-        copy = orig
+function _M.deep_copy(orig)
+  local copy
+  if type(orig) == "table" then
+    copy = {}
+    for orig_key, orig_value in next, orig, nil do
+      copy[_M.deep_copy(orig_key)] = _M.deep_copy(orig_value)
     end
-    return copy
+    setmetatable(copy, _M.deep_copy(getmetatable(orig)))
+  else
+    copy = orig
+  end
+  return copy
 end
 
 -- Add an error message to a key/value table.

--- a/spec/unit/dao/cassandra_spec.lua
+++ b/spec/unit/dao/cassandra_spec.lua
@@ -774,7 +774,7 @@ describe("Cassandra DAO", function()
           assert.falsy(results)
 
           -- All those fields are indeed non queryable
-          for k,v in pairs(err.message) do
+          for k, v in pairs(err.message) do
             assert.is_not_true(dao_factory[collection]._schema[k].queryable)
           end
         end)
@@ -898,10 +898,10 @@ describe("Cassandra DAO", function()
   end) -- describe DAO Collections
 
   --
-  -- KeyAuth plugin collection
+  -- Keyauth plugin collection
   --
 
-  describe("KeyAuthCredentials", function()
+  describe("Keyauth", function()
 
     it("should not insert in DB if consumer does not exist", function()
       -- Without an consumer_id, it's a schema error

--- a/spec/unit/tools/utils_spec.lua
+++ b/spec/unit/tools/utils_spec.lua
@@ -2,80 +2,6 @@ local utils = require "kong.tools.utils"
 
 describe("Utils", function()
   describe("tables", function()
-    describe("#sort_table_iter()", function()
-
-      it("should sort a table in ascending order by its keys without order set", function()
-        local t = { [1] = "one", [3] = "three", [2] = "two" }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({1, 2, 3}, keyset)
-      end)
-
-      it("should sort a table in ascending order by its keys with ascending order set", function()
-        local t = { [1] = "one", [3] = "three", [2] = "two" }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t, utils.sort.ascending) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({1, 2, 3}, keyset)
-      end)
-
-      it("should sort a table in descending order by its keys with descending order set", function()
-        local t = { [1] = "one", [3] = "three", [2] = "two" }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t, utils.sort.descending) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({3, 2, 1}, keyset)
-      end)
-
-      it("should sort an array in ascending order by its keys without order set", function()
-        local t = { 3, 1, 2 }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({1, 2, 3}, keyset)
-      end)
-
-      it("should sort an array in ascending order by its keys with ascending order set", function()
-        local t = { 3, 1, 2 }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t, utils.sort.ascending) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({1, 2, 3}, keyset)
-      end)
-
-      it("should sort an array in descending order by its keys with descending order set", function()
-        local t = { 3, 1, 2 }
-        local keyset = {}
-        for k,v in utils.sort_table_iter(t, utils.sort.descending) do
-          table.insert(keyset, k)
-        end
-
-        assert.are.same({3, 2, 1}, keyset)
-      end)
-
-    end)
-
-    describe("#is_empty()", function()
-
-      it("should return true for empty table, false otherwise", function()
-        assert.True(utils.is_empty({}))
-        assert.is_not_true(utils.is_empty({ foo = "bar" }))
-        assert.is_not_true(utils.is_empty({ "foo", "bar" }))
-      end)
-
-    end)
-
     describe("#table_size()", function()
 
       it("should return the size of a table", function()
@@ -83,15 +9,6 @@ describe("Utils", function()
         assert.are.same(1, utils.table_size({ foo = "bar" }))
         assert.are.same(2, utils.table_size({ foo = "bar", bar = "baz" }))
         assert.are.same(2, utils.table_size({ "foo", "bar" }))
-      end)
-
-    end)
-
-    describe("#reverse_table()", function()
-
-      it("should reverse an array", function()
-        local arr = { "a", "b", "c", "d" }
-        assert.are.same({ "d", "c", "b", "a" }, utils.reverse_table(arr))
       end)
 
     end)


### PR DESCRIPTION
##### Changes

- Plugins can now have their own DAO(s) in a `daos.lua` file. The returned table for this file is a list of all DAOs for this plugin, so a plugin can have multiple DAOs to be future-proof.
- TRUNCATE queries now belong to their respective DAO.
- Migrations DAO is only loaded if explicitly asked. Thus only `kong.tools.migrations` loads it.
- DAOs now have a reference to the Factory: `self._factory`
- DAOs now belong to factory.daos[dao_name] but can be accessed via a shorthand `__index` method: factory[dao_name] for backward compatibility

A lot of work is still needed to have a proper DAO architecture for the plugins architecture:

- Remove tests in the core that rely on some of the plugins. Examples:
  - `database_cache_spec` find another way to test that (@thefosk)
  - `cassandra_spec` move those to their respective plugin
- Implement per-plugin migrations