### PR TITLE
docs(readme) add related git repos and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@
 [![Gitter Badge][gitter-badge]][gitter-url]
 
 - Website: [getkong.org][kong-url]
-- Docs: [getkong.org/docs][kong-docs]
+- Documentation: [getkong.org/docs][kong-docs]
 - Mailing List: [Google Groups][google-groups-url]
 
 [![][kong-logo]][kong-url]
 
 Kong was created to secure, manage and extend Microservices & APIs. Kong is powered by the battle-tested tech of **NGINX** and Cassandra with a focus on scalability, high performance & reliability. Kong runs in production at [Mashape][mashape-url] handling billions of requests to over ten thousand APIs.
 
-## Core Features
+## Summary
+
+- [**Feature**](#features)
+- [**Why Kong?**](#why-kong?)
+- [**Benchmarks**](#benchmarks)
+- [**Ressources**](#ressources)
+- [**Roadmap**](#roadmap)
+- [**Development**](#development)
+- [**Enterprise Support**](#enterprise-support)
+
+## Features
 
 - **CLI**: Control your Kong cluster from the command line just like Neo in The Matrix.
 - **REST API**: Kong can be operated with its RESTful API for maximum flexibility.
@@ -31,7 +41,7 @@ Kong was created to secure, manage and extend Microservices & APIs. Kong is powe
   - **CORS**: Enable cross-origin requests to your APIs that would otherwise be blocked.
   - **Anything**: Need custom functionality? Extend Kong with your own Lua plugins!
 
-## Architecture
+## Why Kong?
 
 If you're building for web, mobile or IoT (Internet of Things) you will likely end up needing common functionality on top of your actual software. Kong can help by acting as a gateway for HTTP requests while providing logging, authentication, rate-limiting and more through plugins.
 
@@ -39,44 +49,46 @@ If you're building for web, mobile or IoT (Internet of Things) you will likely e
 
 ## Benchmarks
 
-We set Kong up on AWS and load tested it to get some performance metrics. The setup consisted of three `m3.medium` EC2 instances; one for Kong, one for Cassandra and a third for an upstream API. After adding the upstream API's `target_url` into Kong we load tested from 1 to 2000 concurrent connections. Complete [reproduction instructions](https://gist.github.com/montanaflynn/01376991f0a3ad07059c) are available and we are currently working towards automating a suite of benchmarks to compare against subsequent releases.
+See our [benchmark report](http://getkong.org/about/benchmark/).
 
-Over two minutes **117,185** requests with an average latency of **10ms** at **976 requests a second** or about **84,373,200 requests a day** went through Kong and back with only a single timeout.
+## Ressources
 
-![](http://cl.ly/image/3R171b2U2l3k/Image%202015-06-01%20at%205.00.13%20PM.png)
+Kong comes in many shapes. While this repository contains its core's source code, other repos are also under active development:
+
+- [Kong-Docker](https://github.com/Mashape/docker-kong): A Dockerfile for running Kong in Docker.
+- [Kong-Vagrant](https://github.com/Mashape/kong-vagrant): A Vagrantfile for provisioning a development ready environment for Kong.
+
+## Roadmap
+
+You can find a detailed Roadmap of Kong on the [Wiki](https://github.com/Mashape/kong/wiki).
 
 ## Development
 
-1. [Download](http://getkong.org/download/) the latest released version of Kong, and install it on your development machine. This will install all the required dependencies.
+If you are planning on developping on Kong (writting your own plugin or contribute to the core), you'll need a development installation.
 
-2. Clone the repository and make it your working directory.
+#### Vagrant
 
-3. Run `[sudo] make install`
+You can use a Vagrant box running Kong and Cassandra that you can find at [Mashape/kong-vagrant](https://github.com/Mashape/kong-vagrant).
 
-  This will build and install the `kong` luarock globally.
+#### Source Install
 
-4. Delete the `/etc/kong` folder: `[sudo] rm -rf /etc/kong`
+First, make sure you have downloaded [Cassandra](http://cassandra.apache.org/download/) and that it is running.
 
-  This is necessary to remove the configuration file of the previous Kong installation at step 1.
+```shell
+$ git clone https://github.com/Mashape/kong
+$ cd kong/
 
-5. Run `make dev`
+# Build and install Kong globally using Luarocks, overriding the version previously installed
+$ [sudo] make install
 
-  This will install development dependencies and create your environment configuration files:
+# Install all development dependencies and create your environment configuration files
+$ make dev
 
-  - `kong_TESTS.yml`
-  - `kong_DEVELOPMENT.yml`
+# Finally, run Kong with the just created development configuration
+$ kong start -c kong_DEVELOPMENT.yml
+```
 
-6. Run the tests:
-
-  ```bash
-  make test-all
-  ```
-
-7. Run Kong with the development configuration file:
-
-   ```bash
-   $ kong start -c kong_DEVELOPMENT.yml
-   ```
+The `lua_package_path` directive in the configuration specifies that the Lua code in your local folder will be used in favor of the system installation. The `lua_code_cache` directive being turned off, you can start Kong, edit your local files, and test your code without restarting Kong.
 
 #### Makefile Operations
 
@@ -98,29 +110,12 @@ When developing, use the `Makefile` for doing the following operations:
 | `test-all`    | Run all unit + integration tests at once                                 |
 | `coverage`    | Run all tests + coverage report                                          |
 
-## Documentation
-
-Complete & versioned documentation is available at [GetKong.org][kong-url]:
-
-- [Latest Docs](http://www.getkong.org/docs/)
-- [Installation](http://www.getkong.org/download)
-- [Quick Start](http://getkong.org/docs/latest/getting-started/quickstart/)
-- [Configuration](http://getkong.org/docs/latest/configuration/)
-- [CLI Reference](http://getkong.org/docs/latest/cli/)
-- [API Reference](http://getkong.org/docs/latest/admin-api)
-
-
 ## Enterprise Support
 
-Support, Demo, Training, API Certifications and Consulting available at http://getkong.org/enterprise
-
+Support, Demo, Training, API Certifications and Consulting available at http://getkong.org/enterprise.
 
 [kong-url]: http://getkong.org/
-[kong-website]: https://github.com/Mashape/getkong.org
 [kong-docs]: http://getkong.org/docs/
-
-[kong-contrib]: https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md
-[kong-changelog]: https://github.com/Mashape/kong/blob/master/CHANGELOG.md
 
 [kong-logo]: http://i.imgur.com/4jyQQAZ.png
 [kong-benefits]: http://cl.ly/image/1B3J3b3h1H1c/Image%202015-07-07%20at%206.57.25%20PM.png


### PR DESCRIPTION
* + summary to not get lost
* + roadmap link
* + nicer development instructions
* - remove benchmark taking all the space, put a link to getknog.org/about/benchmark instead
* - redundant "documentation" paragraph