### PR TITLE
[fix/api] disabling route path with plugin name

### DIFF
--- a/kong/api/routes/apis.lua
+++ b/kong/api/routes/apis.lua
@@ -58,16 +58,16 @@ return {
     end
   },
 
-  ["/apis/:name_or_id/plugins/:plugin_name_or_id"] = {
+  ["/apis/:name_or_id/plugins/:plugin_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_api_by_name_or_id(self, dao_factory, helpers)
       self.params.api_id = self.api.id
 
       local fetch_keys = {
         api_id = self.api.id,
-        [validations.is_valid_uuid(self.params.plugin_name_or_id) and "id" or "name"] = self.params.plugin_name_or_id
+        id = self.params.plugin_id
       }
-      self.params.plugin_name_or_id = nil
+      self.params.plugin_id = nil
 
       local data, err = dao_factory.plugins_configurations:find_by_keys(fetch_keys)
       if err then

--- a/spec/integration/admin_api/apis_routes_spec.lua
+++ b/spec/integration/admin_api/apis_routes_spec.lua
@@ -345,13 +345,6 @@ describe("Admin API", function()
             assert.same(plugin, body)
           end)
 
-          it("should retrieve by name", function()
-            local response, status = http_client.get(BASE_URL..plugin.name)
-            assert.equal(200, status)
-            local body = json.decode(response)
-            assert.same(plugin, body)
-          end)
-
         end)
 
         describe("PATCH", function()
@@ -362,26 +355,26 @@ describe("Admin API", function()
             local body = json.decode(response)
             assert.same("key_updated", body.value.key_names[1])
 
-            response, status = http_client.patch(BASE_URL..plugin.name, {["value.key_names"]={"key_updated-json"}}, {["content-type"]="application/json"})
+            response, status = http_client.patch(BASE_URL..plugin.id, {["value.key_names"]={"key_updated-json"}}, {["content-type"]="application/json"})
             assert.equal(200, status)
             body = json.decode(response)
             assert.same("key_updated-json", body.value.key_names[1])
           end)
 
           it("[FAILURE] should return proper errors", function()
-            local _, status = http_client.patch(BASE_URL.."hello", {})
+            local _, status = http_client.patch(BASE_URL.."b6cca0aa-4537-11e5-af97-23a06d98af51", {})
             assert.equal(404, status)
           end)
 
           it("should not override a plugin's `value` if partial", function()
             -- This is delicate since a plugin's `value` is a text field in a DB like Cassandra
-            local _, status = http_client.patch(BASE_URL..plugin.name, {
+            local _, status = http_client.patch(BASE_URL..plugin.id, {
               ["value.key_names"] = {"key_set_null_test"},
               ["value.hide_credentials"] = true
             })
             assert.equal(200, status)
 
-            local response, status = http_client.patch(BASE_URL..plugin.name, {
+            local response, status = http_client.patch(BASE_URL..plugin.id, {
               ["value.key_names"] = {"key_set_null_test_updated"}
             })
             assert.equal(200, status)
@@ -395,7 +388,7 @@ describe("Admin API", function()
         describe("DELETE", function()
 
           it("[FAILURE] should return proper errors", function()
-            local _, status = http_client.delete(BASE_URL.."hello")
+            local _, status = http_client.delete(BASE_URL.."b6cca0aa-4537-11e5-af97-23a06d98af51")
             assert.equal(404, status)
           end)
 


### PR DESCRIPTION
The `/apis/{api}/plugins/{plugin}` route cannot have {name_or_id} to select the plugin, because multiple plugins might be added to an API (if targeting different Consumers).