### PR TITLE
[ string1 = string2 ] is good compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DEV_ROCKS=busted luacov luacov-coveralls luacheck
 .PHONY: install dev clean start seed drop lint test coverage test-all
 
 install:
-	@if [ `uname` == "Darwin" ]; then \
+	@if [ `uname` = "Darwin" ]; then \
 		luarocks make kong-*.rockspec; \
 	else \
 		luarocks make kong-*.rockspec \

--- a/spec/unit/tools/io_spec.lua
+++ b/spec/unit/tools/io_spec.lua
@@ -29,7 +29,7 @@ describe("IO", function()
     assert.are.same(0, code)
     assert.truthy("Hello", res)
 
-    local res, code = IO.os_execute("asdasda \"Hello\"")
+    local res, code = IO.os_execute("LC_ALL=\"C\";asdasda \"Hello\"")
     assert.are.same(127, code)
     assert.are.same("/bin/bash: asdasda: command not found", res)
   end)


### PR DESCRIPTION
In Makefile, [ string1 = string2 ] is good compatibility, Such as ubuntu:dash do not support [ string1 == string2 ]