### PR TITLE
[fix] Resolver strips port from Host header

### DIFF
--- a/kong/resolver/access.lua
+++ b/kong/resolver/access.lua
@@ -1,5 +1,6 @@
 local url = require "socket.url"
 local cache = require "kong.tools.database_cache"
+local stringy = require "stringy"
 local constants = require "kong.constants"
 local responses = require "kong.tools.responses"
 
@@ -82,6 +83,7 @@ local function find_api(request_uri)
       end
       -- for all values of this header, try to find an API using the apis_by_dns dictionnary
       for _, host in ipairs(hosts) do
+        host = unpack(stringy.split(host, ":"))
         table.insert(all_hosts, host)
         if apis_dics.dns[host] then
           retrieved_api = apis_dics.dns[host]

--- a/spec/integration/proxy/resolver_spec.lua
+++ b/spec/integration/proxy/resolver_spec.lua
@@ -25,10 +25,10 @@ describe("Resolver", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests host resolver 1", public_dns = "mocbkin.com", target_url = "http://mockbin.com" },
-        { name = "tests host resolver 2", public_dns = "mocbkin-auth.com", target_url = "http://mockbin.com" },
-        { name = "tests path resolver", public_dns = "mocbkin-path.com", target_url = "http://mockbin.com", path = "/status/" },
-        { name = "tests stripped path resolver", public_dns = "mocbkin-stripped-path.com", target_url = "http://mockbin.com", path = "/mockbin/", strip_path = true }
+        { name = "tests host resolver 1", public_dns = "mockbin.com", target_url = "http://mockbin.com" },
+        { name = "tests host resolver 2", public_dns = "mockbin-auth.com", target_url = "http://mockbin.com" },
+        { name = "tests path resolver", public_dns = "mockbin-path.com", target_url = "http://mockbin.com", path = "/status/" },
+        { name = "tests stripped path resolver", public_dns = "mockbin-stripped-path.com", target_url = "http://mockbin.com", path = "/mockbin/", strip_path = true }
       },
       plugin_configuration = {
         { name = "keyauth", value = {key_names = {"apikey"} }, __api = 2 }
@@ -55,7 +55,7 @@ describe("Resolver", function()
   describe("SSL", function()
 
     it("should work when calling SSL port", function()
-      local response, status = http_client.get(STUB_GET_SSL_URL, nil, { host = "mocbkin.com" })
+      local response, status = http_client.get(STUB_GET_SSL_URL, nil, { host = "mockbin.com" })
       assert.are.equal(200, status)
       assert.truthy(response)
       local parsed_response = cjson.decode(response)
@@ -102,17 +102,22 @@ describe("Resolver", function()
     describe("By Host", function()
 
       it("should proxy when the API is in Kong", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { host = "mocbkin.com"})
+        local _, status = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com"})
         assert.are.equal(200, status)
       end)
 
       it("should proxy when the Host header is not trimmed", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { host = "   mocbkin.com  "})
+        local _, status = http_client.get(STUB_GET_URL, nil, { host = "   mockbin.com  "})
         assert.are.equal(200, status)
       end)
 
       it("should proxy when the request has no Host header but the X-Host-Override header", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { ["X-Host-Override"] = "mocbkin.com"})
+        local _, status = http_client.get(STUB_GET_URL, nil, { ["X-Host-Override"] = "mockbin.com"})
+        assert.are.equal(200, status)
+      end)
+
+      it("should proxy when the Host header contains a port", function()
+        local _, status = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com:80"})
         assert.are.equal(200, status)
       end)
 
@@ -146,14 +151,14 @@ describe("Resolver", function()
     end)
 
     it("should return the correct Server and Via headers when the request was proxied", function()
-      local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mocbkin.com"})
+      local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com"})
       assert.are.equal(200, status)
       assert.are.equal("cloudflare-nginx", headers.server)
       assert.are.equal(constants.NAME.."/"..constants.VERSION, headers.via)
     end)
 
     it("should return the correct Server and no Via header when the request was NOT proxied", function()
-      local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mocbkin-auth.com"})
+      local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mockbin-auth.com"})
       assert.are.equal(403, status)
       assert.are.equal(constants.NAME.."/"..constants.VERSION, headers.server)
       assert.falsy(headers.via)


### PR DESCRIPTION
When the resolver was called with a Host header, it is possible that the
port is included. if so, it will be stripped out so that the required
Host matches with the set `public_dns`.

Fix #307