### PR TITLE
adds sha1 support for basic auth plugin (issue #33)

### DIFF
--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -1,6 +1,7 @@
 return {
   no_consumer = true,
   fields = {
-    hide_credentials = { type = "boolean", default = false }
+    hide_credentials = { type = "boolean", default = false },
+    encryption_method = { type = "string", default = 'plain' },
   }
 }

--- a/kong/plugins/basic-auth/utils.lua
+++ b/kong/plugins/basic-auth/utils.lua
@@ -1,0 +1,40 @@
+local resty_string = require "resty.string"
+local resty_sha1 = require "resty.sha1"
+
+local string_format = string.format
+
+_M = {}
+
+-- sha1 — Calculate the sha1 hash of a string
+-- @param `string` input string.
+-- @return `string` the sha1 of the given string.
+function _M.sha1(string)
+  local sha1 = resty_sha1:new()
+  if not sha1 then
+    return nil, "failed to create the sha1 object"
+  end
+
+  local ok = sha1:update(string)
+  if not ok then
+    return nil, "failed to add data"
+  end
+
+  local digest = sha1:final()  -- binary digest
+  return resty_string.to_hex(digest)
+end
+
+function _M.salt_credentials(credential)
+  return string_format("%s:%s", credential.password, credential.consumer_id)
+end
+
+-- transformation table for all supported encryption mathods.
+_M.encryption_methods = {
+  plain = function(credential) return credential.password end,
+  sha1 = function(credential)
+    local password_salted = _M.salt_credentials(credential)
+    ngx.log(ngx.ERR, "Dalted: ", password_salted)
+    return _M.sha1(password_salted)
+  end,
+}
+
+return _M

--- a/spec/plugins/basic-auth/api_spec.lua
+++ b/spec/plugins/basic-auth/api_spec.lua
@@ -120,4 +120,40 @@ describe("Basic Auth Credentials API", function()
 
     end)
   end)
+
+  -- test sha1
+  describe("/consumers/:consumer/basic-auth/ sha1", function()
+    local consumer_id = "asd"
+
+    setup(function()
+      local fixtures = spec_helper.insert_fixtures {
+        consumer = {{ username = "john", custom_id = "asdd" }},
+        api = {
+          { name = "basic-auth", inbound_dns = "test1.com", upstream_url = "http://mockbin.com" },
+        },
+        plugin = {
+          { name = "basic-auth", config = { encryption_method = "sha1" },__api = 1 }
+        },
+      }
+
+      consumer = fixtures.consumer[1]
+      BASE_URL = spec_helper.API_URL.."/consumers/john/basic-auth/"
+    end)
+
+    describe("POST", function()
+
+      it("[SUCCESS] should create a basicauth credential with passowrd hashed using sha1", function()
+        local username, password = "john", "1234"
+        local response, status = http_client.post(BASE_URL, { username = username, password = password })
+
+        assert.equal(201, status)
+
+        credential = json.decode(response)
+        assert.equal(username, credential.username)
+        assert.are_not.equal(password, credential.password)
+        assert.equal(40, #credential.password)
+      end)
+    end)
+  end)
+
 end)


### PR DESCRIPTION
**Note:** this code is not ready yet, just wanted to ask some questions related to it.

The code add support for sha1 passowrds.
it adds a configuration key 'encryption_method' that have the following values:
- **plain:** plain passwords .
- **sha1:** sha1 encrypted passwords. password salted with consumer id.

questions:
1. in sha1 as mention in #33, salt the sha1 with consumer id.
i was wondering how it to test: is there a way the i could set consumer id, so that i could test the return sha1 (i could not find one) ? 
2. tests: i have diffrent plugin configuration to test. plain passwords, sha1 passwords.
how can i add and use different configuration for a plugin? should i find a way to remove plugin conf ?
3. what is the preferred way to get plugin configuration in access phase ?

