### PR TITLE
ratelimit plugin: add option to retrieve current rate limit (issue #232)

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -54,6 +54,10 @@ return {
       "day",
       "month",
       "year"
+    },
+    RETRIVE_METRICS = {
+      URI = "/v1/retrive_metrics",
+      NO_LIMIT_VALUE = "unlimited"
     }
   }
 }


### PR DESCRIPTION
adding support to retrieve the current rate limit.
to get json response with current ratelimit, issue an api request to the following path: /v1/retrive_metrics

the request for /v1/retrive_metrics will not count as a request to the upstream server and will not go to the upstream server.

