### PR TITLE
[test] re-enabling start_spec

### DIFF
--- a/spec/integration/cli/start_spec.lua
+++ b/spec/integration/cli/start_spec.lua
@@ -55,9 +55,9 @@ describe("CLI", function()
     it("should not work when an unexisting plugin is being enabled", function()
       replace_conf_property("plugins_available", {"wot-wat"})
 
-      assert.has_error(function()
+      assert.error_matches(function()
         spec_helper.start_kong(SERVER_CONF, true)
-      end, "The following plugin has been enabled in the configuration but it is not installed on the system: wot-wat")
+      end, "The following plugin has been enabled in the configuration but it is not installed on the system: wot-wat", nil, true)
     end)
 
     it("should not fail when an existing plugin is being enabled", function()
@@ -70,24 +70,24 @@ describe("CLI", function()
     it("should not work when an unexisting plugin is being enabled along with an existing one", function()
       replace_conf_property("plugins_available", {"keyauth", "wot-wat"})
 
-      assert.has_error(function()
+      assert.error_matches(function()
         spec_helper.start_kong(SERVER_CONF, true)
-      end, "The following plugin has been enabled in the configuration but it is not installed on the system: wot-wat")
+      end, "The following plugin has been enabled in the configuration but it is not installed on the system: wot-wat", nil, true)
     end)
 
     it("should not work when a plugin is being used in the DB but it's not in the configuration", function()
       spec_helper.get_env(SERVER_CONF).faker:insert_from_table {
         api = {
-          { name = "tests cli 1", public_dns = "foo.com", target_url = "http://mockbin.com" },
+          {name = "tests cli 1", public_dns = "foo.com", target_url = "http://mockbin.com"},
         },
         plugin_configuration = {
-          { name = "ratelimiting", value = {period = "minute", limit = 6}, __api = 1 },
+          {name = "ratelimiting", value = {minute = 6}, __api = 1},
         }
       }
 
       replace_conf_property("plugins_available", {"ssl", "keyauth", "basicauth", "oauth2", "tcplog", "udplog", "filelog", "httplog", "request_transformer", "cors"})
 
-      assert.has_error(function()
+      assert.error_matches(function()
         spec_helper.start_kong(SERVER_CONF, true)
       end, "You are using a plugin that has not been enabled in the configuration: ratelimiting")
     end)


### PR DESCRIPTION
Re enabling the start_spec suite since luassert now has an `error_matches` function.