### PR TITLE
[feature/config] remove port option for better usability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,13 @@ test:
 	@busted -v spec/unit
 
 test-integration:
-	@busted spec/integration
+	@busted -v spec/integration
 
 test-plugins:
-	@busted spec/plugins
+	@busted -v spec/plugins
 
 test-all:
-	@busted spec/
+	@busted -v spec/
 
 coverage:
 	@rm -f luacov.*
@@ -68,5 +68,3 @@ coverage:
 	@luacov -c spec/.luacov
 	@tail -n 1 luacov.report.out | awk '{ print $$3 }'
 
-test-all:
-	@busted -v spec/

--- a/kong.yml
+++ b/kong.yml
@@ -35,8 +35,8 @@ database: cassandra
 databases_available:
   cassandra:
     properties:
-      hosts: "localhost"
-      port: 9042
+      hosts:
+        - "localhost:9042"
       timeout: 1000
       keyspace: kong
       keepalive: 60000 # in milliseconds

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -67,7 +67,7 @@ function BaseDao:_open_session(keyspace)
 
   local options = self._factory:get_session_options()
 
-  ok, err = session:connect(self._properties.hosts, self._properties.port, options)
+  ok, err = session:connect(self._properties.hosts, nil, options)
   if not ok then
     return nil, DaoError(err, error_types.DATABASE)
   end

--- a/kong/dao/cassandra/factory.lua
+++ b/kong/dao/cassandra/factory.lua
@@ -108,7 +108,7 @@ function CassandraFactory:prepare()
 
   local options = self:get_session_options()
 
-  local ok, co_err = session:connect(self._properties.hosts, self._properties.port, options)
+  local ok, co_err = session:connect(self._properties.hosts, nil, options)
   session:close()
 
   if not ok then
@@ -137,7 +137,7 @@ function CassandraFactory:execute_queries(queries, no_keyspace)
 
   local options = self:get_session_options()
 
-  ok, err = session:connect(self._properties.hosts, self._properties.port, options)
+  ok, err = session:connect(self._properties.hosts, nil, options)
   if not ok then
     return DaoError(err, constants.DATABASE_ERROR_TYPES.DATABASE)
   end

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -48,7 +48,7 @@ describe("Cassandra", function()
     session = cassandra:new()
     session:set_timeout(configuration.cassandra.timeout)
 
-    local _, err = session:connect(configuration.cassandra.hosts, configuration.cassandra.port)
+    local _, err = session:connect(configuration.cassandra.hosts)
     assert.falsy(err)
 
     local _, err = session:set_keyspace("kong_tests")

--- a/spec/integration/dao/cassandra/factory_spec.lua
+++ b/spec/integration/dao/cassandra/factory_spec.lua
@@ -8,8 +8,7 @@ configuration.cassandra = configuration.databases_available[configuration.databa
 describe(":prepare()", function()
 
   it("should return an error if cannot connect to Cassandra", function()
-    local new_factory = CassandraFactory({ hosts = "127.0.0.1",
-                                           port = 45678,
+    local new_factory = CassandraFactory({ hosts = "127.0.0.1:45678",
                                            timeout = 1000,
                                            keyspace = configuration.cassandra.keyspace
     })

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -75,8 +75,8 @@ database: cassandra
 databases_available:
   cassandra:
     properties:
-      hosts: "localhost"
-      port: 9042
+      hosts:
+        - "localhost:9042"
       timeout: 1000
       keyspace: kong
       keepalive: 60000 # in milliseconds


### PR DESCRIPTION
Since having the `port` option for Cassandra and also providing a way to set ports on a per-node basis, it makes it harder for users to "guess" how to add Cassandra nodes.

This changes the config file to show that `hosts` is an array of `host:port` and can be intuitively modified.

:warning: This is a breaking change since we don't support the `port` option anymore. Will need to be documented properly in `UPDATE.md` even if the steps are very straightforward.