### PR TITLE
rate limit usage

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -25,6 +25,7 @@ nginx_working_dir: /usr/local/kong/
 proxy_port: 8000
 proxy_ssl_port: 8443
 admin_api_port: 8001
+consumer_api_port: 8002
 
 ## Secondary port configuration
 dnsmasq_port: 8053
@@ -212,4 +213,32 @@ nginx: |
       # Do not remove, additional configuration placeholder for some plugins
       # {{additional_configuration}}
     }
+
+    server {
+      listen {{consumer_api_port}};
+
+      location / {
+        default_type application/json;
+        content_by_lua '
+          ngx.header["Access-Control-Allow-Origin"] = "*"
+          if ngx.req.get_method() == "OPTIONS" then
+            ngx.header["Access-Control-Allow-Methods"] = "GET,HEAD,PUT,PATCH,POST,DELETE"
+            ngx.exit(204)
+          end
+          local lapis = require "lapis"
+          lapis.serve("kong.consumer_api.app")
+        ';
+      }
+
+      location /nginx_status {
+        internal;
+        stub_status;
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+    }
+
   }

--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -5,6 +5,23 @@ local utils = require "kong.tools.utils"
 
 local _M = {}
 
+function _M.find_plugin_conf_by_api_id_and_name(self, dao_factory, helpers)
+  local fetch_keys = {
+    ["api_id"] = self.params.api_id,
+    ["name"] = self.params.name,
+  }
+
+  local data, err = dao_factory.plugins:find_by_keys(fetch_keys)
+  if err then
+    return helpers.yield_error(err)
+  end
+
+  if not data[1] then
+    return helpers.responses.send_HTTP_NOT_FOUND()
+  end
+  self.plugin = data[1]
+end
+
 function _M.find_api_by_name_or_id(self, dao_factory, helpers)
   local fetch_keys = {
     [validations.is_valid_uuid(self.params.name_or_id) and "id" or "name"] = self.params.name_or_id

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -116,6 +116,7 @@ local function prepare_nginx_working_dir(args_config)
     proxy_port = kong_config.proxy_port,
     proxy_ssl_port = kong_config.proxy_ssl_port,
     admin_api_port = kong_config.admin_api_port,
+    consumer_api_port = kong_config.consumer_api_port,
     dns_resolver = "127.0.0.1:"..kong_config.dnsmasq_port,
     memory_cache_size = kong_config.memory_cache_size,
     ssl_cert = ssl_cert_path,
@@ -222,6 +223,7 @@ function _M.prepare_kong(args_config, signal)
   kong_config.proxy_port,
   kong_config.proxy_ssl_port,
   kong_config.admin_api_port,
+  kong_config.consumer_api_port,
   kong_config.dnsmasq_port,
   kong_config.database,
   tostring(dao_config)))
@@ -254,7 +256,7 @@ function _M.send_signal(args_config, signal)
   if not signal then signal = START end
 
   if signal == START then
-    local ports = { kong_config.proxy_port, kong_config.proxy_ssl_port, kong_config.admin_api_port }
+    local ports = { kong_config.proxy_port, kong_config.proxy_ssl_port, kong_config.admin_api_port, kong_config.consumer_api_port }
     for _,port in ipairs(ports) do
       check_port(port)
     end

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -54,6 +54,9 @@ return {
       "day",
       "month",
       "year"
+    },
+    USAGE = {
+      NO_LIMIT_VALUE = "unlimited"
     }
   }
 }

--- a/kong/consumer_api/app.lua
+++ b/kong/consumer_api/app.lua
@@ -1,0 +1,155 @@
+local lapis = require "lapis"
+local utils = require "kong.tools.utils"
+local stringy = require "stringy"
+local responses = require "kong.tools.responses"
+local app_helpers = require "lapis.application"
+local app = lapis.Application()
+
+-- Parses a form value, handling multipart/data values
+-- @param `v` The value object
+-- @return The parsed value
+local function parse_value(v)
+  return type(v) == "table" and v.content or v -- Handle multipart
+end
+
+-- Put nested keys in objects:
+-- Normalize dotted keys in objects.
+-- Example: {["key.value.sub"]=1234} becomes {key = {value = {sub=1234}}
+-- @param `obj` Object to normalize
+-- @return `normalized_object`
+local function normalize_nested_params(obj)
+  local new_obj = {}
+
+  local function attach_dotted_key(keys, attach_to, value)
+    local current_key = keys[1]
+
+    if #keys > 1 then
+      if not attach_to[current_key] then
+        attach_to[current_key] = {}
+      end
+      table.remove(keys, 1)
+      attach_dotted_key(keys, attach_to[current_key], value)
+    else
+      attach_to[current_key] = value
+    end
+  end
+
+  for k, v in pairs(obj) do
+    if type(v) == "table" then
+      -- normalize arrays since Lapis parses ?key[1]=foo as {["1"]="foo"} instead of {"foo"}
+      if utils.is_array(v) then
+        local arr = {}
+        for _, arr_v in pairs(v) do table.insert(arr, arr_v) end
+        v = arr
+      else
+        v = normalize_nested_params(v) -- recursive call on other table values
+      end
+    end
+
+    -- normalize sub-keys with dot notation
+    local keys = stringy.split(k, ".")
+    if #keys > 1 then -- we have a key containing a dot
+      attach_dotted_key(keys, new_obj, parse_value(v))
+    else
+      new_obj[k] = parse_value(v) -- nothing special with that key, simply attaching the value
+    end
+  end
+
+  return new_obj
+end
+
+local function default_on_error(self)
+  local err = self.errors[1]
+  if type(err) == "table" then
+    if err.database then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err.message)
+    elseif err.unique then
+      return responses.send_HTTP_CONFLICT(err.message)
+    elseif err.foreign then
+      return responses.send_HTTP_NOT_FOUND(err.message)
+    elseif err.invalid_type and err.message.id then
+      return responses.send_HTTP_BAD_REQUEST(err.message)
+    else
+      return responses.send_HTTP_BAD_REQUEST(err.message)
+    end
+  end
+end
+
+local function parse_params(fn)
+  return app_helpers.json_params(function(self, ...)
+    local content_type = self.req.headers["content-type"]
+    if content_type and string.find(content_type:lower(), "application/json", nil, true) then
+      if not self.json then
+        return responses.send_HTTP_BAD_REQUEST("Cannot parse JSON body")
+      end
+    end
+    self.params = normalize_nested_params(self.params)
+    return fn(self, ...)
+  end)
+end
+
+app.parse_params = parse_params
+
+app.default_route = function(self)
+  local path = self.req.parsed_url.path:match("^(.*)/$")
+
+  if path and self.app.router:resolve(path, self) then
+    return
+  elseif self.app.router:resolve(self.req.parsed_url.path.."/", self) then
+    return
+  end
+
+  return self.app.handle_404(self)
+end
+
+app.handle_404 = function(self)
+  return responses.send_HTTP_NOT_FOUND()
+end
+
+app.handle_error = function(self, err, trace)
+  if stringy.find(err, "don't know how to respond to") ~= nil then
+    return responses.send_HTTP_METHOD_NOT_ALLOWED()
+  else
+    ngx.log(ngx.ERR, err.."\n"..trace)
+  end
+
+  -- We just logged the error so no need to give it to responses and log it twice
+  return responses.send_HTTP_INTERNAL_SERVER_ERROR()
+end
+
+local handler_helpers = {
+  responses = responses,
+  yield_error = app_helpers.yield_error
+}
+
+local function attach_routes(routes)
+  for route_path, methods in pairs(routes) do
+    if not methods.on_error then
+      methods.on_error = default_on_error
+    end
+
+    for k, v in pairs(methods) do
+      local method = function(self)
+        return v(self, dao, handler_helpers)
+      end
+      methods[k] = parse_params(method)
+    end
+
+    app:match(route_path, route_path, app_helpers.respond_to(methods))
+  end
+end
+
+-- Loading plugins routes
+if configuration and configuration.plugins_available then
+  for _, v in ipairs(configuration.plugins_available) do
+    local loaded, mod = utils.load_module_if_exists("kong.plugins."..v..".consumer_api")
+    if loaded then
+      ngx.log(ngx.DEBUG, "Loading API endpoints for plugin: "..v)
+      attach_routes(mod)
+    else
+      ngx.log(ngx.DEBUG, "No API endpoints loaded for plugin: "..v)
+    end
+  end
+end
+
+return app

--- a/kong/plugins/rate-limiting/consumer_api.lua
+++ b/kong/plugins/rate-limiting/consumer_api.lua
@@ -1,0 +1,56 @@
+local crud = require "kong.api.crud_helpers"
+local timestamp = require "kong.tools.timestamp"
+local constants = require "kong.constants"
+local rate_limit_utils = require "kong.plugins.rate-limiting.utils"
+
+local string_format = string.format
+
+local function format_usage(usage)
+  local usage_for_field
+  local response_data = { rate = {} }
+  local no_limit_value = constants.RATELIMIT.USAGE.NO_LIMIT_VALUE
+
+  for k, field_name in ipairs(constants.RATELIMIT.PERIODS) do
+    usage_for_field = usage[field_name] or {}
+    response_data.rate[string_format("limit-%s", field_name)] = usage_for_field.limit or no_limit_value
+    response_data.rate[string_format("remaining-%s", field_name)] = usage_for_field.remaining or no_limit_value
+  end
+
+  return response_data
+end
+
+return {
+
+  ["/apis/:name_or_id/plugins/rate-limiting/usage/:key"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+
+      local data, err = dao_factory.keyauth_credentials:find_by_keys({ key = self.params.key })
+      if err then
+        return helpers.yield_error(err)
+      end
+
+      self.credential = data[1]
+      if not self.credential then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      local current_timestamp = timestamp.get_utc()
+      local identifier = self.credential.id or ngx.var.remote_addr
+
+      -- get api and plugin configuration
+      crud.find_api_by_name_or_id(self, dao_factory, helpers)
+      self.params.api_id = self.api.id
+      self.params.name = "rate-limiting"
+      crud.find_plugin_conf_by_api_id_and_name(self, dao_factory, helpers)
+
+      -- Load current metric for configured period
+      local usage, _ = rate_limit_utils.get_usage(self.api.id, identifier, current_timestamp, self.plugin.config or {})
+      local response_data = format_usage(usage)
+      return helpers.responses.send_HTTP_OK(response_data)
+    end
+  },
+}

--- a/kong/plugins/rate-limiting/utils.lua
+++ b/kong/plugins/rate-limiting/utils.lua
@@ -1,0 +1,33 @@
+local responses = require "kong.tools.responses"
+
+local _M = {}
+
+function _M.get_usage(api_id, identifier, current_timestamp, limits)
+  local usage = {}
+  local stop
+
+  for name, limit in pairs(limits) do
+    local current_metric, err = dao.ratelimiting_metrics:find_one(api_id, identifier, current_timestamp, name)
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+
+    -- What is the current usage for the configured limit name?
+    local current_usage = current_metric and current_metric.value or 0
+    local remaining = limit - current_usage
+
+    -- Recording usage
+    usage[name] = {
+      limit = limit,
+      remaining = remaining
+    }
+
+    if remaining <= 0 then
+      stop = name
+    end
+  end
+
+  return usage, stop
+end
+
+return _M

--- a/spec/plugins/rate-limiting/consumer_api_spec.lua
+++ b/spec/plugins/rate-limiting/consumer_api_spec.lua
@@ -1,0 +1,75 @@
+local cjson = require "cjson"
+local http_client = require "kong.tools.http_client"
+local spec_helper = require "spec.spec_helpers"
+local constants = require "kong.constants"
+
+local string_format = string.format
+
+describe("Rate Limiting Consumer API", function()
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.insert_fixtures {
+      api = {
+        { name = "tests-rate-limiting-1", inbound_dns = "test-ratelimit1.com", upstream_url = "http://mockbin.com" }
+      },
+      consumer = {
+        { custom_id = "provider_123" },
+      },
+      plugin = {
+        { name = "key-auth", config = {key_names = {"apikey"}, hide_credentials = true}, __api = 1 },
+        { name = "rate-limiting", config = { minute = 6, hour = 12 }, __api = 1 },
+      },
+      keyauth_credential = {
+        { key = "apikey122", __consumer = 1 },
+      }
+    }
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  describe("Rate limit matrics usage", function()
+
+    it("should return json with current rate limit matrics", function()
+
+      -- make 2 requests to the api
+      http_client.get(spec_helper.STUB_GET_URL, {}, {host = "test-ratelimit1.com", apikey = "apikey122"})
+      http_client.get(spec_helper.STUB_GET_URL, {}, {host = "test-ratelimit1.com", apikey = "apikey122"})
+
+      -- get current status
+      local retrive_url = string_format("%s/apis/tests-rate-limiting-1/plugins/rate-limiting/usage/apikey122", spec_helper.CONSUMER_API_URL)
+      local response_json, status = http_client.get(retrive_url, {})
+      local response = cjson.decode(response_json)
+      assert.are.equal(200, status)
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["limit-second"])
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["remaining-second"])
+
+      assert.are.equal(6, response.rate["limit-minute"])
+      assert.are.equal(4, response.rate["remaining-minute"])
+
+      assert.are.equal(12, response.rate["limit-hour"])
+      assert.are.equal(10, response.rate["remaining-hour"])
+
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["limit-day"])
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["remaining-day"])
+
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["limit-month"])
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["remaining-month"])
+
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["limit-year"])
+      assert.are.equal(constants.RATELIMIT.USAGE.NO_LIMIT_VALUE, response.rate["remaining-year"])
+    end)
+  end)
+
+  it("should return error - no consumer ", function()
+    local retrive_url = string_format("%s/apis/tests-rate-limiting-1/plugins/rate-limiting/usage/invalid-api-key", spec_helper.CONSUMER_API_URL)
+    local response_json, status = http_client.get(retrive_url, {})
+    local response = cjson.decode(response_json)
+    assert.are.equal(404, status)
+    assert.are.equal("Not found", response.message)
+
+  end)
+
+end)

--- a/spec/spec_helpers.lua
+++ b/spec/spec_helpers.lua
@@ -17,6 +17,7 @@ local TEST_PROXY_PORT = 8100
 local TEST_PROXY_URL = "http://localhost:"..tostring(TEST_PROXY_PORT)
 local TEST_PROXY_SSL_URL = "https://localhost:8543"
 _M.API_URL = "http://localhost:8101"
+_M.CONSUMER_API_URL = "http://localhost:8102"
 _M.KONG_BIN = "bin/kong"
 _M.PROXY_URL = TEST_PROXY_URL
 _M.PROXY_SSL_URL = TEST_PROXY_SSL_URL

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -67,6 +67,7 @@ nginx_working_dir: /usr/local/kong/
 proxy_port: 8000
 proxy_ssl_port: 8443
 admin_api_port: 8001
+consumer_api_port: 8002
 
 ## Secondary port configuration
 dnsmasq_port: 8053
@@ -254,6 +255,34 @@ nginx: |
       # Do not remove, additional configuration placeholder for some plugins
       # {{additional_configuration}}
     }
+
+    server {
+      listen {{consumer_api_port}};
+
+      location / {
+        default_type application/json;
+        content_by_lua '
+          ngx.header["Access-Control-Allow-Origin"] = "*"
+          if ngx.req.get_method() == "OPTIONS" then
+            ngx.header["Access-Control-Allow-Methods"] = "GET,HEAD,PUT,PATCH,POST,DELETE"
+            ngx.exit(204)
+          end
+          local lapis = require "lapis"
+          lapis.serve("kong.consumer_api.app")
+        ';
+      }
+
+      location /nginx_status {
+        internal;
+        stub_status;
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+    }
+
   }
 ]], configuration)
     end)


### PR DESCRIPTION
adds rate limit usage #232.
after some discussions in #517, this pull request adds a consumer api endpoint (8002).

the ratelimiting plugin implement a url for the consumer api to response with current ratelimit matrics.

example url with consumer key = '123456'
<pre>curl -v -i -X GET   --url http://localhost:8002/apis/mockbin/plugins/rate-limiting/usage/123456   --header 'Host: mockbin.com'</pre>

some notes:
- to add new endpoint (8002) there is some code duplication between kong/api/app.lua and kong/consumer_api/app.lua. personally i think its better to refactor the code to eliminate code duplication. but since i want to change kong/api/app.lua as less as i can, i came up with this.
- 8002 port is not yet mapped in vagrant.