### PR TITLE
[fix/mashape-analytics] ALF serializer and Buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TESTING_CONF = kong_TEST.yml
 DEVELOPMENT_CONF = kong_DEVELOPMENT.yml
 DEV_ROCKS=busted luacov luacov-coveralls luacheck
 
-.PHONY: install dev clean start seed drop lint test test-integration test-plugins test-all coverage
+.PHONY: install dev clean start restart seed drop lint test test-integration test-plugins test-all coverage
 
 install:
 	@if [ `uname` = "Darwin" ]; then \
@@ -37,6 +37,9 @@ start:
 
 stop:
 	@bin/kong stop -c $(DEVELOPMENT_CONF)
+
+restart:
+	@bin/kong restart -c $(DEVELOPMENT_CONF)
 
 seed:
 	@bin/kong db -c $(DEVELOPMENT_CONF) seed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Kong was created to secure, manage and extend Microservices & APIs. Kong is powe
 - **Scalability**: Distributed by nature, Kong scales horizontally simply by adding nodes.
 - **Performance**: Kong handles load with ease by scaling and using NGINX at the core.
 - **Plugins**: Extendable architecture for adding functionality to Kong and APIs.
-  - **OAuth2.0**: Add easily an OAuth2.0 authentication to your APIs. 
+  - **OAuth2.0**: Add easily an OAuth2.0 authentication to your APIs.
   - **Logging**: Log requests and responses to your system over HTTP, TCP, UDP or to disk.
   - **IP-restriction**: Whitelist or blacklist IPs that can make requests.
   - **Analytics**: Visualize, Inspect and Monitor API traffic with [Mashape Analytics](https://apianalytics.com).
@@ -89,11 +89,12 @@ When developing, use the `Makefile` for doing the following operations:
 | `dev`         | Setup your development environment                                       |
 | `clean`       | Clean your development environment                                       |
 | `start`       | Start the `DEVELOPMENT` environment (`kong_DEVELOPMENT.yml`)             |
+| `restart`     | Restart the `DEVELOPMENT` environment (`kong_DEVELOPMENT.yml`)           |
 | `seed`        | Seed the `DEVELOPMENT` environment (`kong_DEVELOPMENT.yml`)              |
 | `drop`        | Drop the `DEVELOPMENT` environment (`kong_DEVELOPMENT.yml`)              |
 | `lint`        | Lint Lua files in `kong/` and `spec/`                                    |
 | `test`        | Run the unit tests                                                       |
-| `test-integration | Run the integration tests (Kong + DAO)                              |
+| `test-integration | Run the integration tests (Kong + DAO)                               |
 | `test-plugins | Run unit + integration tests of all plugins                              |
 | `test-all`    | Run all unit + integration tests at once                                 |
 | `coverage`    | Run all tests + coverage report                                          |

--- a/kong/dao/cassandra/apis.lua
+++ b/kong/dao/cassandra/apis.lua
@@ -53,4 +53,4 @@ function Apis:delete(where_t)
   return ok
 end
 
-return { apis = Apis }
+return {apis = Apis}

--- a/kong/plugins/log_serializers/alf.lua
+++ b/kong/plugins/log_serializers/alf.lua
@@ -97,8 +97,11 @@ function alf_mt:serialize_entry(ngx)
   local alf_send_time = proxy_started_at - alf_started_at * 1000
 
   -- Time waiting for the upstream response
+  local upstream_response_time = 0
   local upstream_response_times = stringy.split(ngx.var.upstream_response_time, ", ")
-  local upstream_response_time = upstream_response_times[#upstream_response_times]
+  for _, val in ipairs(upstream_response_times) do
+    upstream_response_time = upstream_response_time + val
+  end
   local alf_wait_time = upstream_response_time * 1000
 
   -- upstream response fully received - upstream response 1 byte received

--- a/kong/plugins/log_serializers/alf.lua
+++ b/kong/plugins/log_serializers/alf.lua
@@ -74,7 +74,13 @@ function _M.serialize_entry(ngx)
 
   -- Time waiting for the upstream response
   local upstream_response_time = 0
-  local upstream_response_times = stringy.split(ngx.var.upstream_response_time, ", ")
+  local upstream_response_times = ngx.var.upstream_response_time
+  if not upstream_response_times or upstream_response_times == "-" then
+    -- client aborted the request
+    return
+  end
+
+  upstream_response_times = stringy.split(upstream_response_times, ", ")
   for _, val in ipairs(upstream_response_times) do
     upstream_response_time = upstream_response_time + val
   end
@@ -157,6 +163,11 @@ function _M.new_alf(ngx, token, environment)
     error("Missing ngx context", 2)
   elseif not token then
     error("Mashape Analytics serviceToken required", 2)
+  end
+
+  local entry = _M.serialize_entry(ngx)
+  if not entry then
+    return
   end
 
   return {

--- a/kong/plugins/mashape-analytics/buffer.lua
+++ b/kong/plugins/mashape-analytics/buffer.lua
@@ -1,11 +1,27 @@
 -- ALF buffer module
--- This module contains a buffered array of ALF objects to be sent to the upstream
--- Mashape Analytics socket server.
+--
+-- This module contains a buffered array of ALF objects. When the buffer is full (max number of entries
+-- or max payload size), it is converted to a JSON payload and moved to another buffer of payloads to be
+-- sent to the server.
+--
+-- 1 buffer of ALFs (gets flushed once it reached the mmax size)
+-- 1 queue of ready-to-be-sent batches which are JSON payloads
+--
+-- We only remove a payload from the sent queue if it has been correctly received by the socket server.
+-- We retry if there is any error during the sending.
+-- We run a 'delayed timer' in case no call is received for a while to still flush
+-- the buffer and have 'real-time' analytics.
+--
+-- @see alf_serializer.lua
+-- @see handler.lua
 
 local json = require "cjson"
 local http = require "resty_http"
 
+local MB = 1024 * 1024
+local MAX_BUFFER_SIZE = 1 * MB
 local EMPTY_ARRAY_PLACEHOLDER = "__empty_array_placeholder__"
+-- Mashape Analytics socket server properties
 local ANALYTICS_SOCKET = {
   host = "socket.analytics.mashape.com",
   port = 80,
@@ -15,53 +31,128 @@ local ANALYTICS_SOCKET = {
 local buffer_mt = {}
 buffer_mt.__index = buffer_mt
 
-function buffer_mt:add_alf(alf)
-  table.insert(self.alfs, alf)
-  return table.getn(self.alfs)
-end
-
-function buffer_mt:to_json_string()
-  local str = json.encode(self.to_send)
-  return str:gsub("\""..EMPTY_ARRAY_PLACEHOLDER.."\"", ""):gsub("\\/", "/")
-end
-
-function buffer_mt:flush_entries()
-  for _, alf in ipairs(self.alfs) do
-    table.insert(self.to_send, alf)
+-- A handler for delayed batch sending. When no call has been made for X seconds
+-- (X being conf.delay), we send the batch to keep analytics as close to real-time
+-- as possible.
+local delayed_send_handler
+delayed_send_handler = function(premature, buffer)
+  if ngx.now() - buffer.latest_call < buffer.AUTO_FLUSH_DELAY then
+    -- If the latest call was received during the wait delay, abort the delayed send and
+    -- report it for X more seconds.
+    local ok, err = ngx.timer.at(buffer.AUTO_FLUSH_DELAY, delayed_send_handler, buffer)
+    if not ok then
+      buffer.lock_delayed = false -- re-enable creation of a delayed-timer for this buffer
+      ngx.log(ngx.ERR, "[mashape-analytics] failed to create delayed batch sending timer: ", err)
+    end
+  else
+    -- Buffer is not full but it's been too long without an API call, let's flush it
+    -- and send the data to analytics.
+    buffer:flush()
+    buffer.lock_delayed = false
+    buffer.send_batch(nil, buffer)
   end
-
-  self.alfs = {}
 end
 
-function buffer_mt.new()
+-- Instanciate a new buffer with configuration and properties
+function buffer_mt.new(conf)
   local buffer = {
-    alfs = {},
-    sending = false,
-    delayed = false,
-    latest_call = nil, -- stub
-    to_send = {}
+    MAX_ENTRIES = conf.batch_size,
+    MAX_SIZE = MAX_BUFFER_SIZE,
+    AUTO_FLUSH_DELAY = conf.delay,
+    entries = {}, -- current buffer as an array of strings (serialized ALFs)
+    entries_size = 0, -- current buffer size in bytes
+    sending_queue = {}, -- array of constructed payloads (batches of ALFs) to be sent
+    lock_sending = false, -- lock if currently sending its data
+    lock_delayed = false, -- lock if a delayed timer is already set for this buffer
+    latest_call = nil -- date at which a request was last made to this API (for delayed timer)
   }
   return setmetatable(buffer, buffer_mt)
 end
 
-function buffer_mt.send_batch(premature, self)
-  if self.sending then return end
-  self.sending = true -- simple lock
+-- Add an ALF (already serialized) to the buffer
+-- If the buffer is full (max entries or size in bytes), convert the buffer
+-- to a JSON payload and place it in an array to be sent, then trigger a sending.
+-- If the buffer is not full, start a delayed timer in case no call is received
+-- for a while.
+function buffer_mt:add_alf(alf)
+  -- Keep track of the latest call for the delayed timer
+  self.latest_call = ngx.now()
 
-  -- Put ALFs in `to_send`
-  self:flush_entries()
-  if table.getn(self.to_send) < 1 then
+  local str = json.encode(alf)
+  str = str:gsub("\""..EMPTY_ARRAY_PLACEHOLDER.."\"", ""):gsub("\\/", "/")
+
+  -- Check what would be the size of the buffer
+  local next_n_entries = #self.entries + 1
+  local alf_size = string.len(str)
+
+  -- If size or entries exceed the max limits
+  local full = next_n_entries > self.MAX_ENTRIES or self:get_size() > self.MAX_SIZE
+  if full then
+    self:flush()
+    -- Batch size reached, let's send the data
+    local ok, err = ngx.timer.at(0, self.send_batch, self)
+    if not ok then
+      ngx.log(ngx.ERR, "[mashape-analytics] failed to create batch sending timer: ", err)
+    end
+  elseif not self.lock_delayed then
+    -- Batch size not yet reached.
+    -- Set a timer sending the data only in case nothing happens for awhile or if the batch_size is taking
+    -- too much time to reach the limit and trigger the flush.
+    local ok, err = ngx.timer.at(self.AUTO_FLUSH_DELAY, delayed_send_handler, self)
+    if ok then
+      self.lock_delayed = true -- Make sure only one delayed timer is ever pending for a given buffer
+    else
+      ngx.log(ngx.ERR, "[mashape-analytics] failed to create delayed batch sending timer: ", err)
+    end
+  end
+
+  -- Insert in entries
+  table.insert(self.entries, str)
+  -- Update current buffer size
+  self.entries_size = self.entries_size + alf_size
+end
+
+-- Build a JSON payload of the current buffer.
+function buffer_mt:payload_string()
+  return "["..table.concat(self.entries, ",").."]"
+end
+
+-- Get the size of the current buffer if it was to be converted to a JSON payload
+function buffer_mt:get_size()
+  local commas = string.rep(",", #self.entries - 1)
+  return string.len(commas.."[]") + self.entries_size
+end
+
+-- Flush the buffer
+-- 1. Convert the content of it into a JSON payload
+-- 2. Add the payload to the queue of payloads to be sent
+-- 3. Empty the buffer and reset the current buffer size
+function buffer_mt:flush()
+  local payload = self:payload_string()
+  table.insert(self.sending_queue, payload)
+  self.entries = {}
+  self.entries_size = 0
+end
+
+-- Send the oldest payload (batch of ALFs) from the queue to the socket server.
+-- The payload will be removed if the socket server acknowledged the batch.
+-- If the queue still has payloads to be sent, keep on sending them.
+function buffer_mt.send_batch(premature, self)
+  if self.lock_sending then return end
+  self.lock_sending = true -- simple lock
+
+  if table.getn(self.sending_queue) < 1 then
     return
   end
 
-  local message = self:to_json_string()
+  -- Let's send the oldest payload in our buffer
+  local message = self.sending_queue[1]
 
-  local ok, err
   local batch_saved = false
   local client = http:new()
   client:set_timeout(50000) -- 5 sec
 
-  ok, err = client:connect(ANALYTICS_SOCKET.host, ANALYTICS_SOCKET.port)
+  local ok, err = client:connect(ANALYTICS_SOCKET.host, ANALYTICS_SOCKET.port)
   if ok then
     local res, err = client:request({path = ANALYTICS_SOCKET.path, body = message})
     if not res then
@@ -87,15 +178,19 @@ function buffer_mt.send_batch(premature, self)
   end
 
   if batch_saved then
-    self.to_send = {}
-  else
+    -- Remove the payload that was sent
+    table.remove(self.sending_queue, 1)
+  end
+
+  self.lock_sending = false
+
+  -- Keep sendind data if the buffer is not yet emptied
+  if #self.sending_queue > 0 then
     local ok, err = ngx.timer.at(0, self.send_batch, self)
     if not ok then
       ngx.log(ngx.ERR, "[mashape-analytics] failed to create batch retry timer: ", err)
     end
   end
-
-  self.sending = false
 end
 
 return buffer_mt

--- a/kong/plugins/mashape-analytics/buffer.lua
+++ b/kong/plugins/mashape-analytics/buffer.lua
@@ -1,0 +1,101 @@
+-- ALF buffer module
+-- This module contains a buffered array of ALF objects to be sent to the upstream
+-- Mashape Analytics socket server.
+
+local json = require "cjson"
+local http = require "resty_http"
+
+local EMPTY_ARRAY_PLACEHOLDER = "__empty_array_placeholder__"
+local ANALYTICS_SOCKET = {
+  host = "socket.analytics.mashape.com",
+  port = 80,
+  path = "/1.0.0/batch"
+}
+
+local buffer_mt = {}
+buffer_mt.__index = buffer_mt
+
+function buffer_mt:add_alf(alf)
+  table.insert(self.alfs, alf)
+  return table.getn(self.alfs)
+end
+
+function buffer_mt:to_json_string()
+  local str = json.encode(self.to_send)
+  return str:gsub("\""..EMPTY_ARRAY_PLACEHOLDER.."\"", ""):gsub("\\/", "/")
+end
+
+function buffer_mt:flush_entries()
+  for _, alf in ipairs(self.alfs) do
+    table.insert(self.to_send, alf)
+  end
+
+  self.alfs = {}
+end
+
+function buffer_mt.new()
+  local buffer = {
+    alfs = {},
+    sending = false,
+    delayed = false,
+    latest_call = nil, -- stub
+    to_send = {}
+  }
+  return setmetatable(buffer, buffer_mt)
+end
+
+function buffer_mt.send_batch(premature, self)
+  if self.sending then return end
+  self.sending = true -- simple lock
+
+  -- Put ALFs in `to_send`
+  self:flush_entries()
+  if table.getn(self.to_send) < 1 then
+    return
+  end
+
+  local message = self:to_json_string()
+
+  local ok, err
+  local batch_saved = false
+  local client = http:new()
+  client:set_timeout(50000) -- 5 sec
+
+  ok, err = client:connect(ANALYTICS_SOCKET.host, ANALYTICS_SOCKET.port)
+  if ok then
+    local res, err = client:request({path = ANALYTICS_SOCKET.path, body = message})
+    if not res then
+      ngx.log(ngx.ERR, "[mashape-analytics] failed to send batch: "..err)
+    elseif res.status == 200 then
+      batch_saved = true
+      ngx.log(ngx.DEBUG, string.format("[mashape-analytics] successfully saved the batch. (%s)", res.body))
+    else
+      ngx.log(ngx.ERR, string.format("[mashape-analytics] socket server refused the batch. Status: (%s) Error: (%s)", res.status, res.body))
+    end
+
+    -- close connection, or put it into the connection pool
+    if not res or res.headers["connection"] == "close" then
+      ok, err = client:close()
+      if not ok then
+        ngx.log(ngx.ERR, "[mashape-analytics] failed to close socket: "..err)
+      end
+    else
+      client:set_keepalive()
+    end
+  else
+    ngx.log(ngx.ERR, "[mashape-analytics] failed to connect to the socket server: "..err)
+  end
+
+  if batch_saved then
+    self.to_send = {}
+  else
+    local ok, err = ngx.timer.at(0, self.send_batch, self)
+    if not ok then
+      ngx.log(ngx.ERR, "[mashape-analytics] failed to create batch retry timer: ", err)
+    end
+  end
+
+  self.sending = false
+end
+
+return buffer_mt

--- a/kong/plugins/mashape-analytics/handler.lua
+++ b/kong/plugins/mashape-analytics/handler.lua
@@ -2,45 +2,23 @@
 --
 -- How it works:
 -- Keep track of calls made to configured APIs on a per-worker basis, using the ALF format
--- (alf_serializer.lua). `:access()` and `:body_filter()` are implemented to record some properties
+-- (alf_serializer.lua) and per-API buffers. `:access()` and `:body_filter()` are implemented to record some properties
 -- required for the ALF entry.
 --
--- When the buffer is full (it reaches the `batch_size` configuration value), send the batch to the server.
--- If the server doesn't accept it, don't flush the data and it'll try again at the next call.
--- If the server accepted the batch, flush the buffer.
+-- When an API buffer is full (it reaches the `batch_size` configuration value or the maximum payload size), send the batch to the server.
 --
 -- In order to keep Analytics as real-time as possible, we also start a 'delayed timer' running in background.
 -- If no requests are made during a certain period of time (the `delay` configuration value), the
 -- delayed timer will fire and send the batch + flush the data, not waiting for the buffer to be full.
+--
+-- @see alf_serializer.lua
+-- @see buffer.lua
 
 local ALFBuffer = require "kong.plugins.mashape-analytics.buffer"
 local BasePlugin = require "kong.plugins.base_plugin"
 local ALFSerializer = require "kong.plugins.log_serializers.alf"
 
 local ALF_BUFFERS = {} -- buffers per-api
-
--- A handler for delayed batch sending. When no call have been made for X seconds
--- (X being conf.delay), we send the batch to keep analytics as close to real-time
--- as possible.
-local delayed_send_handler
-delayed_send_handler = function(premature, conf, buffer)
-  -- If the latest call was received during the wait delay, abort the delayed send and
-  -- report it for X more seconds.
-  if ngx.now() - buffer.latest_call < conf.delay then
-    local ok, err = ngx.timer.at(conf.delay, delayed_send_handler, conf, buffer)
-    if not ok then
-      buffer.delayed = false -- re-enable creation of a delayed-timer for this buffer
-      ngx.log(ngx.ERR, "[mashape-analytics] failed to create delayed batch sending timer: ", err)
-    end
-  else
-    buffer.delayed = false
-    buffer.send_batch(nil, buffer)
-  end
-end
-
---
---
---
 
 local AnalyticsHandler = BasePlugin:extend()
 
@@ -84,7 +62,7 @@ function AnalyticsHandler:log(conf)
 
   -- Create the ALF buffer if not existing for this API
   if not ALF_BUFFERS[api_id] then
-    ALF_BUFFERS[api_id] = ALFBuffer.new()
+    ALF_BUFFERS[api_id] = ALFBuffer.new(conf)
   end
 
   local buffer = ALF_BUFFERS[api_id]
@@ -92,29 +70,8 @@ function AnalyticsHandler:log(conf)
   -- Creating the ALF
   local alf = ALFSerializer.new_alf(ngx, conf.service_token, conf.environment)
 
-  -- Simply adding the ALF to the buffer
-  local buffer_size = buffer:add_alf(alf)
-
-  -- Keep track of the latest call for the delayed timer
-  buffer.latest_call = ngx.now()
-
-  if buffer_size >= conf.batch_size then
-    -- Batch size reached, let's send the data
-    local ok, err = ngx.timer.at(0, buffer.send_batch, buffer)
-    if not ok then
-      ngx.log(ngx.ERR, "[mashape-analytics] failed to create batch sending timer: ", err)
-    end
-  elseif not buffer.delayed then
-    -- Batch size not yet reached.
-    -- Set a timer sending the data only in case nothing happens for awhile or if the batch_size is taking
-    -- too much time to reach the limit and trigger the flush.
-    local ok, err = ngx.timer.at(conf.delay, delayed_send_handler, conf, buffer)
-    if ok then
-      buffer.delayed = true -- Make sure only one delayed timer is ever pending for a given buffer
-    else
-      ngx.log(ngx.ERR, "[mashape-analytics] failed to create delayed batch sending timer: ", err)
-    end
-  end
+  -- Simply adding the ALF to the buffer, it will decide if it is necessary to flush itself
+  buffer:add_alf(alf)
 end
 
 return AnalyticsHandler

--- a/kong/plugins/mashape-analytics/handler.lua
+++ b/kong/plugins/mashape-analytics/handler.lua
@@ -69,9 +69,10 @@ function AnalyticsHandler:log(conf)
 
   -- Creating the ALF
   local alf = ALFSerializer.new_alf(ngx, conf.service_token, conf.environment)
-
-  -- Simply adding the ALF to the buffer, it will decide if it is necessary to flush itself
-  buffer:add_alf(alf)
+  if alf then
+    -- Simply adding the ALF to the buffer, it will decide if it is necessary to flush itself
+    buffer:add_alf(alf)
+  end
 end
 
 return AnalyticsHandler

--- a/kong/plugins/mashape-analytics/schema.lua
+++ b/kong/plugins/mashape-analytics/schema.lua
@@ -4,6 +4,6 @@ return {
     environment = { type = "string" },
     batch_size = { type = "number", default = 100 },
     log_body = { type = "boolean", default = false },
-    delay = { type = "number", default = 10 }
+    delay = { type = "number", default = 2 }
   }
 }

--- a/kong/tools/ngx_stub.lua
+++ b/kong/tools/ngx_stub.lua
@@ -10,7 +10,11 @@ _G.ngx = {
   say = function() end,
   log = function() end,
   socket = { tcp = {} },
+  now = function() return os.time() end,
   time = function() return os.time() end,
+  timer = {
+    at = function() end
+  },
   re = {
     match = reg.match
   },

--- a/spec/plugins/mashape-analytics/alf_serializer_spec.lua
+++ b/spec/plugins/mashape-analytics/alf_serializer_spec.lua
@@ -107,7 +107,7 @@ describe("ALF serializer", function()
       alf:add_entry(fixtures.MULTIPLE_UPSTREAMS.NGX_STUB)
       assert.equal(3, table.getn(alf.har.log.entries))
       assert.are.sameEntry(fixtures.MULTIPLE_UPSTREAMS.ENTRY, alf.har.log.entries[3])
-      assert.equal(123, alf.har.log.entries[3].timings.wait)
+      assert.equal(60468, alf.har.log.entries[3].timings.wait)
     end)
 
   end)

--- a/spec/plugins/mashape-analytics/alf_serializer_spec.lua
+++ b/spec/plugins/mashape-analytics/alf_serializer_spec.lua
@@ -68,8 +68,7 @@ describe("ALF serializer", function()
         har = {
           log = {
             version = "1.2",
-            creator = { name = "mashape-analytics-agent-kong", version = "1.0.0"
-            },
+            creator = {name = "mashape-analytics-agent-kong", version = "1.0.0"},
             entries = {}
           }
         }
@@ -102,6 +101,13 @@ describe("ALF serializer", function()
     it("#new_alf() should instanciate a new ALF that has nothing to do with the existing one", function()
       local other_alf = ALFSerializer:new_alf()
       assert.are_not_same(alf, other_alf)
+    end)
+
+    it("should handle timing calculation if multiple upstreams were called", function()
+      alf:add_entry(fixtures.MULTIPLE_UPSTREAMS.NGX_STUB)
+      assert.equal(3, table.getn(alf.har.log.entries))
+      assert.are.sameEntry(fixtures.MULTIPLE_UPSTREAMS.ENTRY, alf.har.log.entries[3])
+      assert.equal(123, alf.har.log.entries[3].timings.wait)
     end)
 
   end)

--- a/spec/plugins/mashape-analytics/alf_serializer_spec.lua
+++ b/spec/plugins/mashape-analytics/alf_serializer_spec.lua
@@ -55,90 +55,48 @@ say:set("assertion.sameEntry.negative", "Not the same entries")
 assert:register("assertion", "sameEntry", sameEntry, "assertion.sameEntry.positive", "assertion.sameEntry.negative")
 
 describe("ALF serializer", function()
-
-  local alf
-
-  describe("#new_alf()", function ()
-
-    it("should create a new ALF", function()
-      alf = ALFSerializer:new_alf()
-      assert.same({
-        version = "1.0.0",
-        serviceToken = "",
-        har = {
-          log = {
-            version = "1.2",
-            creator = {name = "mashape-analytics-agent-kong", version = "1.0.0"},
-            entries = {}
-          }
-        }
-      }, alf)
-    end)
-
-  end)
-
   describe("#serialize_entry()", function()
-
     it("should serialize an ngx GET request/response", function()
-      local entry = alf:serialize_entry(fixtures.GET.NGX_STUB)
+      local entry = ALFSerializer.serialize_entry(fixtures.GET.NGX_STUB)
       assert.are.sameEntry(fixtures.GET.ENTRY, entry)
     end)
 
-  end)
-
-  describe("#add_entry()", function()
-
-    it("should add the entry to the serializer entries property", function()
-      alf:add_entry(fixtures.GET.NGX_STUB)
-      assert.equal(1, table.getn(alf.har.log.entries))
-      assert.are.sameEntry(fixtures.GET.ENTRY, alf.har.log.entries[1])
-
-      alf:add_entry(fixtures.GET.NGX_STUB)
-      assert.equal(2, table.getn(alf.har.log.entries))
-      assert.are.sameEntry(fixtures.GET.ENTRY, alf.har.log.entries[2])
-    end)
-
-    it("#new_alf() should instanciate a new ALF that has nothing to do with the existing one", function()
-      local other_alf = ALFSerializer:new_alf()
-      assert.are_not_same(alf, other_alf)
-    end)
-
     it("should handle timing calculation if multiple upstreams were called", function()
-      alf:add_entry(fixtures.MULTIPLE_UPSTREAMS.NGX_STUB)
-      assert.equal(3, table.getn(alf.har.log.entries))
-      assert.are.sameEntry(fixtures.MULTIPLE_UPSTREAMS.ENTRY, alf.har.log.entries[3])
-      assert.equal(60468, alf.har.log.entries[3].timings.wait)
-    end)
-
-  end)
-
-  describe("#to_json_string()", function()
-
-    it("should throw an error if no token was given", function()
-      assert.has_error(function() alf:to_json_string() end,
-        "Mashape Analytics serviceToken required")
-    end)
-
-    it("should return a JSON string", function()
-      local json_str = alf:to_json_string("stub_service_token")
-      assert.equal("string", type(json_str))
-    end)
-
-    it("should add an environment property", function()
-      local json = require "cjson"
-      local json_str = alf:to_json_string("stub_service_token", "test")
-      assert.equal("string", type(json_str))
-      local json_alf = json.decode(json_str)
-      assert.equal(json_alf.environment, "test")
+      local entry = ALFSerializer.serialize_entry(fixtures.MULTIPLE_UPSTREAMS.NGX_STUB)
+      assert.are.sameEntry(fixtures.MULTIPLE_UPSTREAMS.ENTRY, entry)
+      assert.equal(60468, entry.timings.wait)
     end)
   end)
 
-  describe("#flush_entries()", function()
+  describe("#new_alf()", function ()
+    it("should require some parameters", function()
+      assert.has_error(function()
+        ALFSerializer.new_alf()
+      end, "Missing ngx context")
 
-    it("should remove any existing entry", function()
-      alf:flush_entries()
-      assert.equal(0, table.getn(alf.har.log.entries))
+      assert.has_error(function()
+        ALFSerializer.new_alf({})
+      end, "Mashape Analytics serviceToken required")
     end)
-
+    it("should return an ALF with one entry", function()
+      local alf = ALFSerializer.new_alf(fixtures.GET.NGX_STUB, "123456")
+      assert.truthy(alf)
+      assert.equal("1.0.0", alf.version)
+      assert.equal("123456", alf.serviceToken)
+      assert.equal("127.0.0.1", alf.clientIPAddress)
+      assert.falsy(alf.environment)
+      assert.truthy(alf.har)
+      assert.truthy(alf.har.log)
+      assert.equal("1.2", alf.har.log.version)
+      assert.truthy(alf.har.log.creator)
+      assert.equal("mashape-analytics-agent-kong", alf.har.log.creator.name)
+      assert.equal("1.0.1", alf.har.log.creator.version)
+      assert.truthy(alf.har.log.entries)
+      assert.equal(1, #(alf.har.log.entries))
+    end)
+    it("should accept an environment parameter", function()
+      local alf = ALFSerializer.new_alf(fixtures.GET.NGX_STUB, "123456", "test")
+      assert.equal("test", alf.environment)
+    end)
   end)
 end)

--- a/spec/plugins/mashape-analytics/buffer_spec.lua
+++ b/spec/plugins/mashape-analytics/buffer_spec.lua
@@ -1,31 +1,76 @@
 require "kong.tools.ngx_stub"
 
 local ALFBuffer = require "kong.plugins.mashape-analytics.buffer"
+local json = require "cjson"
 
-local ALF_STUB = {}
+local ALF_STUB = {hello = "world"}
+local CONF_STUB = {
+  batch_size = 100,
+  delay = 2
+}
+local str = json.encode(ALF_STUB)
+local STUB_LEN = string.len(str)
 
 describe("ALFBuffer", function()
   local alf_buffer
 
   it("should create a new buffer", function()
-    alf_buffer = ALFBuffer.new()
+    alf_buffer = ALFBuffer.new(CONF_STUB)
     assert.truthy(alf_buffer)
+    assert.equal(100, alf_buffer.MAX_ENTRIES)
+    assert.equal(2, alf_buffer.AUTO_FLUSH_DELAY)
   end)
 
-  it("should be possible to add an ALF to it", function()
-    local n = alf_buffer:add_alf(ALF_STUB)
-    assert.equal(1, n)
-
-    for i = 1, 100 do
+  describe(":add_alf()", function()
+    it("should be possible to add an ALF to it", function()
+      local buffer = ALFBuffer.new(CONF_STUB)
+      buffer:add_alf(ALF_STUB)
+      assert.equal(1, #buffer.entries)
+    end)
+    it("should compute and update the current buffer size in bytes", function()
       alf_buffer:add_alf(ALF_STUB)
-    end
+      assert.equal(STUB_LEN, alf_buffer.entries_size)
 
-    assert.equal(101, #alf_buffer.alfs)
-  end)
+      -- Add 50 objects
+      for i = 1, 50 do
+        alf_buffer:add_alf(ALF_STUB)
+      end
+      assert.equal(51 * STUB_LEN, alf_buffer.entries_size)
+    end)
+    describe(":get_size()", function()
+      it("should return the hypothetical size of what the payload should be", function()
+        local comma_size = string.len(",")
+        local total_comma_size = 50 * comma_size -- 51 - 1 commas
+        local braces_size = string.len("[]")
+        local entries_size = alf_buffer.entries_size
 
-  it("should flush entries to the `to_send` buffer", function()
-    alf_buffer:flush_entries()
-    assert.equal(0, #alf_buffer.alfs)
-    assert.equal(101, #alf_buffer.to_send)
+        assert.equal(entries_size + total_comma_size + braces_size, alf_buffer:get_size())
+      end)
+    end)
+    it("should call :flush() when reaching its n entries limit", function()
+      local s = spy.on(alf_buffer, "flush")
+
+      -- Add 49 more entries
+      for i = 1, 49 do
+        alf_buffer:add_alf(ALF_STUB)
+      end
+
+      assert.spy(s).was_not.called()
+      -- One more to go over the limit
+      alf_buffer:add_alf(ALF_STUB)
+      assert.spy(s).was.called()
+
+      finally(function()
+        alf_buffer.flush:revert()
+      end)
+    end)
+    describe(":flush()", function()
+      it("should have emptied the current buffer and added a payload to be sent", function()
+        assert.equal(1, #alf_buffer.entries)
+        assert.equal(1, #alf_buffer.sending_queue)
+        assert.equal("string", type(alf_buffer.sending_queue[1]))
+        assert.equal(STUB_LEN, alf_buffer.entries_size)
+      end)
+    end)
   end)
 end)

--- a/spec/plugins/mashape-analytics/buffer_spec.lua
+++ b/spec/plugins/mashape-analytics/buffer_spec.lua
@@ -1,0 +1,31 @@
+require "kong.tools.ngx_stub"
+
+local ALFBuffer = require "kong.plugins.mashape-analytics.buffer"
+
+local ALF_STUB = {}
+
+describe("ALFBuffer", function()
+  local alf_buffer
+
+  it("should create a new buffer", function()
+    alf_buffer = ALFBuffer.new()
+    assert.truthy(alf_buffer)
+  end)
+
+  it("should be possible to add an ALF to it", function()
+    local n = alf_buffer:add_alf(ALF_STUB)
+    assert.equal(1, n)
+
+    for i = 1, 100 do
+      alf_buffer:add_alf(ALF_STUB)
+    end
+
+    assert.equal(101, #alf_buffer.alfs)
+  end)
+
+  it("should flush entries to the `to_send` buffer", function()
+    alf_buffer:flush_entries()
+    assert.equal(0, #alf_buffer.alfs)
+    assert.equal(101, #alf_buffer.to_send)
+  end)
+end)

--- a/spec/plugins/mashape-analytics/fixtures/requests.lua
+++ b/spec/plugins/mashape-analytics/fixtures/requests.lua
@@ -173,7 +173,7 @@ return {
         statusText = ""
       },
       startedDateTime = "2015-05-28T20:22:51Z",
-      time = 219,
+      time = 60564,
       timings = {
         blocked = -1,
         connect = -1,
@@ -181,7 +181,7 @@ return {
         receive = 0,
         send = 96,
         ssl = -1,
-        wait = 123
+        wait = 60468
       }
     }
   }

--- a/spec/plugins/mashape-analytics/fixtures/requests.lua
+++ b/spec/plugins/mashape-analytics/fixtures/requests.lua
@@ -7,12 +7,12 @@ return {
         start_time = function() return 1432844571.623 end,
         get_method = function() return "GET" end,
         http_version = function() return 1.1 end,
-        get_headers = function() return {["Accept"]="/*/",["Host"]="mockbin.com"} end,
-        get_uri_args = function() return {["hello"]="world",["foo"]="bar"} end,
-        get_post_args = function() return {["hello"]={"world", "earth"}} end
+        get_headers = function() return {["Accept"] = "/*/", ["Host"] = "mockbin.com"} end,
+        get_uri_args = function() return {["hello"] = "world", ["foo"] = "bar"} end,
+        get_post_args = function() return {["hello"] = {"world", "earth"}} end
       },
       resp = {
-        get_headers = function() return {["Connection"]="close",["Content-Type"]="application/json",["Content-Length"]="934"} end
+        get_headers = function() return {["Connection"] = "close", ["Content-Type"] = "application/json", ["Content-Length"] = "934"} end
       },
       status = 200,
       var = {
@@ -41,8 +41,8 @@ return {
         bodySize = 23,
         cookies = {EMPTY_ARRAY_PLACEHOLDER},
         headers = {
-          { name = "Accept", value = "/*/"},
-          { name = "Host", value = "mockbin.com" }
+          {name = "Accept", value = "/*/"},
+          {name = "Host", value = "mockbin.com"}
         },
         headersSize = 24,
         httpVersion = "HTTP/1.1",
@@ -50,14 +50,14 @@ return {
         postData = {
           mimeType = "application/octet-stream",
           params = {
-            { name = "hello", value = "world" },
-            { name = "hello", value = "earth" }
+            {name = "hello", value = "world"},
+            {name = "hello", value = "earth"}
           },
           text = "hello=world&hello=earth"
         },
         queryString = {
-          { name = "foo", value = "bar" },
-          { name = "hello", value = "world" }
+          {name = "foo", value = "bar"},
+          {name = "hello", value = "world"}
         },
         url = "http://mockbin.com/request"
       },
@@ -70,9 +70,9 @@ return {
         },
         cookies = {EMPTY_ARRAY_PLACEHOLDER},
         headers = {
-          { name = "Content-Length", value = "934" },
-          { name = "Content-Type", value = "application/json" },
-          { name = "Connection", value = "close" }
+          {name = "Content-Length", value = "934"},
+          {name = "Content-Type", value = "application/json"},
+          {name = "Connection", value = "close"}
         },
         headersSize = 60,
         httpVersion = "",
@@ -90,6 +90,98 @@ return {
         send = 96,
         ssl = -1,
         wait = 391
+      }
+    }
+  },
+  ["MULTIPLE_UPSTREAMS"] = {
+    ["NGX_STUB"] = {
+      req = {
+        start_time = function() return 1432844571.623 end,
+        get_method = function() return "GET" end,
+        http_version = function() return 1.1 end,
+        get_headers = function() return {["Accept"] = "/*/", ["Host"] = "mockbin.com"} end,
+        get_uri_args = function() return {["hello"] = "world", ["foo"] = "bar"} end,
+        get_post_args = function() return {["hello"] = {"world", "earth"}} end
+      },
+      resp = {
+        get_headers = function() return {["Connection"] = "close", ["Content-Type"] = "application/json", ["Content-Length"] = "934"} end
+      },
+      status = 200,
+      var = {
+        scheme = "http",
+        host = "mockbin.com",
+        uri = "/request",
+        request_length = 123,
+        body_bytes_sent = 934,
+        remote_addr = "127.0.0.1",
+        upstream_response_time = "60.345, 0.123"
+      },
+      ctx = {
+        proxy_started_at = 1432844571719,
+        proxy_ended_at = 143284457211,
+        analytics = {
+          req_body = "hello=world&hello=earth",
+          res_body = "{\"message\":\"response body\"}",
+          response_received = 143284457211
+        }
+      }
+    },
+    ["ENTRY"] = {
+      cache = {},
+      clientIPAddress = "127.0.0.1",
+      request = {
+        bodySize = 23,
+        cookies = {EMPTY_ARRAY_PLACEHOLDER},
+        headers = {
+          {name = "Accept", value = "/*/"},
+          {name = "Host", value = "mockbin.com"}
+        },
+        headersSize = 24,
+        httpVersion = "HTTP/1.1",
+        method = "GET",
+        postData = {
+          mimeType = "application/octet-stream",
+          params = {
+            {name = "hello", value = "world"},
+            {name = "hello", value = "earth"}
+          },
+          text = "hello=world&hello=earth"
+        },
+        queryString = {
+          {name = "foo", value = "bar"},
+          {name = "hello", value = "world"}
+        },
+        url = "http://mockbin.com/request"
+      },
+      response = {
+        bodySize = 934,
+        content = {
+          mimeType = "application/json",
+          size = 934,
+          text = "{\"message\":\"response body\"}"
+        },
+        cookies = {EMPTY_ARRAY_PLACEHOLDER},
+        headers = {
+          {name = "Content-Length", value = "934"},
+          {name = "Content-Type", value = "application/json"},
+          {name = "Connection", value = "close"}
+        },
+        headersSize = 60,
+        httpVersion = "",
+        redirectURL = "",
+        status = 200,
+        statusText = ""
+      },
+      startedDateTime = "2015-05-28T20:22:51Z",
+      time = 219,
+      timings = {
+        blocked = -1,
+        connect = -1,
+        dns = -1,
+        receive = 0,
+        send = 96,
+        ssl = -1,
+        wait = 123
       }
     }
   }

--- a/spec/plugins/mashape-analytics/fixtures/requests.lua
+++ b/spec/plugins/mashape-analytics/fixtures/requests.lua
@@ -36,7 +36,6 @@ return {
     },
     ["ENTRY"] = {
       cache = {},
-      clientIPAddress = "127.0.0.1",
       request = {
         bodySize = 23,
         cookies = {EMPTY_ARRAY_PLACEHOLDER},
@@ -128,7 +127,6 @@ return {
     },
     ["ENTRY"] = {
       cache = {},
-      clientIPAddress = "127.0.0.1",
       request = {
         bodySize = 23,
         cookies = {EMPTY_ARRAY_PLACEHOLDER},


### PR DESCRIPTION
Addressing various issues reported in #423

- more descriptive logging in error.log
- clientIPAddress #424
- fix an issue when `log_body` was true but the request had no body (GET
  request for example)
- fix an issue when nginx is retrying against upstream after a timeout
  and resulting in multiple `upstream_response_time` values
- more robust buffering (payload size and better flushing)
- don't buffer aborted requests (refused by analytics anyways)