### PR TITLE
[fix] basicauth not being executed by default

### DIFF
--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -134,7 +134,7 @@ function _M.validate_fields(t, schema, options)
         -- Check for sub-schema defaults and required properties in advance
         for sub_field_k, sub_field in pairs(sub_schema.fields) do
           if t[column] == nil then
-            if sub_field.default then -- Sub-value has a default, be polite and pre-assign the sub-value
+            if sub_field.default ~= nil then -- Sub-value has a default, be polite and pre-assign the sub-value
               t[column] = {}
             elseif sub_field.required then -- Only check required if field doesn't have a default
               errors = utils.add_error(errors, column, column.."."..sub_field_k.." is required")

--- a/kong/plugins/basicauth/access.lua
+++ b/kong/plugins/basicauth/access.lua
@@ -66,8 +66,11 @@ local function validate_credentials(credential, username, password)
 end
 
 function _M.execute(conf)
-  if not conf or skip_authentication(ngx.req.get_headers()) then return end
-  if not conf then return end
+  if skip_authentication(ngx.req.get_headers()) then return end
+  if not conf then
+    -- Print the error in logs and signal this is a server error to the client
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR("[basicauth] missing configuration")
+  end
 
   local username, password = retrieve_credentials(ngx.req, conf)
   local credential


### PR DESCRIPTION
Proposed fix for #361

- Fix wrong check in schema validation for sub-values with `default`
- Fix access.lua not throwing an error in case of missing configuration (
  which is mandatory for this plugin)