### PR TITLE
Adding support for JWT auth plugin

### DIFF
--- a/database/migrations/cassandra/2015-06-09-jwtauth.lua
+++ b/database/migrations/cassandra/2015-06-09-jwtauth.lua
@@ -1,0 +1,28 @@
+local Migration = {
+  name = "2015-06-09-jwtauth",
+
+  up = function(options)
+    return [[
+      CREATE TABLE IF NOT EXISTS jwtauth_credentials(
+        id uuid,
+        consumer_id uuid,
+        secret text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON jwtauth_credentials(secret);
+
+      CREATE INDEX IF NOT EXISTS jwtauth_consumer_id ON jwtauth_credentials(consumer_id);
+    ]]
+  end,
+
+  down = function(options)
+    return [[
+      DROP TABLE jwtauth_credentials;
+      DROP INDEX jwtauth_consumer_id;
+    ]]
+  end
+}
+
+return Migration

--- a/kong-0.4.0-1.rockspec
+++ b/kong-0.4.0-1.rockspec
@@ -29,7 +29,8 @@ dependencies = {
 
   "luasocket ~> 2.0.2-5",
   "lrexlib-pcre ~> 2.7.2-1",
-  "lua-llthreads2 ~> 0.1.3-1"
+  "lua-llthreads2 ~> 0.1.3-1",
+  "luajwt ~> 1.3-2"
 }
 build = {
   type = "builtin",
@@ -160,6 +161,12 @@ build = {
     ["kong.plugins.ssl.access"] = "kong/plugins/ssl/access.lua",
     ["kong.plugins.ssl.ssl_util"] = "kong/plugins/ssl/ssl_util.lua",
     ["kong.plugins.ssl.schema"] = "kong/plugins/ssl/schema.lua",
+
+    ["kong.plugins.jwtauth.daos"] = "kong/plugins/jwtauth/daos.lua",
+    ["kong.plugins.jwtauth.access"] = "kong/plugins/jwtauth/access.lua",
+    ["kong.plugins.jwtauth.api"] = "kong/plugins/jwtauth/api.lua",
+    ["kong.plugins.jwtauth.schema"] = "kong/plugins/jwtauth/schema.lua",
+    ["kong.plugins.jwtauth.handler"] = "kong/plugins/jwtauth/handler.lua",
 
     ["kong.plugins.ip_restriction.handler"] = "kong/plugins/ip_restriction/handler.lua",
     ["kong.plugins.ip_restriction.init_worker"] = "kong/plugins/ip_restriction/init_worker.lua",

--- a/kong.yml
+++ b/kong.yml
@@ -15,6 +15,7 @@ plugins_available:
   - requestsizelimiting
   - analytics
   - ip_restriction
+  - jwtauth
 
 ## The Kong working directory
 ## (Make sure you have read and write permissions)

--- a/kong/plugins/jwtauth/access.lua
+++ b/kong/plugins/jwtauth/access.lua
@@ -1,0 +1,186 @@
+local cache = require "kong.tools.database_cache"
+local stringy = require "stringy"
+local Multipart = require "multipart"
+local responses = require "kong.tools.responses"
+local constants = require "kong.constants"
+local jwt = require "luajwt"
+local CONTENT_TYPE = "content-type"
+local CONTENT_LENGTH = "content-length"
+local FORM_URLENCODED = "application/x-www-form-urlencoded"
+local MULTIPART_DATA = "multipart/form-data"
+
+local _M = {}
+
+local function skip_authentication(headers)
+  -- Skip upload request that expect a 100 Continue response
+  return headers["expect"] and stringy.startswith(headers["expect"], "100")
+end
+
+local function get_key_from_query(key_name, request, conf)
+  local key, parameters
+  local found_in = {}
+
+
+  local headers = request.get_headers()
+
+  -- First, try in header
+  if headers[key_name] ~= nil then
+    found_in.header = true
+    key = headers[key_name]
+  end
+
+  parameters = request.get_uri_args()
+
+  -- Find in querystring
+  if parameters[key_name] ~= nil then
+    found_in.querystring = true
+    key = parameters[key_name]
+  -- If missing from querystring, try to get it from the body
+  elseif request.get_headers()[CONTENT_TYPE] then
+    -- Lowercase content-type for easier comparison
+    local content_type = stringy.strip(string.lower(request.get_headers()[CONTENT_TYPE]))
+    if stringy.startswith(content_type, FORM_URLENCODED) then
+      -- Call ngx.req.read_body to read the request body first
+      -- or turn on the lua_need_request_body directive to avoid errors.
+      request.read_body()
+      parameters = request.get_post_args()
+
+      found_in.form = parameters[key_name] ~= nil
+      key = parameters[key_name]
+    elseif stringy.startswith(content_type, MULTIPART_DATA) then
+      -- Call ngx.req.read_body to read the request body first
+      -- or turn on the lua_need_request_body directive to avoid errors.
+      request.read_body()
+
+      local body = request.get_body_data()
+      parameters = Multipart(body, content_type)
+
+      local parameter = parameters:get(key_name)
+      found_in.body = parameter ~= nil
+      key = parameter and parameter.value or nil
+    end
+  end
+
+  if conf.hide_credentials then
+    if found_in.querystring then
+      parameters[key_name] = nil
+      request.set_uri_args(parameters)
+    elseif found_in.header then
+      request.clear_header(key_name)
+    elseif found_in.form then
+      parameters[key_name] = nil
+      local encoded_args = ngx.encode_args(parameters)
+      request.set_header(CONTENT_LENGTH, string.len(encoded_args))
+      request.set_body_data(encoded_args)
+    elseif found_in.body then
+      parameters:delete(key_name)
+      local new_data = parameters:tostring()
+      request.set_header(CONTENT_LENGTH, string.len(new_data))
+      request.set_body_data(new_data)
+    end
+  end
+  return key
+end
+
+-- Fast lookup for credential retrieval depending on the type of the authentication
+--
+-- All methods must respect:
+--
+-- @param request ngx request object
+-- @param {table} conf Plugin configuration (value property)
+-- @return {string} public_key
+-- @return {string} private_key
+local function retrieve_credentials(request, conf)
+  local username, token
+
+  if conf.id_names then
+    for _, id_name in ipairs(conf.id_names) do
+      username = get_key_from_query(id_name, request, conf)
+      if username then break end
+    end
+  end
+
+  local authorization_header = request.get_headers()["authorization"]
+
+  if authorization_header then
+    local iterator, iter_err = ngx.re.gmatch(authorization_header, "\\s*[Bb]earer\\s*(.+)")
+    if not iterator then
+      ngx.log(ngx.ERR, iter_err)
+      return
+    end
+
+    local m, err = iterator()
+    if err then
+      ngx.log(ngx.ERR, err)
+      return
+    end
+
+    if m and table.getn(m) > 0 then
+      token = m[1]
+    end
+  end
+
+  if conf.hide_credentials then
+    request.clear_header("authorization")
+  end
+
+  return username, token
+end
+
+
+function _M.execute(conf)
+  if not conf or skip_authentication(ngx.req.get_headers()) then return end
+  if not conf then return end
+
+  local username, token = retrieve_credentials(ngx.req, conf)
+
+  if not username or not token then
+    ngx.ctx.stop_phases = true -- interrupt other phases of this request
+    return responses.send_HTTP_FORBIDDEN("Invalid authentication credentials")
+  end
+
+  -- Retrieve consumer
+  local consumer = cache.get_or_set(cache.consumer_key(username), function()
+    local consumers, err = dao.consumers:find_by_keys { username = username }
+    local result
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    elseif #consumers > 0 then
+      result = consumers[1]
+    end
+    return result
+  end)
+
+  --Retrieve secret
+  local credential
+
+  -- Make sure we are not sending an empty table to find_by_keys
+  credential = cache.get_or_set(cache.jwtauth_credential_key(consumer.id), function()
+    local credentials, err = dao.jwtauth_credentials:find_by_keys { consumer_id = consumer.id }
+    local result
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    elseif #credentials > 0 then
+      result = credentials[1]
+    end
+    return result
+  end)
+
+  local secret = credential.secret
+
+  local validate = true -- validate signature, exp and nbf (default: true)
+  local profile, err = jwt.decode(token, secret, validate)
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
+
+  -- what to do with profile
+  credential.profile = profile
+
+  ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  ngx.ctx.authenticated_entity = credential
+end
+
+return _M

--- a/kong/plugins/jwtauth/api.lua
+++ b/kong/plugins/jwtauth/api.lua
@@ -1,0 +1,51 @@
+local crud = require "kong.api.crud_helpers"
+
+return {
+  ["/consumers/:username_or_id/jwtauth/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      crud.paginated_set(self, dao_factory.jwtauth_credentials)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.jwtauth_credentials)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.jwtauth_credentials)
+    end
+  },
+
+  ["/consumers/:username_or_id/jwtauth/:id"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+
+      local data, err = dao_factory.jwtauth_credentials:find_by_keys({ id = self.params.id })
+      if err then
+        return helpers.yield_error(err)
+      end
+
+      self.credential = data[1]
+      if not self.credential then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.credential)
+    end,
+
+    PATCH = function(self, dao_factory)
+      crud.patch(self.params, self.credential, dao_factory.jwtauth_credentials)
+    end,
+
+    DELETE = function(self, dao_factory)
+      crud.delete(self.credential, dao_factory.jwtauth_credentials)
+    end
+  }
+}

--- a/kong/plugins/jwtauth/daos.lua
+++ b/kong/plugins/jwtauth/daos.lua
@@ -1,0 +1,22 @@
+local BaseDao = require "kong.dao.cassandra.base_dao"
+
+local SCHEMA = {
+  primary_key = {"id"},
+  fields = {
+    id = { type = "id", dao_insert_value = true },
+    created_at = { type = "timestamp", dao_insert_value = true },
+    consumer_id = { type = "id", required = true, foreign = "consumers:id" },
+    secret = { type = "string", required = true, unique = true, queryable = true }
+  }
+}
+
+local JwtAuth = BaseDao:extend()
+
+function JwtAuth:new(properties)
+  self._table = "jwtauth_credentials"
+  self._schema = SCHEMA
+
+  JwtAuth.super.new(self, properties)
+end
+
+return { jwtauth_credentials = JwtAuth }

--- a/kong/plugins/jwtauth/handler.lua
+++ b/kong/plugins/jwtauth/handler.lua
@@ -1,0 +1,17 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local access = require "kong.plugins.jwtauth.access"
+
+local JwtAuthHandler = BasePlugin:extend()
+
+function JwtAuthHandler:new()
+  JwtAuthHandler.super.new(self, "JwtAuth")
+end
+
+function JwtAuthHandler:access(conf)
+  JwtAuthHandler.super.access(self)
+  access.execute(conf)
+end
+
+JwtAuthHandler.PRIORITY = 1000
+
+return JwtAuthHandler

--- a/kong/plugins/jwtauth/schema.lua
+++ b/kong/plugins/jwtauth/schema.lua
@@ -1,0 +1,12 @@
+local function default_id_names(t)
+  if not t.id_names then
+    return {"id"}
+  end
+end
+
+return {
+  fields = {
+    id_names = { required = true, type = "array", default = default_id_names },
+    hide_credentials = { type = "boolean", default = false }
+  }
+}

--- a/kong/tools/database_cache.lua
+++ b/kong/tools/database_cache.lua
@@ -8,6 +8,7 @@ local CACHE_KEYS = {
   KEYAUTH_CREDENTIAL = "keyauth_credentials",
   OAUTH2_CREDENTIAL = "oauth2_credentials",
   OAUTH2_TOKEN = "oauth2_token",
+  JWTAUTH_CREDENTIAL = "jwtauth_credentials",
   SSL = "ssl",
   REQUESTS = "requests"
 }
@@ -88,6 +89,10 @@ end
 
 function _M.keyauth_credential_key(key)
   return CACHE_KEYS.KEYAUTH_CREDENTIAL.."/"..key
+end
+
+function _M.jwtauth_credential_key(id)
+  return CACHE_KEYS.JWTAUTH_CREDENTIAL.."/"..id
 end
 
 function _M.ssl_data(api_id)

--- a/kong/tools/faker.lua
+++ b/kong/tools/faker.lua
@@ -57,7 +57,7 @@ function Faker:insert_from_table(entities_to_insert)
   -- Insert in order (for foreign relashionships)
   -- 1. consumers and APIs
   -- 2. credentials, which need references to inserted apis and consumers
-  for _, type in ipairs({ "api", "consumer", "plugin_configuration", "oauth2_credential", "basicauth_credential", "keyauth_credential" }) do
+  for _, type in ipairs({ "api", "consumer", "plugin_configuration", "oauth2_credential", "basicauth_credential", "keyauth_credential", "jwtauth_credential" }) do
     if entities_to_insert[type] then
       for i, entity in ipairs(entities_to_insert[type]) do
 

--- a/spec/plugins/jwtauth/access_spec.lua
+++ b/spec/plugins/jwtauth/access_spec.lua
@@ -1,0 +1,144 @@
+local spec_helper = require "spec.spec_helpers"
+local http_client = require "kong.tools.http_client"
+local cjson = require "cjson"
+local jwt = require "luajwt"
+
+local STUB_GET_URL = spec_helper.STUB_GET_URL
+local STUB_POST_URL = spec_helper.STUB_POST_URL
+
+describe("Authentication Plugin", function()
+
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.insert_fixtures {
+      api = {
+        { name = "tests jwtauth", public_dns = "jwtauth.com", target_url = "http://mockbin.com" },
+        { name = "tests jwtauth 2", public_dns = "jwtauth2.com", target_url = "http://mockbin.com" }
+      },
+      consumer = {
+        { username = "jwtauth_tests_consumer" }
+      },
+      plugin_configuration = {
+        { name = "jwtauth", value = { }, __api = 1 },
+        { name = "jwtauth", value = { id_names = { "username" }, hide_credentials = true }, __api = 2 }
+      },
+      jwtauth_credential = {
+        { secret = "example_key", __consumer = 1 }
+      }
+    }
+
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  describe("JWT Authentication", function()
+
+    it("should return invalid credentials when the credential value is wrong", function()
+      local response, status = http_client.get(STUB_GET_URL, {id = "jwtauth_tests_consumer"}, {host = "jwtauth.com", authorization = "asd"})
+      local body = cjson.decode(response)
+      assert.are.equal(403, status)
+      assert.are.equal("Invalid authentication credentials", body.message)
+    end)
+
+    it("should return invalid credentials when only passing authorization", function()
+      local response, status = http_client.get(STUB_GET_URL, {}, {host = "jwtauth.com", authorization = "asd"})
+      local body = cjson.decode(response)
+      assert.are.equal(403, status)
+      assert.are.equal("Invalid authentication credentials", body.message)
+    end)
+
+    it("should return invalid credentials when only passing id", function()
+      local response, status = http_client.get(STUB_GET_URL, {id = "jwtauth_tests_consumer"}, {host = "jwtauth.com"})
+      local body = cjson.decode(response)
+      assert.are.equal(403, status)
+      assert.are.equal("Invalid authentication credentials", body.message)
+    end)
+
+    it("should return invalid credentials when the credential parameter name is wrong in GET", function()
+      local response, status = http_client.get(STUB_GET_URL, {}, {host = "jwtauth.com", authorization123 = "Bearer dXNlcm5hbWU6cGFzc3dvcmQ="})
+      local body = cjson.decode(response)
+      assert.are.equal(403, status)
+      assert.are.equal("Invalid authentication credentials", body.message)
+    end)
+
+    it("should return invalid credentials when the credential parameter name is wrong in POST", function()
+      local response, status = http_client.post(STUB_POST_URL, {}, {host = "jwtauth.com", authorization123 = "Bearer dXNlcm5hbWU6cGFzc3dvcmQ="})
+      local body = cjson.decode(response)
+      assert.are.equal(403, status)
+      assert.are.equal("Invalid authentication credentials", body.message)
+    end)
+
+    it("should pass with GET", function()
+      local key = "example_key"
+
+      local payload = {
+          iss = "12345678",
+          nbf = os.time(),
+          exp = os.time() + 3600,
+      }
+
+      local alg = "HS256"
+      local token = jwt.encode(payload, key, alg)
+      local response, status = http_client.get(STUB_GET_URL, {id = "jwtauth_tests_consumer"}, {host = "jwtauth.com", authorization = "Bearer " .. token})
+      assert.are.equal(200, status)
+      local parsed_response = cjson.decode(response)
+      assert.are.equal("Bearer " .. token, parsed_response.headers.authorization)
+    end)
+
+    it("should pass with GET with id in headers", function()
+      local key = "example_key"
+
+      local payload = {
+          iss = "12345678",
+          nbf = os.time(),
+          exp = os.time() + 3600,
+      }
+
+      local alg = "HS256"
+      local token = jwt.encode(payload, key, alg)
+      local response, status = http_client.get(STUB_GET_URL, {}, {host = "jwtauth.com", authorization = "Bearer " .. token, id = "jwtauth_tests_consumer"})
+      assert.are.equal(200, status)
+      local parsed_response = cjson.decode(response)
+      assert.are.equal("Bearer " .. token, parsed_response.headers.authorization)
+      assert.are.equal("jwtauth_tests_consumer", parsed_response.headers.id)
+    end)
+
+    it("should pass with POST", function()
+      local key = "example_key"
+
+      local payload = {
+          iss = "12345678",
+          nbf = os.time(),
+          exp = os.time() + 3600,
+      }
+
+      local alg = "HS256"
+      local token = jwt.encode(payload, key, alg)
+      local response, status = http_client.post(STUB_POST_URL, {id = "jwtauth_tests_consumer"}, {host = "jwtauth.com", authorization = "Bearer " .. token})
+      assert.are.equal(200, status)
+      local parsed_response = cjson.decode(response)
+      assert.are.equal("Bearer " .. token, parsed_response.headers.authorization)
+    end)
+
+    it("should hide credentials with hide_credentials set", function()
+      local key = "example_key"
+
+      local payload = {
+          iss = "12345678",
+          nbf = os.time(),
+          exp = os.time() + 3600,
+      }
+
+      local alg = "HS256"
+      local token = jwt.encode(payload, key, alg)
+      local response, status = http_client.get(STUB_GET_URL, {}, {host = "jwtauth2.com", authorization = "Bearer " .. token, username = "jwtauth_tests_consumer"})
+      assert.are.equal(200, status)
+      local parsed_response = cjson.decode(response)
+      assert.are.equal(nil, parsed_response.headers.authorization)
+      assert.are.equal(nil, parsed_response.headers.id)
+    end)
+  end)
+end)

--- a/spec/plugins/jwtauth/api_spec.lua
+++ b/spec/plugins/jwtauth/api_spec.lua
@@ -1,0 +1,121 @@
+local json = require "cjson"
+local http_client = require "kong.tools.http_client"
+local spec_helper = require "spec.spec_helpers"
+
+describe("Jwt Auth Credentials API", function()
+  local BASE_URL, credential, consumer
+
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  describe("/consumers/:consumer/jwtauth/", function()
+
+    setup(function()
+      local fixtures = spec_helper.insert_fixtures {
+        consumer = {{ username = "bob" }}
+      }
+      consumer = fixtures.consumer[1]
+      BASE_URL = spec_helper.API_URL.."/consumers/bob/jwtauth/"
+    end)
+
+    describe("POST", function()
+
+      it("[SUCCESS] should create a jwtauth credential", function()
+        local response, status = http_client.post(BASE_URL, { secret = "1234" })
+        assert.equal(201, status)
+        credential = json.decode(response)
+        assert.equal(consumer.id, credential.consumer_id)
+      end)
+
+      it("[FAILURE] should return proper errors", function()
+        local response, status = http_client.post(BASE_URL, {})
+        assert.equal(400, status)
+        assert.equal('{"secret":"secret is required"}\n', response)
+      end)
+
+    end)
+
+    describe("PUT", function()
+      setup(function()
+        spec_helper.get_env().dao_factory.jwtauth_credentials:delete({id = credential.id})
+      end)
+
+      it("[SUCCESS] should create and update", function()
+        local response, status = http_client.put(BASE_URL, { secret = "1234" })
+        assert.equal(201, status)
+        credential = json.decode(response)
+        assert.equal(consumer.id, credential.consumer_id)
+      end)
+
+      it("[FAILURE] should return proper errors", function()
+        local response, status = http_client.put(BASE_URL, {})
+        assert.equal(400, status)
+        assert.equal('{"secret":"secret is required"}\n', response)
+      end)
+
+    end)
+
+    describe("GET", function()
+
+      it("should retrieve all", function()
+        local response, status = http_client.get(BASE_URL)
+        assert.equal(200, status)
+        local body = json.decode(response)
+        assert.equal(1, #(body.data))
+      end)
+
+    end)
+  end)
+
+  describe("/consumers/:consumer/jwtauth/:id", function()
+
+    describe("GET", function()
+
+      it("should retrieve by id", function()
+        local _, status = http_client.get(BASE_URL..credential.id)
+        assert.equal(200, status)
+      end)
+
+    end)
+
+    describe("PATCH", function()
+
+      it("[SUCCESS] should update a credential", function()
+        local response, status = http_client.patch(BASE_URL..credential.id, { secret = "4321" })
+        assert.equal(200, status)
+        credential = json.decode(response)
+        assert.equal("4321", credential.secret)
+      end)
+
+      it("[FAILURE] should return proper errors", function()
+        local response, status = http_client.patch(BASE_URL..credential.id, { secret = "" })
+        assert.equal(400, status)
+        assert.equal('{"secret":"secret is not a string"}\n', response)
+      end)
+
+    end)
+
+    describe("DELETE", function()
+
+      it("[FAILURE] should return proper errors", function()
+        local _, status = http_client.delete(BASE_URL.."blah")
+        assert.equal(400, status)
+
+        _, status = http_client.delete(BASE_URL.."00000000-0000-0000-0000-000000000000")
+        assert.equal(404, status)
+      end)
+
+      it("[SUCCESS] should delete a credential", function()
+        local _, status = http_client.delete(BASE_URL..credential.id)
+        assert.equal(204, status)
+      end)
+
+    end)
+  end)
+end)

--- a/spec/plugins/jwtauth/daos_spec.lua
+++ b/spec/plugins/jwtauth/daos_spec.lua
@@ -1,0 +1,60 @@
+local spec_helper = require "spec.spec_helpers"
+local uuid = require "uuid"
+
+local env = spec_helper.get_env()
+local dao_factory = env.dao_factory
+local faker = env.faker
+
+describe("DAO jwtauth Credentials", function()
+
+  setup(function()
+    spec_helper.prepare_db()
+  end)
+
+  it("should not insert in DB if consumer does not exist", function()
+    -- Without a consumer_id, it's a schema error
+    local app_t = {name = "jwtauth", value = {id_names = {"id"}}}
+    local app, err = dao_factory.jwtauth_credentials:insert(app_t)
+    assert.falsy(app)
+    assert.truthy(err)
+    assert.True(err.schema)
+    assert.are.same("consumer_id is required", err.message.consumer_id)
+
+    -- With an invalid consumer_id, it's a FOREIGN error
+    local app_t = {secret = "secretkey123", consumer_id = uuid()}
+    local app, err = dao_factory.jwtauth_credentials:insert(app_t)
+    assert.falsy(app)
+    assert.truthy(err)
+    assert.True(err.foreign)
+    assert.equal("consumer_id "..app_t.consumer_id.." does not exist", err.message.consumer_id)
+  end)
+
+  it("should insert in DB and add generated values", function()
+    local consumer_t = faker:fake_entity("consumer")
+    local consumer, err = dao_factory.consumers:insert(consumer_t)
+    assert.falsy(err)
+
+    local cred_t = {secret = "secretkey123", consumer_id = consumer.id}
+    local app, err = dao_factory.jwtauth_credentials:insert(cred_t)
+    assert.falsy(err)
+    assert.truthy(app.id)
+    assert.truthy(app.created_at)
+  end)
+
+  it("should find a Credential by public_key", function()
+    local app, err = dao_factory.jwtauth_credentials:find_by_keys {
+      secret = "user122"
+    }
+    assert.falsy(err)
+    assert.truthy(app)
+  end)
+
+  it("should handle empty strings", function()
+    local apps, err = dao_factory.jwtauth_credentials:find_by_keys {
+      secret = ""
+    }
+    assert.falsy(err)
+    assert.same({}, apps)
+  end)
+
+end)

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -55,6 +55,7 @@ plugins_available:
   - requestsizelimiting
   - analytics
   - ip_restriction
+  - jwtauth
 
 ## The Kong working directory
 ## (Make sure you have read and write permissions)

--- a/spec/unit/tools/migrations_spec.lua
+++ b/spec/unit/tools/migrations_spec.lua
@@ -109,7 +109,7 @@ describe("Migrations", function()
             assert.are.same(migrations_names[i], migration.name..".lua")
           end)
 
-          assert.are.same(5, i)
+          assert.are.same(6, i)
           assert.spy(env.dao_factory.migrations.get_migrations).was.called(1)
           assert.spy(env.dao_factory.execute_queries).was.called(#migrations_names-1)
           assert.spy(env.dao_factory.migrations.add_migration).was.called(#migrations_names-1)


### PR DESCRIPTION
This adds support for using JWTs to auth a consumer. Requests require the JWT in the Authorization header and the username in either header or query params.

Added a table to store JWT secrets with a consumer_id as the FK. 

The code is based off the basicauth and keyauth plugins. 

This is my first time hacking in lua.