### PR TITLE
Handling multiple rate-limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 
 env:
   global:
-    - CASSANDRA_VERSION=2.1.7
+    - CASSANDRA_VERSION=2.1.8
   matrix:
     - LUA=lua5.1
 

--- a/.travis/setup_cassandra.sh
+++ b/.travis/setup_cassandra.sh
@@ -3,5 +3,5 @@
 CASSANDRA_BASE=apache-cassandra-$CASSANDRA_VERSION
 
 sudo rm -rf /var/lib/cassandra/*
-curl http://apache.spinellicreations.com/cassandra/$CASSANDRA_VERSION/$CASSANDRA_BASE-bin.tar.gz | tar xz
+curl http://apache.mirrors.ionfish.org/cassandra/$CASSANDRA_VERSION/$CASSANDRA_BASE-bin.tar.gz | tar xz
 sudo sh $CASSANDRA_BASE/bin/cassandra

--- a/database/migrations/cassandra/2015-06-09-170921_0.4.0.lua
+++ b/database/migrations/cassandra/2015-06-09-170921_0.4.0.lua
@@ -3,6 +3,7 @@ local Migration = {
 
   up = function(options)
     return [[
+
       CREATE TABLE IF NOT EXISTS oauth2_credentials(
         id uuid,
         name text,

--- a/kong/dao/schemas/plugins_configurations.lua
+++ b/kong/dao/schemas/plugins_configurations.lua
@@ -38,6 +38,13 @@ return {
       return false, DaoError("No consumer can be configured for that plugin", constants.DATABASE_ERROR_TYPES.SCHEMA)
     end
 
+    if value_schema.self_check and type(value_schema.self_check) == "function" then
+      local ok, err = value_schema.self_check(value_schema, plugin_t.value and plugin_t.value or {}, dao, is_update)
+      if not ok then
+        return false, err
+      end
+    end
+
     if not is_update then
       local res, err = dao.plugins_configurations:find_by_keys({
         name = plugin_t.name,

--- a/kong/plugins/ratelimiting/schema.lua
+++ b/kong/plugins/ratelimiting/schema.lua
@@ -1,8 +1,44 @@
+local DaoError = require "kong.dao.error"
 local constants = require "kong.constants"
 
 return {
   fields = {
-    limit = { required = true, type = "number" },
-    period = { required = true, type = "string", enum = constants.RATELIMIT.PERIODS }
-  }
+    second = { type = "number" },
+    minute = { type = "number" },
+    hour = { type = "number" },
+    day = { type = "number" },
+    month = { type = "number" },
+    year = { type = "number" }
+  },
+  self_check = function(schema, plugin_t, dao, is_update)
+    local ordered_periods = { "second", "minute", "hour", "day", "month", "year"}
+    local has_value
+    local invalid_order
+    local invalid_value
+
+    for i, v in ipairs(ordered_periods) do
+      if plugin_t[v] then
+        has_value = true
+        if plugin_t[v] <=0 then
+          invalid_value = "Value for "..v.." must be greater than zero"
+        else
+          for t = i, #ordered_periods do
+            if plugin_t[ordered_periods[t]] and plugin_t[ordered_periods[t]] < plugin_t[v] then
+              invalid_order = "The value for "..ordered_periods[t].." cannot be lower than the value for "..v
+            end
+          end
+        end
+      end
+    end
+
+    if not has_value then
+      return false, DaoError("You need to set at least one limit: second, minute, hour, day, month, year", constants.DATABASE_ERROR_TYPES.SCHEMA)
+    elseif invalid_value then
+      return false, DaoError(invalid_value, constants.DATABASE_ERROR_TYPES.SCHEMA)
+    elseif invalid_order then
+      return false, DaoError(invalid_order, constants.DATABASE_ERROR_TYPES.SCHEMA)
+    end
+
+    return true
+  end
 }

--- a/spec/plugins/ratelimiting/api_spec.lua
+++ b/spec/plugins/ratelimiting/api_spec.lua
@@ -1,0 +1,43 @@
+local json = require "cjson"
+local http_client = require "kong.tools.http_client"
+local spec_helper = require "spec.spec_helpers"
+
+local BASE_URL = spec_helper.API_URL.."/apis/%s/plugins/"
+
+describe("Rate Limiting API", function()
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.insert_fixtures {
+      api = {
+        { name = "tests ratelimiting 1", public_dns = "test1.com", target_url = "http://mockbin.com" }
+      }
+    }
+    spec_helper.start_kong()
+
+    local response = http_client.get(spec_helper.API_URL.."/apis/")
+    BASE_URL = string.format(BASE_URL, json.decode(response).data[1].id)
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  describe("POST", function()
+    
+    it("should not save with empty value", function()
+      local response, status = http_client.post(BASE_URL, { name = "ratelimiting" })
+      local body = json.decode(response)
+      assert.are.equal(400, status)
+      assert.are.equal("You need to set at least one limit: second, minute, hour, day, month, year", body.message)
+    end)
+    
+    it("should save with proper value", function()
+      local response, status = http_client.post(BASE_URL, { name = "ratelimiting", ["value.second"] = 10 })
+      local body = json.decode(response)
+      assert.are.equal(201, status)
+      assert.are.equal(10, body.value.second)
+    end)
+    
+  end)
+
+end)

--- a/spec/plugins/ratelimiting/schema_spec.lua
+++ b/spec/plugins/ratelimiting/schema_spec.lua
@@ -1,0 +1,36 @@
+local schemas = require "kong.dao.schemas_validation"
+local validate_entity = schemas.validate_entity
+
+local plugin_schema = require "kong.plugins.ratelimiting.schema"
+
+describe("Rate Limiting schema", function()
+
+  it("should be invalid when no value is being set", function()
+    local values = {}
+    local valid, _, err = validate_entity(values, plugin_schema)
+    assert.falsy(valid)
+    assert.are.equal("You need to set at least one limit: second, minute, hour, day, month, year", err.message)
+  end)
+
+  it("should work when the proper value is being set", function()
+    local values = { second = 10 }
+    local valid, _, err = validate_entity(values, plugin_schema)
+    assert.truthy(valid)
+    assert.falsy(err)
+  end)
+
+  it("should work when the proper value are being set", function()
+    local values = { second = 10, hour = 20 }
+    local valid, _, err = validate_entity(values, plugin_schema)
+    assert.truthy(valid)
+    assert.falsy(err)
+  end)
+
+  it("should not work when invalid data is being set", function()
+    local values = { second = 20, hour = 10 }
+    local valid, _, err = validate_entity(values, plugin_schema)
+    assert.falsy(valid)
+    assert.are.equal("The value for hour cannot be lower than the value for second", err.message)
+  end)
+  
+end)

--- a/spec/unit/dao/cassandra/base_dao_spec.lua
+++ b/spec/unit/dao/cassandra/base_dao_spec.lua
@@ -537,7 +537,7 @@ describe("Cassandra", function()
             },
             plugin_configuration = {
               {name = "keyauth", __api = 1},
-              {name = "ratelimiting", value = {period = "minute", limit = 6}, __api = 1},
+              {name = "ratelimiting", value = { minute = 6}, __api = 1},
               {name = "filelog", value = {path = "/tmp/spec.log" }, __api = 1},
 
               {name = "keyauth", __api = 2}
@@ -590,7 +590,7 @@ describe("Cassandra", function()
             },
             plugin_configuration = {
               {name = "keyauth", __api = 1, __consumer = 1},
-              {name = "ratelimiting", value = {period = "minute", limit = 6}, __api = 1, __consumer = 1},
+              {name = "ratelimiting", value = { minute = 6}, __api = 1, __consumer = 1},
               {name = "filelog", value = {path = "/tmp/spec.log" }, __api = 1, __consumer = 1},
 
               {name = "keyauth", __api = 1, __consumer = 2}
@@ -658,8 +658,8 @@ describe("Cassandra", function()
             },
             plugin_configuration = {
               { name = "keyauth", value = {key_names = {"apikey"}, hide_credentials = true}, __api = 1 },
-              { name = "ratelimiting", value = {period = "minute", limit = 6}, __api = 1 },
-              { name = "ratelimiting", value = {period = "minute", limit = 6}, __api = 2 },
+              { name = "ratelimiting", value = { minute = 6}, __api = 1 },
+              { name = "ratelimiting", value = { minute = 6}, __api = 2 },
               { name = "filelog", value = { path = "/tmp/spec.log" }, __api = 1 }
             }
           }

--- a/spec/unit/dao/entities_schemas_spec.lua
+++ b/spec/unit/dao/entities_schemas_spec.lua
@@ -238,12 +238,11 @@ describe("Entities Schemas", function()
       assert.True(valid)
 
       -- Failure
-      plugin = {name = "ratelimiting", api_id = "stub", value = {period = "hello"}}
+      plugin = {name = "ratelimiting", api_id = "stub", value = { second = "hello" }}
 
       local valid, errors = validate_entity(plugin, plugins_configurations_schema, {dao = dao_stub})
       assert.False(valid)
-      assert.equal("limit is required", errors["value.limit"])
-      assert.equal("\"hello\" is not allowed. Allowed values are: \"second\", \"minute\", \"hour\", \"day\", \"month\", \"year\"", errors["value.period"])
+      assert.equal("second is not a number", errors["value.second"])
     end)
 
     describe("self_check", function()


### PR DESCRIPTION
Closes issue #205 and deprecates #224.

This pull requests enables support for multiple rate-limit periods on the same API.

## New plugin configuration value format

This PR promotes a new format for setting up the `ratelimiting` plugin, whose value is now `value.{period}={limit}`, for example: 

`value.second=10` instead of the previous one `value.limit=10&value.period=second`.

The plugin will transparently handle the old value format **without requiring** a migration of the data.
