### PR TITLE
Added authenticated_userid to password grant

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -266,7 +266,7 @@ local function issue_token(conf)
           if not ok then
             response_params = scopes -- If it's not ok, then this is the error message
           else
-            response_params = generate_token(conf, client, nil, table.concat(scopes, " "), state)
+            response_params = generate_token(conf, client, parameters.authenticated_userid, table.concat(scopes, " "), state)
           end
         end
       elseif grant_type == GRANT_REFRESH_TOKEN then


### PR DESCRIPTION
The password grant did not save the authenticated_userid before (nil). Without this information the resource server will not be able to perform authorization on the user. 
I'm pretty sure the client credential grant should also try and save the authenticated_userid  if provided, but as I'm not lua guy I would let someone else have a look at that part.