### PR TITLE
[feat/admin api] enable CORS support

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -179,7 +179,15 @@ nginx: |
 
       location / {
         default_type application/json;
-        content_by_lua 'require("lapis").serve("kong.api.app")';
+        content_by_lua '
+          ngx.header["Access-Control-Allow-Origin"] = "*"
+          if ngx.req.get_method() == "OPTIONS" then
+            ngx.header["Access-Control-Allow-Methods"] = "GET,HEAD,PUT,PATCH,POST,DELETE"
+            ngx.exit(204)
+          end
+          local lapis = require "lapis"
+          lapis.serve("kong.api.app")
+        ';
       }
 
       location /robots.txt {

--- a/kong/api/app.lua
+++ b/kong/api/app.lua
@@ -139,6 +139,7 @@ local function attach_routes(routes)
   end
 end
 
+-- Load core routes
 for _, v in ipairs({"kong", "apis", "consumers", "plugins_configurations"}) do
   local routes = require("kong.api.routes."..v)
   attach_routes(routes)

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -219,7 +219,15 @@ nginx: |
 
       location / {
         default_type application/json;
-        content_by_lua 'require("lapis").serve("kong.api.app")';
+        content_by_lua '
+          ngx.header["Access-Control-Allow-Origin"] = "*"
+          if ngx.req.get_method() == "OPTIONS" then
+            ngx.header["Access-Control-Allow-Methods"] = "GET,HEAD,PUT,PATCH,POST,DELETE"
+            ngx.exit(204)
+          end
+          local lapis = require "lapis"
+          lapis.serve("kong.api.app")
+        ';
       }
 
       location /robots.txt {


### PR DESCRIPTION
Implementing CORS support in the Admin API #298.

This is the simplest way to do it, as I see no way to do it once Lapis has started processing the request.

Thoughts @ajayk @thefosk ?