### PR TITLE
[feature/dao] cassandra authentication + client encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:
 	@find kong spec -name '*.lua' ! -name 'invalid-module.lua' | xargs luacheck -q
 
 test:
-	@busted spec/unit
+	@busted -v spec/unit
 
 test-integration:
 	@busted spec/integration
@@ -67,3 +67,6 @@ coverage:
 	@busted --coverage spec/
 	@luacov -c spec/.luacov
 	@tail -n 1 luacov.report.out | awk '{ print $$3 }'
+
+test-all:
+	@busted -v spec/

--- a/kong-0.4.1-1.rockspec
+++ b/kong-0.4.1-1.rockspec
@@ -19,7 +19,7 @@ dependencies = {
   "yaml ~> 1.1.1-1",
   "lapis ~> 1.1.0-1",
   "stringy ~> 0.4-1",
-  "kong-cassandra ~> 0.5-8",
+  "lua-cassandra ~> 0.3.3-0",
   "multipart ~> 0.1-3",
   "lua-path ~> 0.2.3-1",
   "lua-cjson ~> 2.1.0-1",

--- a/kong-0.4.1-1.rockspec
+++ b/kong-0.4.1-1.rockspec
@@ -19,7 +19,7 @@ dependencies = {
   "yaml ~> 1.1.1-1",
   "lapis ~> 1.1.0-1",
   "stringy ~> 0.4-1",
-  "lua-cassandra ~> 0.3.3-0",
+  "lua-cassandra ~> 0.3.5-0",
   "multipart ~> 0.1-3",
   "lua-path ~> 0.2.3-1",
   "lua-cjson ~> 2.1.0-1",

--- a/kong.yml
+++ b/kong.yml
@@ -113,6 +113,7 @@ nginx: |
     lua_shared_dict locks 100k;
     lua_shared_dict cache {{memory_cache_size}}m;
     lua_socket_log_errors off;
+    {{lua_ssl_trusted_certificate}}
 
     init_by_lua '
       kong = require "kong"

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -112,7 +112,8 @@ local function prepare_nginx_working_dir(args_config)
     dns_resolver = "127.0.0.1:"..kong_config.dnsmasq_port,
     memory_cache_size = kong_config.memory_cache_size,
     ssl_cert = ssl_cert_path,
-    ssl_key = ssl_key_path
+    ssl_key = ssl_key_path,
+    lua_ssl_trusted_certificate = kong_config.databases_available[kong_config.database].properties.ssl_certificate or "no"
   }
 
   -- Auto-tune

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -102,6 +102,7 @@ local function prepare_nginx_working_dir(args_config)
   end
 
   local ssl_cert_path, ssl_key_path = cutils.get_ssl_cert_and_key(kong_config)
+  local trusted_ssl_cert_path = kong_config.databases_available[kong_config.database].properties.ssl_certificate -- DAO ssl cert
 
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = kong_config.nginx
@@ -113,7 +114,7 @@ local function prepare_nginx_working_dir(args_config)
     memory_cache_size = kong_config.memory_cache_size,
     ssl_cert = ssl_cert_path,
     ssl_key = ssl_key_path,
-    lua_ssl_trusted_certificate = kong_config.databases_available[kong_config.database].properties.ssl_certificate or "no"
+    lua_ssl_trusted_certificate = trusted_ssl_cert_path ~= nil and "lua_ssl_trusted_certificate \""..trusted_ssl_cert_path.."\";" or ""
   }
 
   -- Auto-tune

--- a/kong/cli/utils/utils.lua
+++ b/kong/cli/utils/utils.lua
@@ -55,9 +55,6 @@ end
 
 function Logger:error_exit(str)
   self:error(str)
-  -- Optional stacktrace
-  --print("")
-  --error("", 2)
   os.exit(1)
 end
 

--- a/kong/dao/cassandra/apis.lua
+++ b/kong/dao/cassandra/apis.lua
@@ -13,7 +13,7 @@ end
 function Apis:find_all()
   local apis = {}
   local select_q = query_builder.select(self._table)
-  for _, rows, page, err in Apis.super.execute(self, select_q, nil, nil, {auto_paging=true}) do
+  for rows, err in Apis.super.execute(self, select_q, nil, nil, {auto_paging=true}) do
     if err then
       return nil, err
     end
@@ -37,7 +37,7 @@ function Apis:delete(where_t)
   local plugins_dao = self._factory.plugins_configurations
   local select_q, columns = query_builder.select(plugins_dao._table, {api_id = where_t.id}, plugins_dao._column_family_details)
 
-  for _, rows, page, err in plugins_dao:execute(select_q, columns, {api_id = where_t.id}, {auto_paging = true}) do
+  for rows, err in plugins_dao:execute(select_q, columns, {api_id = where_t.id}, {auto_paging = true}) do
     if err then
       return nil, err
     end

--- a/kong/dao/cassandra/consumers.lua
+++ b/kong/dao/cassandra/consumers.lua
@@ -22,7 +22,7 @@ function Consumers:delete(where_t)
   local select_q, columns = query_builder.select(plugins_dao._table, {consumer_id = where_t.id}, plugins_dao._column_family_details)
 
   -- delete all related plugins configurations
-  for _, rows, page, err in plugins_dao:execute(select_q, columns, {consumer_id = where_t.id}, {auto_paging = true}) do
+  for rows, err in plugins_dao:execute(select_q, columns, {consumer_id = where_t.id}, {auto_paging = true}) do
     if err then
       return nil, err
     end

--- a/kong/dao/cassandra/plugins_configurations.lua
+++ b/kong/dao/cassandra/plugins_configurations.lua
@@ -55,7 +55,7 @@ function PluginsConfigurations:find_distinct()
 
   -- Execute query
   local distinct_names = {}
-  for _, rows, page, err in PluginsConfigurations.super.execute(self, select_q, nil, nil, {auto_paging=true}) do
+  for rows, err in PluginsConfigurations.super.execute(self, select_q, nil, nil, {auto_paging=true}) do
     if err then
       return nil, err
     end

--- a/kong/plugins/ratelimiting/daos.lua
+++ b/kong/plugins/ratelimiting/daos.lua
@@ -26,7 +26,7 @@ end
 
 function RateLimitingMetrics:increment(api_id, identifier, current_timestamp)
   local periods = timestamp.get_timestamps(current_timestamp)
-  local batch = cassandra.BatchStatement(cassandra.batch_types.COUNTER)
+  local batch = cassandra:BatchStatement(cassandra.batch_types.COUNTER)
 
   for period, period_date in pairs(periods) do
     batch:add(self.queries.increment_counter, {

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -45,7 +45,7 @@ describe("Cassandra", function()
     spec_helper.prepare_db()
 
     -- Create a parallel session to verify the dao's behaviour
-    session = cassandra.new()
+    session = cassandra:new()
     session:set_timeout(configuration.cassandra.timeout)
 
     local _, err = session:connect(configuration.cassandra.hosts, configuration.cassandra.port)

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -153,6 +153,7 @@ nginx: |
     lua_shared_dict locks 100k;
     lua_shared_dict cache {{memory_cache_size}}m;
     lua_socket_log_errors off;
+    {{lua_ssl_trusted_certificate}}
 
     init_by_lua '
       kong = require "kong"


### PR DESCRIPTION
This PR addresses #373 (Cassandra authentication). Kong can now be used with any authenticated/encrypted Cassandra cluster (ie. instaclustr.com).

In order to do this and as an investment for Cassandra related features to move faster in the future, the Cassandra driver was switched from jbochi/lua-resty-cassandra to a [new one](http://thibaultcha.github.io/lua-cassandra/manual/README.md.html), which supports both binary protocols v2 and v3, as well as authentication and client encryption.

#### Changes

- Cassandra driver (lua-cassandra) now uses binary protocol v3. This in an investment in order to improve the DAO in the future, and use some of the new features provided by the v3 protocol (ie. named values binding).
- Support for authentication ([PasswordAuthenticator](http://docs.datastax.com/en/cassandra/2.0/cassandra/security/security_config_native_authenticate_t.html)).
- Support for client-to-node [encryption](http://docs.datastax.com/en/cassandra/2.0/cassandra/security/secureSSLClientToNode_t.html).

The driver supports all those features for both Luasocket and OpenResty environments. For it to work in Kong, this is the changes one would have to make to their configuration file:

```yaml
databases_available:
  cassandra:
  properties:
    ssl: true # for client-to-node encryption
    ssl_verify: true # if SSL verification
    ssl_certificate: "/path/to/cluster-ca-certificate.pem" # **absolute** path to the certificate authority file
    user: cassandra # user (and password) if the cluster has authentication enabled
    password: cassandra
    #  [...]
```

This makes Kong fully compatible with Cassandra provisioning services such as https://www.instaclustr.com.

I would recommend not merging this for the upcoming 0.4.0 since the switch of the underlying Cassandra driver is a potential breaking change. This could be part of an eventual 0.4.1 or 0.5.0 (in a shorter time span then 0.3.2 -> 0.4.0).