### PR TITLE
[fix/alf-serializer] invalid 'url' property in ALF

### DIFF
--- a/kong/plugins/log_serializers/alf.lua
+++ b/kong/plugins/log_serializers/alf.lua
@@ -120,7 +120,7 @@ function _M.serialize_entry(ngx)
     time = alf_time,
     request = {
       method = ngx.req.get_method(),
-      url = ngx.var.scheme.."://"..ngx.var.host..ngx.var.uri,
+      url = ngx.var.scheme.."://"..ngx.var.host..ngx.var.request_uri,
       httpVersion = "HTTP/"..ngx.req.http_version(),
       queryString = dic_to_array(ngx.req.get_uri_args()),
       headers = alf_req_headers_arr,

--- a/spec/plugins/mashape-analytics/fixtures/requests.lua
+++ b/spec/plugins/mashape-analytics/fixtures/requests.lua
@@ -17,7 +17,7 @@ return {
       var = {
         scheme = "http",
         host = "mockbin.com",
-        uri = "/request",
+        request_uri = "/request",
         request_length = 123,
         body_bytes_sent = 934,
         remote_addr = "127.0.0.1",
@@ -109,7 +109,7 @@ return {
       var = {
         scheme = "http",
         host = "mockbin.com",
-        uri = "/request",
+        request_uri = "/request",
         request_length = 123,
         body_bytes_sent = 934,
         remote_addr = "127.0.0.1",


### PR DESCRIPTION
Fix invalid ALFs when the URI contains reserved characters because
`request_uri` returns an unescaped string. `uri` returns the string
untouched but with querystring, which is fine for HAR.

Fix #470