### PR TITLE
[chore] Pass empty configuration to plugins

### DIFF
--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -168,7 +168,7 @@ function _M.exec_plugins_certificate()
 
     local plugin_conf = ngx.ctx.plugin_conf[plugin.name]
     if not ngx.ctx.stop_phases and (plugin.resolver or plugin_conf) then
-      plugin.handler:certificate(plugin_conf and plugin_conf.value or nil)
+      plugin.handler:certificate(plugin_conf and plugin_conf.value or {})
     end
   end
 
@@ -195,7 +195,7 @@ function _M.exec_plugins_access()
 
     local plugin_conf = ngx.ctx.plugin_conf[plugin.name]
     if not ngx.ctx.stop_phases and (plugin.resolver or plugin_conf) then
-      plugin.handler:access(plugin_conf and plugin_conf.value or nil)
+      plugin.handler:access(plugin_conf and plugin_conf.value or {})
     end
   end
   -- Append any modified querystring parameters
@@ -224,7 +224,7 @@ function _M.exec_plugins_header_filter()
     for _, plugin in ipairs(plugins) do
       local plugin_conf = ngx.ctx.plugin_conf[plugin.name]
       if plugin_conf then
-        plugin.handler:header_filter(plugin_conf and plugin_conf.value or nil)
+        plugin.handler:header_filter(plugin_conf and plugin_conf.value or {})
       end
     end
   end
@@ -238,7 +238,7 @@ function _M.exec_plugins_body_filter()
     for _, plugin in ipairs(plugins) do
       local plugin_conf = ngx.ctx.plugin_conf[plugin.name]
       if plugin_conf then
-        plugin.handler:body_filter(plugin_conf and plugin_conf.value or nil)
+        plugin.handler:body_filter(plugin_conf and plugin_conf.value or {})
       end
     end
   end
@@ -251,7 +251,7 @@ function _M.exec_plugins_log()
     for _, plugin in ipairs(plugins) do
       local plugin_conf = ngx.ctx.plugin_conf[plugin.name]
       if plugin_conf then
-        plugin.handler:log(plugin_conf and plugin_conf.value or nil)
+        plugin.handler:log(plugin_conf and plugin_conf.value or {})
       end
     end
   end

--- a/kong/plugins/basicauth/access.lua
+++ b/kong/plugins/basicauth/access.lua
@@ -67,10 +67,6 @@ end
 
 function _M.execute(conf)
   if skip_authentication(ngx.req.get_headers()) then return end
-  if not conf then
-    -- Print the error in logs and signal this is a server error to the client
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR("[basicauth] missing configuration")
-  end
 
   local username, password = retrieve_credentials(ngx.req, conf)
   local credential

--- a/kong/plugins/cors/access.lua
+++ b/kong/plugins/cors/access.lua
@@ -46,8 +46,6 @@ local function configure_max_age(ngx, conf)
 end
 
 function _M.execute(conf)
-  if not conf then conf = {} end
-  
   local request = ngx.req
   local method = request.get_method()
   local headers = request.get_headers()

--- a/kong/plugins/keyauth/access.lua
+++ b/kong/plugins/keyauth/access.lua
@@ -116,7 +116,7 @@ local retrieve_credentials = {
 }
 
 function _M.execute(conf)
-  if not conf or skip_authentication(ngx.req.get_headers()) then return end
+  if skip_authentication(ngx.req.get_headers()) then return end
 
   local credential
   for _, v in ipairs({ constants.AUTHENTICATION.QUERY, constants.AUTHENTICATION.HEADER }) do

--- a/kong/plugins/request_transformer/access.lua
+++ b/kong/plugins/request_transformer/access.lua
@@ -26,8 +26,6 @@ local function get_content_type()
 end
 
 function _M.execute(conf)
-  if not conf then return end
-
   if conf.add then
 
     -- Add headers

--- a/kong/plugins/response_transformer/header_filter.lua
+++ b/kong/plugins/response_transformer/header_filter.lua
@@ -25,8 +25,6 @@ local function iterate_and_exec(val, cb)
 end
 
 function _M.execute(conf)
-  if not conf then return end
-
   local is_json_body = get_content_type() == APPLICATION_JSON
 
   if conf.add then


### PR DESCRIPTION
Instead of passing nil, pass an empty objects to plugins so they don't
have to check if `conf` exists.

Fix #352