### PR TITLE
add support for gzip response (issue #409)

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -88,6 +88,9 @@ nginx: |
     client_body_timeout 60s;
     send_timeout 60s;
 
+    # gzip
+    gzip on;
+
     # Proxy Settings
     proxy_buffer_size 128k;
     proxy_buffers 4 256k;

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -128,6 +128,9 @@ nginx: |
     client_body_timeout 60s;
     send_timeout 60s;
 
+    # gzip
+    gzip on;
+
     # Proxy Settings
     proxy_buffer_size 128k;
     proxy_buffers 4 256k;


### PR DESCRIPTION
Adds the gzip directive to nginx.conf.
this will enable the gzip module, http://nginx.org/en/docs/http/ngx_http_gzip_module.html.
