### PR TITLE
[feature] implement wildcard subdomains for APIs' public_dns

### DIFF
--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -24,12 +24,30 @@ local function check_public_dns_and_path(value, api_t)
     return false, "At least a 'public_dns' or a 'path' must be specified"
   end
 
-  return true
+  -- Validate wildcard public_dns
+  if public_dns then
+    local _, count = public_dns:gsub("%*", "")
+    if count > 1 then
+      return false, "Only one wildcard is allowed: "..public_dns
+    elseif count > 0 then
+      local pos = public_dns:find("%*")
+      local valid
+      if pos == 1 then
+        valid = public_dns:match("^%*%.") ~= nil
+      elseif pos == string.len(public_dns) then
+        valid = public_dns:match(".%.%*$") ~= nil
+      end
+
+      if not valid then
+        return false, "Invalid wildcard placement: "..public_dns
+      end
+    end
+  end
 end
 
 local function check_path(path, api_t)
   local valid, err = check_public_dns_and_path(path, api_t)
-  if not valid then
+  if valid == false then
     return false, err
   end
 

--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -1,8 +1,5 @@
 local utils = require "kong.tools.utils"
 local stringy = require "stringy"
-local DaoError = require "kong.dao.error"
-local constants = require "kong.constants"
-local error_types = constants.DATABASE_ERROR_TYPES
 
 local POSSIBLE_TYPES = {
   id = true,
@@ -172,7 +169,7 @@ function _M.validate_entity(t, schema, options)
         -- [FUNC] Check field against a custom function
         -- only if there is no error on that field already.
         local ok, err, new_fields = v.func(t[column], t, column)
-        if not ok and err then
+        if ok == false and err then
           errors = utils.add_error(errors, column, err)
         elseif new_fields then
           for k, v in pairs(new_fields) do

--- a/spec/integration/proxy/resolver_spec.lua
+++ b/spec/integration/proxy/resolver_spec.lua
@@ -25,11 +25,13 @@ describe("Resolver", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests host resolver 1", public_dns = "mockbin.com", target_url = "http://mockbin.com" },
-        { name = "tests host resolver 2", public_dns = "mockbin-auth.com", target_url = "http://mockbin.com" },
-        { name = "tests path resolver", target_url = "http://mockbin.com", path = "/status/" },
-        { name = "tests stripped path resolver", target_url = "http://mockbin.com", path = "/mockbin/", strip_path = true },
-        { name = "tests deep path resolver", target_url = "http://mockbin.com", path = "/deep/path/", strip_path = true }
+        {name = "tests host resolver 1", public_dns = "mockbin.com", target_url = "http://mockbin.com"},
+        {name = "tests host resolver 2", public_dns = "mockbin-auth.com", target_url = "http://mockbin.com"},
+        {name = "tests path resolver", target_url = "http://mockbin.com", path = "/status/"},
+        {name = "tests stripped path resolver", target_url = "http://mockbin.com", path = "/mockbin/", strip_path = true},
+        {name = "tests deep path resolver", target_url = "http://mockbin.com", path = "/deep/path/", strip_path = true},
+        {name = "tests wildcard subdomain", target_url = "http://mockbin.com/status/200", public_dns = "*.wildcard.com"},
+        {name = "tests wildcard subdomain 2", target_url = "http://mockbin.com/status/201", public_dns = "wildcard.*"}
       },
       plugin_configuration = {
         { name = "keyauth", value = {key_names = {"apikey"} }, __api = 2 }
@@ -47,8 +49,8 @@ describe("Resolver", function()
 
     it("should return Not Found when the API is not in Kong", function()
       local response, status = http_client.get(spec_helper.STUB_GET_URL, nil, { host = "foo.com" })
-      assert.are.equal(404, status)
-      assert.are.equal('{"public_dns":["foo.com"],"message":"API not found with these values","path":"\\/request"}\n', response)
+      assert.equal(404, status)
+      assert.equal('{"public_dns":["foo.com"],"message":"API not found with these values","path":"\\/request"}\n', response)
     end)
 
   end)
@@ -57,10 +59,10 @@ describe("Resolver", function()
 
     it("should work when calling SSL port", function()
       local response, status = http_client.get(STUB_GET_SSL_URL, nil, { host = "mockbin.com" })
-      assert.are.equal(200, status)
+      assert.equal(200, status)
       assert.truthy(response)
       local parsed_response = cjson.decode(response)
-      assert.are.same("GET", parsed_response.method)
+      assert.same("GET", parsed_response.method)
     end)
 
     it("should work when manually triggering the handshake on default route", function()
@@ -86,13 +88,13 @@ describe("Resolver", function()
 
       local cert = parse_cert(conn:getpeercertificate())
 
-      assert.are.same(6, utils.table_size(cert))
-      assert.are.same("Kong", cert.organizationName)
-      assert.are.same("IT", cert.organizationalUnitName)
-      assert.are.same("US", cert.countryName)
-      assert.are.same("California", cert.stateOrProvinceName)
-      assert.are.same("San Francisco", cert.localityName)
-      assert.are.same("localhost", cert.commonName)
+      assert.same(6, utils.table_size(cert))
+      assert.same("Kong", cert.organizationName)
+      assert.same("IT", cert.organizationalUnitName)
+      assert.same("US", cert.countryName)
+      assert.same("California", cert.stateOrProvinceName)
+      assert.same("San Francisco", cert.localityName)
+      assert.same("localhost", cert.commonName)
 
       conn:close()
     end)
@@ -103,70 +105,81 @@ describe("Resolver", function()
     describe("By Host", function()
 
       it("should proxy when the API is in Kong", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com"})
-        assert.are.equal(200, status)
+        local _, status = http_client.get(STUB_GET_URL, nil, {host = "mockbin.com"})
+        assert.equal(200, status)
       end)
 
       it("should proxy when the Host header is not trimmed", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { host = "   mockbin.com  "})
-        assert.are.equal(200, status)
+        local _, status = http_client.get(STUB_GET_URL, nil, {host = "   mockbin.com  "})
+        assert.equal(200, status)
       end)
 
       it("should proxy when the request has no Host header but the X-Host-Override header", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { ["X-Host-Override"] = "mockbin.com"})
-        assert.are.equal(200, status)
+        local _, status = http_client.get(STUB_GET_URL, nil, {["X-Host-Override"] = "mockbin.com"})
+        assert.equal(200, status)
       end)
 
       it("should proxy when the Host header contains a port", function()
-        local _, status = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com:80"})
-        assert.are.equal(200, status)
+        local _, status = http_client.get(STUB_GET_URL, nil, {host = "mockbin.com:80"})
+        assert.equal(200, status)
       end)
 
+      describe("with wildcard subdomain", function()
+
+        it("should proxy when the public_dns is a wildcard subdomain", function()
+          local _, status = http_client.get(STUB_GET_URL, nil, {host = "subdomain.wildcard.com"})
+          assert.equal(200, status)
+
+          _, status = http_client.get(STUB_GET_URL, nil, {host = "wildcard.org"})
+          assert.equal(201, status)
+        end)
+
+      end)
     end)
 
     describe("By Path", function()
 
       it("should proxy when no Host is present but the request_uri matches the API's path", function()
         local _, status = http_client.get(spec_helper.PROXY_URL.."/status/200")
-        assert.are.equal(200, status)
+        assert.equal(200, status)
 
         local _, status = http_client.get(spec_helper.PROXY_URL.."/status/301")
-        assert.are.equal(301, status)
+        assert.equal(301, status)
       end)
 
       it("should not proxy when the path does not match the start of the request_uri", function()
         local response, status = http_client.get(spec_helper.PROXY_URL.."/somepath/status/200")
         local body = cjson.decode(response)
-        assert.are.equal("API not found with these values", body.message)
-        assert.are.equal("/somepath/status/200", body.path)
-        assert.are.equal(404, status)
+        assert.equal("API not found with these values", body.message)
+        assert.equal("/somepath/status/200", body.path)
+        assert.equal(404, status)
       end)
 
       it("should proxy and strip the path if `strip_path` is true", function()
         local response, status = http_client.get(spec_helper.PROXY_URL.."/mockbin/request")
-        assert.are.equal(200, status)
+        assert.equal(200, status)
         local body = cjson.decode(response)
-        assert.are.equal("http://mockbin.com/request", body.url)
+        assert.equal("http://mockbin.com/request", body.url)
       end)
 
       it("should proxy when the path has a deep level", function()
         local _, status = http_client.get(spec_helper.PROXY_URL.."/deep/path/status/200")
-        assert.are.equal(200, status)
+        assert.equal(200, status)
       end)
 
     end)
 
     it("should return the correct Server and Via headers when the request was proxied", function()
       local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mockbin.com"})
-      assert.are.equal(200, status)
-      assert.are.equal("cloudflare-nginx", headers.server)
-      assert.are.equal(constants.NAME.."/"..constants.VERSION, headers.via)
+      assert.equal(200, status)
+      assert.equal("cloudflare-nginx", headers.server)
+      assert.equal(constants.NAME.."/"..constants.VERSION, headers.via)
     end)
 
     it("should return the correct Server and no Via header when the request was NOT proxied", function()
       local _, status, headers = http_client.get(STUB_GET_URL, nil, { host = "mockbin-auth.com"})
-      assert.are.equal(401, status)
-      assert.are.equal(constants.NAME.."/"..constants.VERSION, headers.server)
+      assert.equal(401, status)
+      assert.equal(constants.NAME.."/"..constants.VERSION, headers.server)
       assert.falsy(headers.via)
     end)
 

--- a/spec/unit/dao/cassandra/base_dao_spec.lua
+++ b/spec/unit/dao/cassandra/base_dao_spec.lua
@@ -161,7 +161,7 @@ describe("Cassandra", function()
         assert.are.same("consumer_id "..plugin_t.consumer_id.." does not exist", err.message.consumer_id)
       end)
 
-      it("should do insert checks for entities with `on_insert`", function()
+      it("should do insert checks for entities with `self_check`", function()
         local api, err = dao_factory.apis:insert(faker:fake_entity("api"))
         assert.falsy(err)
         assert.truthy(api.id)

--- a/spec/unit/dao/oauth2/oauth2_entities_spec.lua
+++ b/spec/unit/dao/oauth2/oauth2_entities_spec.lua
@@ -1,4 +1,4 @@
-local validate_fields = require("kong.dao.schemas_validation").validate_fields
+local validate_entity = require("kong.dao.schemas_validation").validate_entity
 local oauth2_schema = require "kong.plugins.oauth2.schema"
 
 require "kong.tools.ngx_stub"
@@ -8,26 +8,26 @@ describe("OAuth2 Entities Schemas", function()
   describe("OAuth2 Configuration", function()
 
     it("should not require a `scopes` when `mandatory_scope` is false", function()
-      local valid, errors = validate_fields({ mandatory_scope = false }, oauth2_schema)
+      local valid, errors = validate_entity({ mandatory_scope = false }, oauth2_schema)
       assert.truthy(valid)
       assert.falsy(errors)
     end)
 
     it("should require a `scopes` when `mandatory_scope` is true", function()
-      local valid, errors = validate_fields({ mandatory_scope = true }, oauth2_schema)
+      local valid, errors = validate_entity({ mandatory_scope = true }, oauth2_schema)
       assert.falsy(valid)
       assert.equal("To set a mandatory scope you also need to create available scopes", errors.mandatory_scope)
     end)
 
     it("should pass when both `scopes` when `mandatory_scope` are passed", function()
-      local valid, errors = validate_fields({ mandatory_scope = true, scopes = { "email", "info" } }, oauth2_schema)
+      local valid, errors = validate_entity({ mandatory_scope = true, scopes = { "email", "info" } }, oauth2_schema)
       assert.truthy(valid)
       assert.falsy(errors)
     end)
 
     it("should autogenerate a `provision_key` when it is not being passed", function()
       local t = { mandatory_scope = true, scopes = { "email", "info" } }
-      local valid, errors = validate_fields(t, oauth2_schema)
+      local valid, errors = validate_entity(t, oauth2_schema)
       assert.truthy(valid)
       assert.falsy(errors)
       assert.truthy(t.provision_key)
@@ -36,7 +36,7 @@ describe("OAuth2 Entities Schemas", function()
 
     it("should not autogenerate a `provision_key` when it is being passed", function()
       local t = { mandatory_scope = true, scopes = { "email", "info" }, provision_key = "hello" }
-      local valid, errors = validate_fields(t, oauth2_schema)
+      local valid, errors = validate_entity(t, oauth2_schema)
       assert.truthy(valid)
       assert.falsy(errors)
       assert.truthy(t.provision_key)

--- a/spec/unit/schemas_spec.lua
+++ b/spec/unit/schemas_spec.lua
@@ -1,5 +1,5 @@
 local schemas = require "kong.dao.schemas_validation"
-local validate_fields = schemas.validate_fields
+local validate_entity = schemas.validate_entity
 
 require "kong.tools.ngx_stub"
 
@@ -7,7 +7,7 @@ describe("Schemas", function()
 
   -- Ok kids, today we're gonna test a custom validation schema,
   -- grab a pair of glasses, this stuff can literally explode.
-  describe("#validate_fields()", function()
+  describe("#validate_entity()", function()
     local schema = {
       fields = {
         string = { type = "string", required = true, immutable = true},
@@ -39,7 +39,7 @@ describe("Schemas", function()
     it("should confirm a valid entity is valid", function()
       local values = {string = "mockbin entity", url = "mockbin.com"}
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.True(valid)
     end)
@@ -48,7 +48,7 @@ describe("Schemas", function()
       it("should invalidate entity if required property is missing", function()
         local values = { url = "mockbin.com" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.False(valid)
         assert.truthy(err)
         assert.are.same("string is required", err.string)
@@ -60,7 +60,7 @@ describe("Schemas", function()
        -- Failure
       local values = { string = "foo", table = "bar" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.False(valid)
       assert.truthy(err)
       assert.are.same("table is not a table", err.table)
@@ -68,14 +68,14 @@ describe("Schemas", function()
       -- Success
       local values = { string = "foo", table = { foo = "bar" }}
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.True(valid)
 
       -- Failure
       local values = { string = 1, table = { foo = "bar" }}
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.False(valid)
       assert.truthy(err)
       assert.are.same("string is not a string", err.string)
@@ -83,14 +83,14 @@ describe("Schemas", function()
       -- Success
       local values = { string = "foo", number = 10 }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.True(valid)
 
       -- Success
       local values = { string = "foo", number = "10" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.truthy(valid)
       assert.are.same("number", type(values.number))
@@ -98,7 +98,7 @@ describe("Schemas", function()
        -- Success
       local values = { string = "foo", boolean_val = true }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.truthy(valid)
       assert.are.same("boolean", type(values.boolean_val))
@@ -106,14 +106,14 @@ describe("Schemas", function()
       -- Success
       local values = { string = "foo", boolean_val = "true" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.truthy(valid)
 
       -- Failure
       local values = { string = "foo",  endpoint = "" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
       assert.are.equal("endpoint is not a url", err.endpoint)
@@ -121,28 +121,28 @@ describe("Schemas", function()
       -- Failure
       local values = { string = "foo",  endpoint = "asdasd" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
 
       -- Failure
       local values = { string = "foo",  endpoint = "http://google.com" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
 
       -- Success
       local values = { string = "foo",  endpoint = "http://google.com/" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.truthy(valid)
       assert.falsy(err)
 
       -- Success
       local values = { string = "foo",  endpoint = "http://google.com/hello/?world=asd" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.truthy(valid)
       assert.falsy(err)
     end)
@@ -150,7 +150,7 @@ describe("Schemas", function()
     it("should return error when an invalid boolean value is passed", function()
       local values = { string = "test", boolean_val = "ciao" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
       assert.are.same("boolean_val is not a boolean", err.boolean_val)
@@ -159,7 +159,7 @@ describe("Schemas", function()
     it("should not return an error when a true boolean value is passed", function()
       local values = { string = "test", boolean_val = true }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.truthy(valid)
     end)
@@ -167,7 +167,7 @@ describe("Schemas", function()
     it("should not return an error when a false boolean value is passed", function()
       local values = { string = "test", boolean_val = false }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(err)
       assert.truthy(valid)
     end)
@@ -181,7 +181,7 @@ describe("Schemas", function()
 
       local values = { id = "123" }
 
-      local valid, err = validate_fields(values, s)
+      local valid, err = validate_entity(values, s)
       assert.falsy(err)
       assert.truthy(valid)
     end)
@@ -196,14 +196,14 @@ describe("Schemas", function()
       -- Success
       local values = { array = {"hello", "world"} }
 
-      local valid, err = validate_fields(values, s)
+      local valid, err = validate_entity(values, s)
       assert.True(valid)
       assert.falsy(err)
 
       -- Failure
       local values = { array = {hello="world"} }
 
-      local valid, err = validate_fields(values, s)
+      local valid, err = validate_entity(values, s)
       assert.False(valid)
       assert.truthy(err)
       assert.equal("array is not a array", err.array)
@@ -213,7 +213,7 @@ describe("Schemas", function()
       it("should not return an error when a `number` is passed as a string", function()
         local values = { string = "test", number = "10" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.same("number", type(values.number))
@@ -222,7 +222,7 @@ describe("Schemas", function()
       it("should not return an error when a `boolean` is passed as a string", function()
         local values = { string = "test", boolean_val = "false" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.same("boolean", type(values.boolean_val))
@@ -238,7 +238,7 @@ describe("Schemas", function()
         -- It should also strip the resulting strings
         local values = { array = "hello, world" }
 
-        local valid, err = validate_fields(values, s)
+        local valid, err = validate_entity(values, s)
         assert.True(valid)
         assert.falsy(err)
         assert.same({"hello", "world"}, values.array)
@@ -251,7 +251,7 @@ describe("Schemas", function()
         -- Variables
         local values = { string = "mockbin entity", url = "mockbin.com" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.are.same(123456, values.date)
@@ -259,7 +259,7 @@ describe("Schemas", function()
         -- Functions
         local values = { string = "mockbin entity", url = "mockbin.com" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.are.same("default", values.default)
@@ -269,7 +269,7 @@ describe("Schemas", function()
         -- Variables
         local values = { string = "mockbin entity", url = "mockbin.com", date = 654321 }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.are.same(654321, values.date)
@@ -277,7 +277,7 @@ describe("Schemas", function()
         -- Functions
         local values = { string = "mockbin entity", url = "mockbin.com", default = "abcdef" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.are.same("abcdef", values.default)
@@ -289,7 +289,7 @@ describe("Schemas", function()
       it("should validate a field against a regex", function()
         local values = { string = "mockbin entity", url = "mockbin_!" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(valid)
         assert.truthy(err)
         assert.are.same("url has an invalid value", err.url)
@@ -301,14 +301,14 @@ describe("Schemas", function()
         -- Success
         local values = { string = "somestring", allowed = "hello" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
 
         -- Failure
         local values = { string = "somestring", allowed = "hello123" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(valid)
         assert.truthy(err)
         assert.are.same("\"hello123\" is not allowed. Allowed values are: \"hello\", \"world\"", err.allowed)
@@ -320,14 +320,14 @@ describe("Schemas", function()
         -- Success
         local values = { string = "somestring", custom = true, default = "test_custom_func" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
 
         -- Failure
         local values = { string = "somestring", custom = true, default = "not the default :O" }
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(valid)
         assert.truthy(err)
         assert.are.same("Nah", err.custom)
@@ -346,7 +346,7 @@ describe("Schemas", function()
       it("should call a given function when encountering a field with `dao_insert_value`", function()
         local values = {string = "hello", id = "0000"}
 
-        local valid, err = validate_fields(values, schema, {dao_insert = function(field)
+        local valid, err = validate_entity(values, schema, {dao_insert = function(field)
           if field.type == "id" then
             return "1234"
           elseif field.type == "timestamp" then
@@ -363,7 +363,7 @@ describe("Schemas", function()
       it("should not raise any error if the function is not given", function()
         local values = { string = "hello", id = "0000" }
 
-        local valid, err = validate_fields(values, schema, { dao_insert = true }) -- invalid type
+        local valid, err = validate_entity(values, schema, { dao_insert = true }) -- invalid type
         assert.falsy(err)
         assert.True(valid)
         assert.equal("0000", values.id)
@@ -375,7 +375,7 @@ describe("Schemas", function()
     it("should return error when unexpected values are included in the schema", function()
       local values = { string = "mockbin entity", url = "mockbin.com", unexpected = "abcdef" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
     end)
@@ -383,7 +383,7 @@ describe("Schemas", function()
     it("should be able to return multiple errors at once", function()
       local values = { url = "mockbin.com", unexpected = "abcdef" }
 
-      local valid, err = validate_fields(values, schema)
+      local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
       assert.truthy(err)
       assert.are.same("string is required", err.string)
@@ -399,7 +399,7 @@ describe("Schemas", function()
       }
 
       assert.has_no_errors(function()
-        local valid, err = validate_fields({}, schema)
+        local valid, err = validate_entity({}, schema)
         assert.False(valid)
         assert.are.same("property is required", err.property)
       end)
@@ -407,7 +407,7 @@ describe("Schemas", function()
 
     describe("Sub-schemas", function()
       -- To check wether schema_from_function was called, we will simply use booleans because
-      -- busted's spy methods create tables and metatable magic, but the validate_fields() function
+      -- busted's spy methods create tables and metatable magic, but the validate_entity() function
       -- only callse v.schema if the type is a function. Which is not the case with a busted spy.
       local called, called_with
       local schema_from_function = function(t)
@@ -441,7 +441,7 @@ describe("Schemas", function()
         -- Success
         local values = { some_required = "somestring", sub_schema = { sub_field_required = "sub value" }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.are.same("abcd", values.sub_schema.sub_field_default)
@@ -449,7 +449,7 @@ describe("Schemas", function()
         -- Failure
         local values = { some_required = "somestring", sub_schema = { sub_field_default = "" }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.truthy(err)
         assert.falsy(valid)
         assert.are.same("sub_field_required is required", err["sub_schema.sub_field_required"])
@@ -464,7 +464,7 @@ describe("Schemas", function()
                                                         sub_sub_schema = { sub_sub_field_required = "test" }
                                                        }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.falsy(err)
         assert.truthy(valid)
 
@@ -474,7 +474,7 @@ describe("Schemas", function()
                                                         sub_sub_schema = {}
                                                        }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.truthy(err)
         assert.falsy(valid)
         assert.are.same("sub_sub_field_required is required", err["sub_schema.sub_sub_schema.sub_sub_field_required"])
@@ -487,7 +487,7 @@ describe("Schemas", function()
                                                         sub_sub_schema = { sub_sub_field_required = "test" }
                                                       }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.falsy(err)
         assert.truthy(valid)
         assert.True(called)
@@ -502,7 +502,7 @@ describe("Schemas", function()
                                                         sub_sub_schema = { sub_sub_field_required = "test" }
                                                       }}
 
-        local valid, err = validate_fields(values, nested_schema)
+        local valid, err = validate_entity(values, nested_schema)
         assert.truthy(err)
         assert.falsy(valid)
         assert.are.same("Error loading the sub-sub-schema", err["sub_schema.sub_sub_schema"])
@@ -523,7 +523,7 @@ describe("Schemas", function()
         }
 
         local obj = {}
-        local valid, err = validate_fields(obj, schema)
+        local valid, err = validate_entity(obj, schema)
         assert.falsy(err)
         assert.True(valid)
         assert.are.same("hello", obj.value.some_property)
@@ -537,7 +537,7 @@ describe("Schemas", function()
         }
 
         local obj = {}
-        local valid, err = validate_fields(obj, schema)
+        local valid, err = validate_entity(obj, schema)
         assert.truthy(err)
         assert.False(valid)
         assert.are.same("value.some_property is required", err.value)
@@ -549,7 +549,7 @@ describe("Schemas", function()
       it("should ignore required properties and defaults if we are updating because the entity might be partial", function()
         local values = {}
 
-        local valid, err = validate_fields(values, schema, {partial_update = true})
+        local valid, err = validate_entity(values, schema, {partial_update = true})
         assert.falsy(err)
         assert.True(valid)
         assert.falsy(values.default)
@@ -559,7 +559,7 @@ describe("Schemas", function()
       it("should still validate set properties", function()
         local values = { string = 123 }
 
-        local valid, err = validate_fields(values, schema, {partial_update = true})
+        local valid, err = validate_entity(values, schema, {partial_update = true})
         assert.False(valid)
         assert.equal("string is not a string", err.string)
       end)
@@ -567,7 +567,7 @@ describe("Schemas", function()
       it("should ignore immutable fields if they are required", function()
         local values = { string = "somestring" }
 
-        local valid, err = validate_fields(values, schema, {partial_update = true})
+        local valid, err = validate_entity(values, schema, {partial_update = true})
         assert.falsy(err)
         assert.True(valid)
       end)
@@ -576,12 +576,12 @@ describe("Schemas", function()
         -- Success
         local values = {string = "somestring", date = 1234}
 
-        local valid, err = validate_fields(values, schema)
+        local valid, err = validate_entity(values, schema)
         assert.falsy(err)
         assert.truthy(valid)
 
         -- Failure
-        local valid, err = validate_fields(values, schema, {partial_update = true})
+        local valid, err = validate_entity(values, schema, {partial_update = true})
         assert.False(valid)
         assert.truthy(err)
         assert.equal("date cannot be updated", err.date)
@@ -592,7 +592,7 @@ describe("Schemas", function()
       it("should not ignore required properties and ignore defaults", function()
         local values = {}
 
-        local valid, err = validate_fields(values, schema, {full_update = true})
+        local valid, err = validate_entity(values, schema, {full_update = true})
         assert.False(valid)
         assert.truthy(err)
         assert.equal("string is required", err.string)


### PR DESCRIPTION
An API's `public_dns` can now contain one '*' at the start or at the end of the string, and on a dot border (same rules as http://nginx.org/en/docs/http/server_names.html#wildcard_names).

If so, it will get special treatment during the lookup and the resolver will try to match any given `Host` header against all wildcard `public_dns`.

We keep things efficient by guaranteeing O(1) lookup for non wildcard `public_dns`. Only wildcard `public_dns` and `paths` will be O(n).

Implements #297.