### PR TITLE
[fix/migrations] handle missing schema_migrations

### DIFF
--- a/kong-0.4.0-1.rockspec
+++ b/kong-0.4.0-1.rockspec
@@ -44,6 +44,7 @@ build = {
 
     ["kong.cli.utils"] = "kong/cli/utils/utils.lua",
     ["kong.cli.utils.signal"] = "kong/cli/utils/signal.lua",
+    ["kong.cli.utils.input"] = "kong/cli/utils/input.lua",
     ["kong.cli.db"] = "kong/cli/db.lua",
     ["kong.cli.config"] = "kong/cli/config.lua",
     ["kong.cli.quit"] = "kong/cli/quit.lua",

--- a/kong/cli/utils/input.lua
+++ b/kong/cli/utils/input.lua
@@ -1,0 +1,24 @@
+local _M = {}
+
+local ANSWERS = {
+  y = true,
+  Y = true,
+  yes = true,
+  YES = true,
+  n = false,
+  N = false,
+  no = false,
+  NO = false
+}
+
+function _M.confirm(question)
+  local answer
+  repeat
+    io.write(question.." [Y/n] ")
+    answer = ANSWERS[io.read("*l")]
+  until answer ~= nil
+
+  return answer
+end
+
+return _M

--- a/kong/tools/migrations.lua
+++ b/kong/tools/migrations.lua
@@ -153,18 +153,4 @@ function Migrations:rollback(callback)
   callback(migration_to_rollback)
 end
 
--- Execute all migrations DOWN
--- @param {function} callback A function to execute on each migration (ie: for logging)
-function Migrations:reset(callback)
-  local done = false
-  while not done do
-    self:rollback(function(migration, err)
-      if not migration and not err then
-        done = true
-      end
-      callback(migration, err)
-    end)
-  end
-end
-
 return Migrations


### PR DESCRIPTION
Handle occasional error where the schema_migrations columnfamily would
be missing thus preventing the migrations to work properly.

We now print a better error for the unaware user and suggest that the
"kong migrations reset" command should be run to fix this.

Fix #250 

```shell
$ kong start
[...]
[INFO] Connecting to the database...
[ERR] Missing mandatory column family "schema_migrations" in configured keyspace. Please consider running "kong migrations reset" to fix this.
$ kong migrations reset
[INFO] Resetting cassandra keyspace "kong"
Are you sure? You will lose your data. [Y/n] idk
Are you sure? You will lose your data. [Y/n] y
[OK] Keyspace successfully reset
$ kong start
[...]
[INFO] Connecting to the database...
[INFO] Database not initialized. Running migrations...
[OK] Migrated up to: 2015-01-12-175310_init_schema
[OK] Migrated up to: 2015-04-24-154530_plugins
[OK] Migrated up to: 2015-05-22-235608_0.3.0
[INFO] dnsmasq started
[OK] Started
```