### PR TITLE
[feat/admin api] endpoint to retrieve a plugin's schema

### DIFF
--- a/kong/api/app.lua
+++ b/kong/api/app.lua
@@ -140,7 +140,7 @@ local function attach_routes(routes)
 end
 
 -- Load core routes
-for _, v in ipairs({"kong", "apis", "consumers", "plugins_configurations"}) do
+for _, v in ipairs({"kong", "apis", "consumers", "plugins", "plugins_configurations"}) do
   local routes = require("kong.api.routes."..v)
   attach_routes(routes)
 end

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -1,0 +1,36 @@
+local utils = require "kong.tools.utils"
+
+-- Remove functions from a schema definition so that
+-- cjson can encode the schema.
+local function remove_functions(schema)
+  for k, v in pairs(schema) do
+    if type(v) == "function" then
+      schema[k] = "function"
+    end
+    if type(v) == "table" then
+      remove_functions(schema[k])
+    end
+  end
+end
+
+return {
+  ["/plugins"] = {
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK {
+        enabled_plugins = configuration.plugins_available
+      }
+    end
+  },
+  ["/plugins/:name/schema"] = {
+    GET = function(self, dao_factory, helpers)
+      local ok, plugin_schema = utils.load_module_if_exists("kong.plugins."..self.params.name..".schema")
+      if not ok then
+        return helpers.responses.send_HTTP_NOT_FOUND("No plugin named '"..self.params.name.."'")
+      end
+
+      remove_functions(plugin_schema)
+
+      return helpers.responses.send_HTTP_OK(plugin_schema)
+    end
+  }
+}

--- a/spec/integration/admin_api/plugins_routes_spec.lua
+++ b/spec/integration/admin_api/plugins_routes_spec.lua
@@ -1,0 +1,43 @@
+local json = require "cjson"
+local http_client = require "kong.tools.http_client"
+local spec_helper = require "spec.spec_helpers"
+
+describe("Admin API", function()
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  describe("/plugins/", function()
+    local BASE_URL = spec_helper.API_URL.."/plugins/"
+
+    it("should return a list of enabled plugins on this node", function()
+      local response, status = http_client.get(BASE_URL)
+      assert.equal(200, status)
+      local body = json.decode(response)
+      assert.equal("table", type(body.enabled_plugins))
+    end)
+  end)
+
+  describe("/plugins/:name/schema", function()
+    local BASE_URL = spec_helper.API_URL.."/plugins/keyauth/schema"
+
+    it("[SUCCESS] should return the schema of a plugin", function()
+      local response, status = http_client.get(BASE_URL)
+      assert.equal(200, status)
+      local body = json.decode(response)
+      assert.equal("table", type(body.fields))
+    end)
+
+    it("[FAILURE] should return a descriptive error if schema is not found", function()
+      local response, status = http_client.get(spec_helper.API_URL.."/plugins/foo/schema")
+      assert.equal(404, status)
+      local body = json.decode(response)
+      assert.equal("No plugin named 'foo'", body.message)
+    end)
+  end)
+end)


### PR DESCRIPTION
Implement a suggestion from #309 to expose a plugin's schema in the API.
This allows UI builders to abstract a part of their code.

This adds an endpoint: `/plugins` to retrieve the `enabled_plugins` of
the node and `/plugins/:name/schema` to retrieve the schema.

`/plugins` can be confounded with `/plugins_configurations` but I see no
better name for it now.

Fix #309.