### PR TITLE
[fix] ALF Serializer and responses tests

### DIFF
--- a/kong/plugins/log_serializers/alf.lua
+++ b/kong/plugins/log_serializers/alf.lua
@@ -28,7 +28,7 @@ function alf_mt:new_alf()
   local ALF = {
     version = "1.0.0",
     serviceToken = "", -- will be filled by to_json_string()
-    environment = "",
+    environment = nil, -- stub
     har = {
       log = {
         version = "1.2",

--- a/spec/integration/admin_api/apis_routes_spec.lua
+++ b/spec/integration/admin_api/apis_routes_spec.lua
@@ -375,13 +375,13 @@ describe("Admin API", function()
 
           it("should not override a plugin's `value` if partial", function()
             -- This is delicate since a plugin's `value` is a text field in a DB like Cassandra
-            local response, status = http_client.patch(BASE_URL..plugin.name, {
+            local _, status = http_client.patch(BASE_URL..plugin.name, {
               ["value.key_names"] = {"key_set_null_test"},
               ["value.hide_credentials"] = true
             })
             assert.equal(200, status)
 
-            response, status = http_client.patch(BASE_URL..plugin.name, {
+            local response, status = http_client.patch(BASE_URL..plugin.name, {
               ["value.key_names"] = {"key_set_null_test_updated"}
             })
             assert.equal(200, status)

--- a/spec/plugins/analytics/alf_serializer_spec.lua
+++ b/spec/plugins/analytics/alf_serializer_spec.lua
@@ -68,7 +68,7 @@ describe("ALF serializer", function()
         har = {
           log = {
             version = "1.2",
-            creator = { name = "kong-mashape-analytics-plugin", version = "1.0.0"
+            creator = { name = "mashape-analytics-agent-kong", version = "1.0.0"
             },
             entries = {}
           }
@@ -118,6 +118,13 @@ describe("ALF serializer", function()
       assert.equal("string", type(json_str))
     end)
 
+    it("should add an environment property", function()
+      local json = require "cjson"
+      local json_str = alf:to_json_string("stub_service_token", "test")
+      assert.equal("string", type(json_str))
+      local json_alf = json.decode(json_str)
+      assert.equal(json_alf.environment, "test")
+    end)
   end)
 
   describe("#flush_entries()", function()

--- a/spec/unit/tools/responses_spec.lua
+++ b/spec/unit/tools/responses_spec.lua
@@ -71,8 +71,11 @@ describe("Responses", function()
     assert.falsy(ngx.ctx.stop_phases)
 
     responses.send_HTTP_INTERNAL_SERVER_ERROR()
-    assert.stub(ngx.log).was.called()
+    assert.stub(ngx.log).was_not_called()
     assert.True(ngx.ctx.stop_phases)
+
+    responses.send_HTTP_INTERNAL_SERVER_ERROR("error")
+    assert.stub(ngx.log).was_called()
   end)
 
   describe("default content rules for some status codes", function()


### PR DESCRIPTION
- ALF serializer has a new test for the environment property
- Update the responses 500 test not calling ngx.log