### PR TITLE
[fix/api] Prevent PATCH from overriding plugin's value

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -106,8 +106,8 @@ function _M.post(params, dao_collection, success)
   end
 end
 
-function _M.patch(new_entity, old_entity, dao_collection)
-  for k, v in pairs(new_entity) do
+function _M.patch(params, old_entity, dao_collection)
+  for k, v in pairs(params) do
     old_entity[k] = v
   end
 

--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -132,8 +132,8 @@ function _M.validate_fields(t, schema, options)
 
       if sub_schema then
         -- Check for sub-schema defaults and required properties in advance
-        for sub_field_k, sub_field in pairs(sub_schema.fields) do
-          if t[column] == nil then
+        if t[column] == nil then
+          for sub_field_k, sub_field in pairs(sub_schema.fields) do
             if sub_field.default ~= nil then -- Sub-value has a default, be polite and pre-assign the sub-value
               t[column] = {}
             elseif sub_field.required then -- Only check required if field doesn't have a default


### PR DESCRIPTION
#362 bis. Since plugin_configuration's `value` is stored as plain text in
Cassandra, if one made a PATCH request it could potentially override the
stored value because the DAO treated the field just like any other.

Instead, we need to set each property of a `value` that is not updated
by the PATCH before updating the row.

That behaviour doesn't apply to PUT requests.