### PR TITLE
[chore/travis] bump Cassandra version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 
 env:
   global:
-    - CASSANDRA_VERSION=2.1.8
+    - CASSANDRA_VERSION=2.1.9
   matrix:
     - LUA=lua5.1
 


### PR DESCRIPTION
2.1.9 has been released, and 2.1.8 is not available to download
anymore...