### PR TITLE
[chore] renaming APIs properties (bis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ Several breaking changes are introduced. You will have to slightly change your c
 
 - Many plugins were renamed due to new naming conventions for consistency. [#480](https://github.com/Mashape/kong/issues/480)
 - In the configuration file, the Cassandra `hosts` property was renamed to `contact_points`. [#513](https://github.com/Mashape/kong/issues/513)
-- `public_dns` and `target_url` properties of APIs were respectively renamed to `inbound_dns` and `upstream_url`. [#513](https://github.com/Mashape/kong/issues/513)
-- `plugins_configurations` have been renamed to `plugins`, and their `value` property has been renamed to `config` to avoid confusions. [#513](https://github.com/Mashape/kong/issues/513)
+- Properties belonging to APIs entities have been renamed for clarity [#513](https://github.com/Mashape/kong/issues/513)
+  - `public_dns` -> `request_host`
+  - `path` -> `request_path`
+  - `strip_path` -> `strip_request_path`
+  - `target_url` -> `upstream_url`
 - The database schema has been updated to handle the separation of plugins outside of the core repository.
 - The Key authentication and Basic authentication plugins routes have changed:
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -91,7 +91,7 @@ Your cluster is now fully migrated to `0.5.0`.
 
 Some entities and properties were renamed to avoid confusion:
 
-- `public_dns` and `target_url` properties of APIs were respectively renamed to `inbound_dns` and `upstream_url`.
+- `public_dns` and `target_url` properties of APIs were respectively renamed to `request_host` and `upstream_url`.
 - `plugins_configurations` have been renamed to `plugins`, and their `value` property has been renamed to `config` to avoid confusions.
 - The Key authentication and Basic authentication plugins routes have changed:
 

--- a/kong/dao/cassandra/schema/migrations.lua
+++ b/kong/dao/cassandra/schema/migrations.lua
@@ -41,9 +41,9 @@ local Migrations = {
         CREATE TABLE IF NOT EXISTS apis(
           id uuid,
           name text,
-          inbound_dns text,
-          path text,
-          strip_path boolean,
+          request_host text,
+          request_path text,
+          strip_request_path boolean,
           upstream_url text,
           preserve_host boolean,
           created_at timestamp,
@@ -51,8 +51,8 @@ local Migrations = {
         );
 
         CREATE INDEX IF NOT EXISTS ON apis(name);
-        CREATE INDEX IF NOT EXISTS ON apis(inbound_dns);
-        CREATE INDEX IF NOT EXISTS ON apis(path);
+        CREATE INDEX IF NOT EXISTS ON apis(request_host);
+        CREATE INDEX IF NOT EXISTS ON apis(request_path);
 
         CREATE TABLE IF NOT EXISTS plugins(
           id uuid,

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -350,8 +350,8 @@ local function parse_access_token(conf)
 end
 
 function _M.execute(conf)
-  -- Check if the API has a path and if it's being invoked with the path resolver
-  local path_prefix = (ngx.ctx.api.path and stringy.startswith(ngx.var.request_uri, ngx.ctx.api.path)) and ngx.ctx.api.path or ""
+  -- Check if the API has a request_path and if it's being invoked with the path resolver
+  local path_prefix = (ngx.ctx.api.request_path and stringy.startswith(ngx.var.request_uri, ngx.ctx.api.request_path)) and ngx.ctx.api.request_path or ""
   if stringy.endswith(path_prefix, "/") then
     path_prefix = path_prefix:sub(1, path_prefix:len() - 1)
   end

--- a/kong/resolver/access.lua
+++ b/kong/resolver/access.lua
@@ -6,11 +6,11 @@ local responses = require "kong.tools.responses"
 
 local _M = {}
 
--- Take a inbound_dns and make it a pattern for wildcard matching.
--- Only do so if the inbound_dns actually has a wildcard.
-local function create_wildcard_pattern(inbound_dns)
-  if string.find(inbound_dns, "*", 1, true) then
-    local pattern = string.gsub(inbound_dns, "%.", "%%.")
+-- Take a request_host and make it a pattern for wildcard matching.
+-- Only do so if the request_host actually has a wildcard.
+local function create_wildcard_pattern(request_host)
+  if string.find(request_host, "*", 1, true) then
+    local pattern = string.gsub(request_host, "%.", "%%.")
     pattern = string.gsub(pattern, "*", ".+")
     pattern = string.format("^%s$", pattern)
     return pattern
@@ -18,8 +18,8 @@ local function create_wildcard_pattern(inbound_dns)
 end
 
 -- Handles pattern-specific characters if any.
-local function create_strip_path_pattern(path)
-  return string.gsub(path, "[%(%)%.%%%+%-%*%?%[%]%^%$]", function(c) return "%"..c end)
+local function create_strip_request_path_pattern(request_path)
+  return string.gsub(request_path, "[%(%)%.%%%+%-%*%?%[%]%^%$]", function(c) return "%"..c end)
 end
 
 local function get_backend_url(api)
@@ -50,45 +50,45 @@ local function get_host_from_url(val)
 end
 
 -- Load all APIs in memory.
--- Sort the data for faster lookup: dictionary per inbound_dns and an array of wildcard inbound_dns.
+-- Sort the data for faster lookup: dictionary per request_host and an array of wildcard request_host.
 function _M.load_apis_in_memory()
   local apis, err = dao.apis:find_all()
   if err then
     return nil, err
   end
 
-  -- build dictionnaries of inbound_dns:api for efficient O(1) lookup.
-  -- we only do O(n) lookup for wildcard inbound_dns and path that are in arrays.
-  local dns_dic, dns_wildcard_arr, path_arr = {}, {}, {}
+  -- build dictionnaries of request_host:api for efficient O(1) lookup.
+  -- we only do O(n) lookup for wildcard request_host and request_path that are in arrays.
+  local dns_dic, dns_wildcard_arr, request_path_arr = {}, {}, {}
   for _, api in ipairs(apis) do
-    if api.inbound_dns then
-      local pattern = create_wildcard_pattern(api.inbound_dns)
+    if api.request_host then
+      local pattern = create_wildcard_pattern(api.request_host)
       if pattern then
-        -- If the inbound_dns is a wildcard, we have a pattern and we can
+        -- If the request_host is a wildcard, we have a pattern and we can
         -- store it in an array for later lookup.
         table.insert(dns_wildcard_arr, {pattern = pattern, api = api})
       else
-        -- Keep non-wildcard inbound_dns in a dictionary for faster lookup.
-        dns_dic[api.inbound_dns] = api
+        -- Keep non-wildcard request_host in a dictionary for faster lookup.
+        dns_dic[api.request_host] = api
       end
     end
-    if api.path then
-      table.insert(path_arr, {
+    if api.request_path then
+      table.insert(request_path_arr, {
         api = api,
-        path = api.path,
-        strip_path_pattern = create_strip_path_pattern(api.path)
+        request_path = api.request_path,
+        strip_request_path_pattern = create_strip_request_path_pattern(api.request_path)
       })
     end
   end
 
   return {
     by_dns = dns_dic,
-    path_arr = path_arr, -- all APIs with a path
-    wildcard_dns_arr = dns_wildcard_arr -- all APIs with a wildcard inbound_dns
+    request_path_arr = request_path_arr, -- all APIs with a request_path
+    wildcard_dns_arr = dns_wildcard_arr -- all APIs with a wildcard request_host
   }
 end
 
-function _M.find_api_by_inbound_dns(req_headers, apis_dics)
+function _M.find_api_by_request_host(req_headers, apis_dics)
   local all_hosts = {}
   for _, header_name in ipairs({"Host", constants.HEADERS.HOST_OVERRIDE}) do
     local hosts = req_headers[header_name]
@@ -103,7 +103,7 @@ function _M.find_api_by_inbound_dns(req_headers, apis_dics)
         if apis_dics.by_dns[host] then
           return apis_dics.by_dns[host]
         else
-          -- If the API was not found in the dictionary, maybe it is a wildcard inbound_dns.
+          -- If the API was not found in the dictionary, maybe it is a wildcard request_host.
           -- In that case, we need to loop over all of them.
           for _, wildcard_dns in ipairs(apis_dics.wildcard_dns_arr) do
             if string.match(host, wildcard_dns.pattern) then
@@ -121,36 +121,36 @@ end
 -- To do so, we have to compare entire URI segments (delimited by "/").
 -- Comparing by entire segment allows us to avoid edge-cases such as:
 -- uri = /mockbin-with-pattern/xyz
--- api.path regex = ^/mockbin
+-- api.request_path regex = ^/mockbin
 -- ^ This would wrongfully match. Wether:
--- api.path regex = ^/mockbin/
+-- api.request_path regex = ^/mockbin/
 -- ^ This does not match.
 
 -- Because we need to compare by entire URI segments, all URIs need to have a trailing slash, otherwise:
 -- uri = /mockbin
--- api.path regex = ^/mockbin/
+-- api.request_path regex = ^/mockbin/
 -- ^ This would not match.
 -- @param  `uri` The URI for this request.
--- @param  `path_arr`    An array of all APIs that have a path property.
-function _M.find_api_by_path(uri, path_arr)
+-- @param  `request_path_arr`    An array of all APIs that have a request_path property.
+function _M.find_api_by_request_path(uri, request_path_arr)
   if not stringy.endswith(uri, "/") then
     uri = uri.."/"
   end
 
-  for _, item in ipairs(path_arr) do
-    local m, err = ngx.re.match(uri, "^"..item.path.."/")
+  for _, item in ipairs(request_path_arr) do
+    local m, err = ngx.re.match(uri, "^"..item.request_path.."/")
     if err then
-      ngx.log(ngx.ERR, "[resolver] error matching requested path: "..err)
+      ngx.log(ngx.ERR, "[resolver] error matching requested request_path: "..err)
     elseif m then
-      return item.api, item.strip_path_pattern
+      return item.api, item.strip_request_path_pattern
     end
   end
 end
 
--- Replace `/path` with `path`, and then prefix with a `/`
--- or replace `/path/foo` with `/foo`, and then do not prefix with `/`.
-function _M.strip_path(uri, strip_path_pattern)
-  local uri = string.gsub(uri, strip_path_pattern, "", 1)
+-- Replace `/request_path` with `request_path`, and then prefix with a `/`
+-- or replace `/request_path/foo` with `/foo`, and then do not prefix with `/`.
+function _M.strip_request_path(uri, strip_request_path_pattern)
+  local uri = string.gsub(uri, strip_request_path_pattern, "", 1)
   if string.sub(uri, 0, 1) ~= "/" then
     uri = "/"..uri
   end
@@ -158,7 +158,7 @@ function _M.strip_path(uri, strip_path_pattern)
 end
 
 -- Find an API from a request made to nginx. Either from one of the Host or X-Host-Override headers
--- matching the API's `inbound_dns`, either from the `uri` matching the API's `path`.
+-- matching the API's `request_host`, either from the `uri` matching the API's `request_path`.
 --
 -- To perform this, we need to query _ALL_ APIs in memory. It is the only way to compare the `uri`
 -- as a regex to the values set in DB, as well as matching wildcard dns.
@@ -169,9 +169,9 @@ end
 -- @return `err`         Any error encountered during the retrieval.
 -- @return `api`         The retrieved API, if any.
 -- @return `hosts`       The list of headers values found in Host and X-Host-Override.
--- @return `strip_path_pattern` If the API was retrieved by path, contain the pattern to strip it from the URI.
+-- @return `strip_request_path_pattern` If the API was retrieved by request_path, contain the pattern to strip it from the URI.
 local function find_api(uri)
-  local api, all_hosts, strip_path_pattern
+  local api, all_hosts, strip_request_path_pattern
 
   -- Retrieve all APIs
   local apis_dics, err = cache.get_or_set("ALL_APIS_BY_DIC", _M.load_apis_in_memory, 60) -- 60 seconds cache, longer than usual
@@ -180,35 +180,35 @@ local function find_api(uri)
   end
 
   -- Find by Host header
-  api, all_hosts = _M.find_api_by_inbound_dns(ngx.req.get_headers(), apis_dics)
+  api, all_hosts = _M.find_api_by_request_host(ngx.req.get_headers(), apis_dics)
 
   -- If it was found by Host, return
   if api then
     return nil, api, all_hosts
   end
 
-  -- Otherwise, we look for it by path. We have to loop over all APIs and compare the requested URI.
-  api, strip_path_pattern = _M.find_api_by_path(uri, apis_dics.path_arr)
+  -- Otherwise, we look for it by request_path. We have to loop over all APIs and compare the requested URI.
+  api, strip_request_path_pattern = _M.find_api_by_request_path(uri, apis_dics.request_path_arr)
 
-  return nil, api, all_hosts, strip_path_pattern
+  return nil, api, all_hosts, strip_request_path_pattern
 end
 
 function _M.execute(conf)
   local uri = ngx.var.uri
-  local err, api, hosts, strip_path_pattern = find_api(uri)
+  local err, api, hosts, strip_request_path_pattern = find_api(uri)
   if err then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   elseif not api then
     return responses.send_HTTP_NOT_FOUND {
       message = "API not found with these values",
-      inbound_dns = hosts,
-      path = uri
+      request_host = hosts,
+      request_path = uri
     }
   end
 
-  -- If API was retrieved by path and the path needs to be stripped
-  if strip_path_pattern and api.strip_path then
-    uri = _M.strip_path(uri, strip_path_pattern)
+  -- If API was retrieved by request_path and the request_path needs to be stripped
+  if strip_request_path_pattern and api.strip_request_path then
+    uri = _M.strip_request_path(uri, strip_request_path_pattern)
   end
 
   -- Setting the backend URL for the proxy_pass directive

--- a/kong/resolver/certificate.lua
+++ b/kong/resolver/certificate.lua
@@ -9,7 +9,7 @@ local function find_api(hosts)
     local sanitized_host = stringy.split(host, ":")[1]
 
     retrieved_api, err = cache.get_or_set(cache.api_key(sanitized_host), function()
-      local apis, err = dao.apis:find_by_keys { inbound_dns = sanitized_host }
+      local apis, err = dao.apis:find_by_keys { request_host = sanitized_host }
       if err then
         return nil, err
       elseif apis and #apis == 1 then

--- a/kong/tools/faker.lua
+++ b/kong/tools/faker.lua
@@ -15,7 +15,7 @@ function Faker:fake_entity(type)
   if type == "api" then
     return {
       name = "random"..r,
-      inbound_dns = "random"..r..".com",
+      request_host = "random"..r..".com",
       upstream_url = "http://random"..r..".com"
     }
   elseif type == "consumer" then

--- a/scripts/migration.py
+++ b/scripts/migration.py
@@ -151,12 +151,15 @@ def migrate_rename_apis_properties(sessions):
     log.info("Renaming some properties for APIs...")
 
     session.execute("ALTER TABLE apis ADD request_host text")
+    session.execute("ALTER TABLE apis ADD request_path text")
+    session.execute("ALTER TABLE apis ADD strip_request_path boolean")
     session.execute("ALTER TABLE apis ADD upstream_url text")
     session.execute("CREATE INDEX IF NOT EXISTS ON apis(request_host)")
+    session.execute("CREATE INDEX IF NOT EXISTS ON apis(request_path)")
 
     select_query = SimpleStatement("SELECT * FROM apis", consistency_level=ConsistencyLevel.ALL)
     for api in session.execute(select_query):
-        session.execute("UPDATE apis SET request_host = %s, upstream_url = %s WHERE id = %s", [api.public_dns, api.target_url, api.id])
+        session.execute("UPDATE apis SET request_host = %s, request_path = %s, strip_request_path = %s, upstream_url = %s WHERE id = %s", [api.public_dns, api.path, api.strip_path, api.target_url, api.id])
 
     log.info("APIs properties renamed")
 
@@ -189,6 +192,8 @@ def migrate_hash_passwords(session):
 def purge(session):
     session.execute("ALTER TABLE apis DROP public_dns")
     session.execute("ALTER TABLE apis DROP target_url")
+    session.execute("ALTER TABLE apis DROP path")
+    session.execute("ALTER TABLE apis DROP strip_path")
     session.execute("ALTER TABLE basicauth_credentials DROP plain_password")
     session.execute("DROP TABLE plugins_configurations")
     session.execute(SimpleStatement("DELETE FROM schema_migrations WHERE id = 'migrations'", consistency_level=ConsistencyLevel.ALL))

--- a/scripts/migration.py
+++ b/scripts/migration.py
@@ -150,13 +150,13 @@ def migrate_rename_apis_properties(sessions):
     """
     log.info("Renaming some properties for APIs...")
 
-    session.execute("ALTER TABLE apis ADD inbound_dns text")
+    session.execute("ALTER TABLE apis ADD request_host text")
     session.execute("ALTER TABLE apis ADD upstream_url text")
-    session.execute("CREATE INDEX IF NOT EXISTS ON apis(inbound_dns)")
+    session.execute("CREATE INDEX IF NOT EXISTS ON apis(request_host)")
 
     select_query = SimpleStatement("SELECT * FROM apis", consistency_level=ConsistencyLevel.ALL)
     for api in session.execute(select_query):
-        session.execute("UPDATE apis SET inbound_dns = %s, upstream_url = %s WHERE id = %s", [api.public_dns, api.target_url, api.id])
+        session.execute("UPDATE apis SET request_host = %s, upstream_url = %s WHERE id = %s", [api.public_dns, api.target_url, api.id])
 
     log.info("APIs properties renamed")
 

--- a/spec/integration/admin_api/apis_routes_spec.lua
+++ b/spec/integration/admin_api/apis_routes_spec.lua
@@ -22,7 +22,7 @@ describe("Admin API", function()
       it("[SUCCESS] should create an API", function()
         send_content_types(BASE_URL, "POST", {
           name="api POST tests",
-          inbound_dns="api.mockbin.com",
+          request_host="api.mockbin.com",
           upstream_url="http://mockbin.com"
         }, 201, nil, {drop_db=true})
       end)
@@ -36,15 +36,15 @@ describe("Admin API", function()
       it("[FAILURE] should return proper errors", function()
         send_content_types(BASE_URL, "POST", {},
         400,
-        '{"path":"At least an \'inbound_dns\' or a \'path\' must be specified","upstream_url":"upstream_url is required","inbound_dns":"At least an \'inbound_dns\' or a \'path\' must be specified"}')
+        '{"upstream_url":"upstream_url is required","request_path":"At least a \'request_host\' or a \'request_path\' must be specified","request_host":"At least a \'request_host\' or a \'request_path\' must be specified"}')
 
-        send_content_types(BASE_URL, "POST", {inbound_dns="api.mockbin.com"},
+        send_content_types(BASE_URL, "POST", {request_host="api.mockbin.com"},
         400, '{"upstream_url":"upstream_url is required"}')
 
         send_content_types(BASE_URL, "POST", {
-          inbound_dns="api.mockbin.com",
+          request_host="api.mockbin.com",
           upstream_url="http://mockbin.com"
-        }, 409, '{"inbound_dns":"inbound_dns already exists with value \'api.mockbin.com\'"}')
+        }, 409, '{"request_host":"request_host already exists with value \'api.mockbin.com\'"}')
       end)
 
     end)
@@ -58,14 +58,14 @@ describe("Admin API", function()
       it("[SUCCESS] should create and update", function()
         local api = send_content_types(BASE_URL, "PUT", {
           name="api PUT tests",
-          inbound_dns="api.mockbin.com",
+          request_host="api.mockbin.com",
           upstream_url="http://mockbin.com"
         }, 201, nil, {drop_db=true})
 
         api = send_content_types(BASE_URL, "PUT", {
           id=api.id,
           name="api PUT tests updated",
-          inbound_dns="updated-api.mockbin.com",
+          request_host="updated-api.mockbin.com",
           upstream_url="http://mockbin.com"
         }, 200)
         assert.equal("api PUT tests updated", api.name)
@@ -74,15 +74,15 @@ describe("Admin API", function()
       it("[FAILURE] should return proper errors", function()
         send_content_types(BASE_URL, "PUT", {},
         400,
-        '{"path":"At least an \'inbound_dns\' or a \'path\' must be specified","upstream_url":"upstream_url is required","inbound_dns":"At least an \'inbound_dns\' or a \'path\' must be specified"}')
+        '{"upstream_url":"upstream_url is required","request_path":"At least a \'request_host\' or a \'request_path\' must be specified","request_host":"At least a \'request_host\' or a \'request_path\' must be specified"}')
 
-        send_content_types(BASE_URL, "PUT", {inbound_dns="api.mockbin.com"},
+        send_content_types(BASE_URL, "PUT", {request_host="api.mockbin.com"},
         400, '{"upstream_url":"upstream_url is required"}')
 
         send_content_types(BASE_URL, "PUT", {
-          inbound_dns="updated-api.mockbin.com",
+          request_host="updated-api.mockbin.com",
           upstream_url="http://mockbin.com"
-        }, 409, '{"inbound_dns":"inbound_dns already exists with value \'updated-api.mockbin.com\'"}')
+        }, 409, '{"request_host":"request_host already exists with value \'updated-api.mockbin.com\'"}')
       end)
 
     end)
@@ -138,7 +138,7 @@ describe("Admin API", function()
     setup(function()
       spec_helper.drop_db()
       local fixtures = spec_helper.insert_fixtures {
-        api = {{ inbound_dns="mockbin.com", upstream_url="http://mockbin.com" }}
+        api = {{ request_host="mockbin.com", upstream_url="http://mockbin.com" }}
       }
       api = fixtures.api[1]
     end)
@@ -211,7 +211,7 @@ describe("Admin API", function()
       setup(function()
         spec_helper.drop_db()
         local fixtures = spec_helper.insert_fixtures {
-          api = {{ inbound_dns="mockbin.com", upstream_url="http://mockbin.com" }}
+          api = {{ request_host="mockbin.com", upstream_url="http://mockbin.com" }}
         }
         api = fixtures.api[1]
         BASE_URL = BASE_URL..api.id.."/plugins/"
@@ -328,7 +328,7 @@ describe("Admin API", function()
         setup(function()
           spec_helper.drop_db()
           local fixtures = spec_helper.insert_fixtures {
-            api = {{ inbound_dns="mockbin.com", upstream_url="http://mockbin.com" }},
+            api = {{ request_host="mockbin.com", upstream_url="http://mockbin.com" }},
             plugin = {{ name = "key-auth", config = { key_names = { "apikey" }}, __api = 1 }}
           }
           api = fixtures.api[1]

--- a/spec/integration/cli/start_spec.lua
+++ b/spec/integration/cli/start_spec.lua
@@ -74,7 +74,7 @@ describe("CLI", function()
     it("should not work when a plugin is being used in the DB but it's not in the configuration", function()
       spec_helper.get_env(SERVER_CONF).faker:insert_from_table {
         api = {
-          {name = "tests cli 1", inbound_dns = "foo.com", upstream_url = "http://mockbin.com"},
+          {name = "tests cli 1", request_host = "foo.com", upstream_url = "http://mockbin.com"},
         },
         plugin = {
           {name = "rate-limiting", config = {minute = 6}, __api = 1},

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -89,7 +89,7 @@ describe("Cassandra", function()
 
         -- API
         api, err = dao_factory.apis:insert {
-          inbound_dns = "test.com",
+          request_host = "test.com",
           upstream_url = "http://mockbin.com"
         }
         assert.falsy(err)
@@ -228,7 +228,7 @@ describe("Cassandra", function()
         assert.equal(1, #apis)
         assert.equal(api_t.id, apis[1].id)
         assert.equal(api_t.name, apis[1].name)
-        assert.equal(api_t.inbound_dns, apis[1].inbound_dns)
+        assert.equal(api_t.request_host, apis[1].request_host)
         assert.equal(api_t.upstream_url, apis[1].upstream_url)
 
         -- Consumer
@@ -271,38 +271,38 @@ describe("Cassandra", function()
         assert.True(#apis > 0)
 
         local api_t = apis[1]
-        -- Should not work because we're reusing a inbound_dns
-        api_t.inbound_dns = apis[2].inbound_dns
+        -- Should not work because we're reusing a request_host
+        api_t.request_host = apis[2].request_host
 
         local api, err = dao_factory.apis:update(api_t)
         assert.truthy(err)
         assert.falsy(api)
         assert.is_daoError(err)
         assert.True(err.unique)
-        assert.equal("inbound_dns already exists with value '"..api_t.inbound_dns.."'", err.message.inbound_dns)
+        assert.equal("request_host already exists with value '"..api_t.request_host.."'", err.message.request_host)
       end)
 
       describe("full", function()
 
         it("should set to NULL if a field is not specified", function()
           local api_t = faker:fake_entity("api")
-          api_t.path = "/path"
+          api_t.request_path = "/request_path"
 
           local api, err = dao_factory.apis:insert(api_t)
           assert.falsy(err)
-          assert.truthy(api_t.path)
+          assert.truthy(api_t.request_path)
 
           -- Update
-          api.path = nil
+          api.request_path = nil
           api, err = dao_factory.apis:update(api, true)
           assert.falsy(err)
           assert.truthy(api)
-          assert.falsy(api.path)
+          assert.falsy(api.request_path)
 
           -- Check update
           api, err = session:execute("SELECT * FROM apis WHERE id = ?", {cassandra.uuid(api.id)})
           assert.falsy(err)
-          assert.falsy(api.path)
+          assert.falsy(api.request_path)
         end)
 
         it("should still check the validity of the schema", function()
@@ -313,7 +313,7 @@ describe("Cassandra", function()
           assert.truthy(api_t)
 
           -- Update
-          api.inbound_dns = nil
+          api.request_host = nil
 
           local nil_api, err = dao_factory.apis:update(api, true)
           assert.truthy(err)
@@ -323,7 +323,7 @@ describe("Cassandra", function()
           api, err = session:execute("SELECT * FROM apis WHERE id = ?", {cassandra.uuid(api.id)})
           assert.falsy(err)
           assert.truthy(api[1].name)
-          assert.truthy(api[1].inbound_dns)
+          assert.truthy(api[1].request_host)
         end)
 
       end)
@@ -366,7 +366,7 @@ describe("Cassandra", function()
         assert.True(needs_filtering)
 
         -- No Filtering needed
-        apis, err, needs_filtering = dao_factory.apis:find_by_keys {inbound_dns = api_t.inbound_dns}
+        apis, err, needs_filtering = dao_factory.apis:find_by_keys {request_host = api_t.request_host}
         assert.falsy(err)
         assert.same(api_t, apis[1])
         assert.False(needs_filtering)
@@ -545,8 +545,8 @@ describe("Cassandra", function()
         it("should find distinct plugins configurations", function()
           faker:insert_from_table {
             api = {
-              { name = "tests distinct 1", inbound_dns = "foo.com", upstream_url = "http://mockbin.com" },
-              { name = "tests distinct 2", inbound_dns = "bar.com", upstream_url = "http://mockbin.com" }
+              { name = "tests distinct 1", request_host = "foo.com", upstream_url = "http://mockbin.com" },
+              { name = "tests distinct 2", request_host = "bar.com", upstream_url = "http://mockbin.com" }
             },
             plugin = {
               { name = "key-auth", config = {key_names = {"apikey"}, hide_credentials = true}, __api = 1 },

--- a/spec/integration/dao/cassandra/cascade_spec.lua
+++ b/spec/integration/dao/cassandra/cascade_spec.lua
@@ -18,10 +18,10 @@ describe("Cassandra cascade delete", function()
       local fixtures = spec_helper.insert_fixtures {
         api = {
           {name = "cascade delete",
-           inbound_dns = "mockbin.com",
+           request_host = "mockbin.com",
            upstream_url = "http://mockbin.com"},
           {name = "untouched cascade delete",
-           inbound_dns = "untouched.com",
+           request_host = "untouched.com",
            upstream_url = "http://mockbin.com"}
         },
         plugin = {
@@ -67,7 +67,7 @@ describe("Cassandra cascade delete", function()
       local fixtures = spec_helper.insert_fixtures {
         api = {
           {name = "cascade delete",
-           inbound_dns = "mockbin.com",
+           request_host = "mockbin.com",
            upstream_url = "http://mockbin.com"}
         },
         consumer = {

--- a/spec/integration/proxy/api_resolver_spec.lua
+++ b/spec/integration/proxy/api_resolver_spec.lua
@@ -26,17 +26,17 @@ describe("Resolver", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        {name = "tests host resolver 1", inbound_dns = "mockbin.com", upstream_url = "http://mockbin.com"},
-        {name = "tests host resolver 2", inbound_dns = "mockbin-auth.com", upstream_url = "http://mockbin.com"},
-        {name = "tests path resolver", upstream_url = "http://mockbin.com", path = "/status"},
-        {name = "tests stripped path resolver", upstream_url = "http://mockbin.com", path = "/mockbin", strip_path = true},
-        {name = "tests stripped path resolver with pattern characters", upstream_url = "http://mockbin.com", path = "/mockbin-with-pattern/", strip_path = true},
-        {name = "tests deep path resolver", upstream_url = "http://mockbin.com", path = "/deep/path/", strip_path = true},
-        {name = "tests dup path resolver", upstream_url = "http://mockbin.com", path = "/har", strip_path = true},
-        {name = "tests wildcard subdomain", upstream_url = "http://mockbin.com/status/200", inbound_dns = "*.wildcard.com"},
-        {name = "tests wildcard subdomain 2", upstream_url = "http://mockbin.com/status/201", inbound_dns = "wildcard.*"},
-        {name = "tests preserve host", inbound_dns = "httpbin-nopreserve.com", upstream_url = "http://httpbin.org"},
-        {name = "tests preserve host 2", inbound_dns = "httpbin-preserve.com", upstream_url = "http://httpbin.org", preserve_host = true}
+        {name = "tests host resolver 1", request_host = "mockbin.com", upstream_url = "http://mockbin.com"},
+        {name = "tests host resolver 2", request_host = "mockbin-auth.com", upstream_url = "http://mockbin.com"},
+        {name = "tests request_path resolver", upstream_url = "http://mockbin.com", request_path = "/status"},
+        {name = "tests stripped request_path resolver", upstream_url = "http://mockbin.com", request_path = "/mockbin", strip_request_path = true},
+        {name = "tests stripped request_path resolver with pattern characters", upstream_url = "http://mockbin.com", request_path = "/mockbin-with-pattern/", strip_request_path = true},
+        {name = "tests deep request_path resolver", upstream_url = "http://mockbin.com", request_path = "/deep/request_path/", strip_request_path = true},
+        {name = "tests dup request_path resolver", upstream_url = "http://mockbin.com", request_path = "/har", strip_request_path = true},
+        {name = "tests wildcard subdomain", upstream_url = "http://mockbin.com/status/200", request_host = "*.wildcard.com"},
+        {name = "tests wildcard subdomain 2", upstream_url = "http://mockbin.com/status/201", request_host = "wildcard.*"},
+        {name = "tests preserve host", request_host = "httpbin-nopreserve.com", upstream_url = "http://httpbin.org"},
+        {name = "tests preserve host 2", request_host = "httpbin-preserve.com", upstream_url = "http://httpbin.org", preserve_host = true}
       },
       plugin = {
         {name = "key-auth", config = {key_names = {"apikey"} }, __api = 2}
@@ -55,7 +55,7 @@ describe("Resolver", function()
     it("should return Not Found when the API is not in Kong", function()
       local response, status = http_client.get(spec_helper.STUB_GET_URL, nil, {host = "foo.com"})
       assert.equal(404, status)
-      assert.equal('{"path":"\\/request","message":"API not found with these values","inbound_dns":["foo.com"]}\n', response)
+      assert.equal('{"request_path":"\\/request","message":"API not found with these values","request_host":["foo.com"]}\n', response)
     end)
 
   end)
@@ -130,7 +130,7 @@ describe("Resolver", function()
 
       describe("with wildcard subdomain", function()
 
-        it("should proxy when the inbound_dns is a wildcard subdomain", function()
+        it("should proxy when the request_host is a wildcard subdomain", function()
           local _, status = http_client.get(STUB_GET_URL, nil, {host = "subdomain.wildcard.com"})
           assert.equal(200, status)
 
@@ -140,8 +140,8 @@ describe("Resolver", function()
       end)
     end)
 
-    describe("By Path", function()
-      it("should proxy when no Host is present but the request_uri matches the API's path", function()
+    describe("By request_Path", function()
+      it("should proxy when no Host is present but the request_uri matches the API's request_path", function()
         local _, status = http_client.get(spec_helper.PROXY_URL.."/status/200")
         assert.equal(200, status)
 
@@ -151,34 +151,34 @@ describe("Resolver", function()
         local _, status = http_client.get(spec_helper.PROXY_URL.."/mockbin")
         assert.equal(200, status)
       end)
-      it("should not proxy when the path does not match the start of the request_uri", function()
-        local response, status = http_client.get(spec_helper.PROXY_URL.."/somepath/status/200")
+      it("should not proxy when the request_path does not match the start of the request_uri", function()
+        local response, status = http_client.get(spec_helper.PROXY_URL.."/somerequest_path/status/200")
         local body = cjson.decode(response)
         assert.equal("API not found with these values", body.message)
-        assert.equal("/somepath/status/200", body.path)
+        assert.equal("/somerequest_path/status/200", body.request_path)
         assert.equal(404, status)
       end)
-      it("should proxy and strip the path if `strip_path` is true", function()
+      it("should proxy and strip the request_path if `strip_request_path` is true", function()
         local response, status = http_client.get(spec_helper.PROXY_URL.."/mockbin/request")
         assert.equal(200, status)
         local body = cjson.decode(response)
         assert.equal("http://mockbin.com/request", body.url)
       end)
-      it("should proxy and strip the path if `strip_path` is true if path has pattern characters", function()
+      it("should proxy and strip the request_path if `strip_request_path` is true if request_path has pattern characters", function()
         local response, status = http_client.get(spec_helper.PROXY_URL.."/mockbin-with-pattern/request")
         assert.equal(200, status)
         local body = cjson.decode(response)
         assert.equal("http://mockbin.com/request", body.url)
       end)
-      it("should proxy when the path has a deep level", function()
-        local _, status = http_client.get(spec_helper.PROXY_URL.."/deep/path/status/200")
+      it("should proxy when the request_path has a deep level", function()
+        local _, status = http_client.get(spec_helper.PROXY_URL.."/deep/request_path/status/200")
         assert.equal(200, status)
       end)
       it("should not care about querystring parameters", function()
         local _, status = http_client.get(spec_helper.PROXY_URL.."/mockbin?foo=bar")
         assert.equal(200, status)
       end)
-      it("should not strip if the `path` pattern is repeated in the request_uri", function()
+      it("should not strip if the `request_path` pattern is repeated in the request_uri", function()
         local response, status = http_client.get(spec_helper.PROXY_URL.."/har/har/of/request")
         assert.equal(200, status)
         local body = cjson.decode(response)

--- a/spec/integration/proxy/database_cache_spec.lua
+++ b/spec/integration/proxy/database_cache_spec.lua
@@ -10,7 +10,7 @@ describe("Database cache", function()
     spec_helper.prepare_db()
     fixtures = spec_helper.insert_fixtures {
       api = {
-        { name = "tests database cache", inbound_dns = "cache.test", upstream_url = "http://httpbin.org" }
+        { name = "tests database cache", request_host = "cache.test", upstream_url = "http://httpbin.org" }
       }
     }
 

--- a/spec/integration/proxy/dns_resolver_spec.lua
+++ b/spec/integration/proxy/dns_resolver_spec.lua
@@ -9,8 +9,8 @@ describe("DNS", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests dns 1", inbound_dns = "dns1.com", upstream_url = "http://127.0.0.1:"..TCP_PORT },
-        { name = "tests dns 2", inbound_dns = "dns2.com", upstream_url = "http://localhost:"..TCP_PORT }
+        { name = "tests dns 1", request_host = "dns1.com", upstream_url = "http://127.0.0.1:"..TCP_PORT },
+        { name = "tests dns 2", request_host = "dns2.com", upstream_url = "http://localhost:"..TCP_PORT }
       }
     }
 

--- a/spec/integration/proxy/realip_spec.lua
+++ b/spec/integration/proxy/realip_spec.lua
@@ -13,7 +13,7 @@ describe("Real IP", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests realip", inbound_dns = "realip.com", upstream_url = "http://mockbin.com" }
+        { name = "tests realip", request_host = "realip.com", upstream_url = "http://mockbin.com" }
       },
       plugin = {
         { name = "file-log", config = { path = FILE_LOG_PATH }, __api = 1 }

--- a/spec/plugins/acl/access_spec.lua
+++ b/spec/plugins/acl/access_spec.lua
@@ -10,13 +10,13 @@ describe("ACL Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        {name = "ACL 1", inbound_dns = "acl1.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 2", inbound_dns = "acl2.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 3", inbound_dns = "acl3.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 4", inbound_dns = "acl4.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 5", inbound_dns = "acl5.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 6", inbound_dns = "acl6.com", upstream_url = "http://mockbin.com"},
-        {name = "ACL 7", inbound_dns = "acl7.com", upstream_url = "http://mockbin.com"}
+        {name = "ACL 1", request_host = "acl1.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 2", request_host = "acl2.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 3", request_host = "acl3.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 4", request_host = "acl4.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 5", request_host = "acl5.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 6", request_host = "acl6.com", upstream_url = "http://mockbin.com"},
+        {name = "ACL 7", request_host = "acl7.com", upstream_url = "http://mockbin.com"}
       },
       consumer = {
         {username = "consumer1"},

--- a/spec/plugins/basic-auth/access_spec.lua
+++ b/spec/plugins/basic-auth/access_spec.lua
@@ -10,7 +10,7 @@ describe("Authentication Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        {name = "tests basicauth", inbound_dns = "basicauth.com", upstream_url = "http://httpbin.org"}
+        {name = "tests basicauth", request_host = "basicauth.com", upstream_url = "http://httpbin.org"}
       },
       consumer = {
         {username = "basicauth_tests_consuser"}

--- a/spec/plugins/cors/access_spec.lua
+++ b/spec/plugins/cors/access_spec.lua
@@ -9,8 +9,8 @@ describe("CORS Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests cors 1", inbound_dns = "cors1.com", upstream_url = "http://mockbin.com" },
-        { name = "tests cors 2", inbound_dns = "cors2.com", upstream_url = "http://mockbin.com" }
+        { name = "tests cors 1", request_host = "cors1.com", upstream_url = "http://mockbin.com" },
+        { name = "tests cors 2", request_host = "cors2.com", upstream_url = "http://mockbin.com" }
       },
       plugin = {
         { name = "cors", config = {}, __api = 1 },

--- a/spec/plugins/hmac-auth/access_spec.lua
+++ b/spec/plugins/hmac-auth/access_spec.lua
@@ -22,7 +22,7 @@ describe("Authentication Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        {name = "tests hmac auth", inbound_dns = "hmacauth.com", upstream_url = "http://mockbin.org/"}
+        {name = "tests hmac auth", request_host = "hmacauth.com", upstream_url = "http://mockbin.org/"}
       },
       consumer = {
         {username = "hmacauth_tests_consuser"}

--- a/spec/plugins/ip-restriction/access_spec.lua
+++ b/spec/plugins/ip-restriction/access_spec.lua
@@ -10,12 +10,12 @@ describe("IP Restriction", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "iprestriction1", inbound_dns = "test1.com", upstream_url = "http://mockbin.com" },
-        { name = "iprestriction2", inbound_dns = "test2.com", upstream_url = "http://mockbin.com" },
-        { name = "iprestriction3", inbound_dns = "test3.com", upstream_url = "http://mockbin.com" },
-        { name = "iprestriction4", inbound_dns = "test4.com", upstream_url = "http://mockbin.com" },
-        { name = "iprestriction7", inbound_dns = "test5.com", upstream_url = "http://mockbin.com" },
-        { name = "iprestriction8", inbound_dns = "test6.com", upstream_url = "http://mockbin.com" }
+        { name = "iprestriction1", request_host = "test1.com", upstream_url = "http://mockbin.com" },
+        { name = "iprestriction2", request_host = "test2.com", upstream_url = "http://mockbin.com" },
+        { name = "iprestriction3", request_host = "test3.com", upstream_url = "http://mockbin.com" },
+        { name = "iprestriction4", request_host = "test4.com", upstream_url = "http://mockbin.com" },
+        { name = "iprestriction5", request_host = "test5.com", upstream_url = "http://mockbin.com" },
+        { name = "iprestriction6", request_host = "test6.com", upstream_url = "http://mockbin.com" }
       },
       plugin = {
         { name = "ip-restriction", config = { blacklist = { "127.0.0.1" }}, __api = 1 },

--- a/spec/plugins/jwt/access_spec.lua
+++ b/spec/plugins/jwt/access_spec.lua
@@ -19,9 +19,9 @@ describe("JWT access", function()
     spec_helper.prepare_db()
     local fixtures = spec_helper.insert_fixtures {
       api = {
-        {name = "tests jwt", inbound_dns = "jwt.com", upstream_url = "http://mockbin.com"},
-        {name = "tests jwt2", inbound_dns = "jwt2.com", upstream_url = "http://mockbin.com"},
-        {name = "tests jwt3", inbound_dns = "jwt3.com", upstream_url = "http://mockbin.com"}
+        {name = "tests jwt", request_host = "jwt.com", upstream_url = "http://mockbin.com"},
+        {name = "tests jwt2", request_host = "jwt2.com", upstream_url = "http://mockbin.com"},
+        {name = "tests jwt3", request_host = "jwt3.com", upstream_url = "http://mockbin.com"}
       },
       consumer = {
         {username = "jwt_tests_consumer"}

--- a/spec/plugins/key-auth/access_spec.lua
+++ b/spec/plugins/key-auth/access_spec.lua
@@ -11,8 +11,8 @@ describe("Authentication Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        {name = "tests auth 1", inbound_dns = "keyauth1.com", upstream_url = "http://mockbin.com"},
-        {name = "tests auth 2", inbound_dns = "keyauth2.com", upstream_url = "http://mockbin.com"}
+        {name = "tests auth 1", request_host = "keyauth1.com", upstream_url = "http://mockbin.com"},
+        {name = "tests auth 2", request_host = "keyauth2.com", upstream_url = "http://mockbin.com"}
       },
       consumer = {
         {username = "auth_tests_consumer"}

--- a/spec/plugins/logging_spec.lua
+++ b/spec/plugins/logging_spec.lua
@@ -28,12 +28,12 @@ describe("Logging Plugins", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests tcp logging", inbound_dns = "tcp_logging.com", upstream_url = "http://mockbin.com" },
-        { name = "tests tcp logging2", inbound_dns = "tcp_logging2.com", upstream_url = "http://localhost:"..HTTP_DELAY_PORT },
-        { name = "tests udp logging", inbound_dns = "udp_logging.com", upstream_url = "http://mockbin.com" },
-        { name = "tests http logging", inbound_dns = "http_logging.com", upstream_url = "http://mockbin.com" },
-        { name = "tests https logging", inbound_dns = "https_logging.com", upstream_url = "http://mockbin.com" },
-        { name = "tests file logging", inbound_dns = "file_logging.com", upstream_url = "http://mockbin.com" }
+        { name = "tests tcp logging", request_host = "tcp_logging.com", upstream_url = "http://mockbin.com" },
+        { name = "tests tcp logging2", request_host = "tcp_logging2.com", upstream_url = "http://localhost:"..HTTP_DELAY_PORT },
+        { name = "tests udp logging", request_host = "udp_logging.com", upstream_url = "http://mockbin.com" },
+        { name = "tests http logging", request_host = "http_logging.com", upstream_url = "http://mockbin.com" },
+        { name = "tests https logging", request_host = "https_logging.com", upstream_url = "http://mockbin.com" },
+        { name = "tests file logging", request_host = "file_logging.com", upstream_url = "http://mockbin.com" }
       },
       plugin = {
         { name = "tcp-log", config = { host = "127.0.0.1", port = TCP_PORT }, __api = 1 },

--- a/spec/plugins/oauth2/access_spec.lua
+++ b/spec/plugins/oauth2/access_spec.lua
@@ -40,11 +40,11 @@ describe("Authentication Plugin", function()
     spec_helper.drop_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests oauth2", inbound_dns = "oauth2.com", upstream_url = "http://mockbin.com" },
-        { name = "tests oauth2 with path", inbound_dns = "mockbin-path.com", upstream_url = "http://mockbin.com", path = "/somepath/" },
-        { name = "tests oauth2 with hide credentials", inbound_dns = "oauth2_3.com", upstream_url = "http://mockbin.com" },
-        { name = "tests oauth2 client credentials", inbound_dns = "oauth2_4.com", upstream_url = "http://mockbin.com" },
-        { name = "tests oauth2 password grant", inbound_dns = "oauth2_5.com", upstream_url = "http://mockbin.com" }
+        { name = "tests oauth2", request_host = "oauth2.com", upstream_url = "http://mockbin.com" },
+        { name = "tests oauth2 with path", request_host = "mockbin-path.com", upstream_url = "http://mockbin.com", request_path = "/somepath/" },
+        { name = "tests oauth2 with hide credentials", request_host = "oauth2_3.com", upstream_url = "http://mockbin.com" },
+        { name = "tests oauth2 client credentials", request_host = "oauth2_4.com", upstream_url = "http://mockbin.com" },
+        { name = "tests oauth2 password grant", request_host = "oauth2_5.com", upstream_url = "http://mockbin.com" }
       },
       consumer = {
         { username = "auth_tests_consumer" }

--- a/spec/plugins/rate-limiting/access_spec.lua
+++ b/spec/plugins/rate-limiting/access_spec.lua
@@ -19,10 +19,10 @@ describe("RateLimiting Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests rate-limiting 1", inbound_dns = "test3.com", upstream_url = "http://mockbin.com" },
-        { name = "tests rate-limiting 2", inbound_dns = "test4.com", upstream_url = "http://mockbin.com" },
-        { name = "tests rate-limiting 3", inbound_dns = "test5.com", upstream_url = "http://mockbin.com" },
-        { name = "tests rate-limiting 4", inbound_dns = "test6.com", upstream_url = "http://mockbin.com" }
+        { name = "tests rate-limiting 1", request_host = "test3.com", upstream_url = "http://mockbin.com" },
+        { name = "tests rate-limiting 2", request_host = "test4.com", upstream_url = "http://mockbin.com" },
+        { name = "tests rate-limiting 3", request_host = "test5.com", upstream_url = "http://mockbin.com" },
+        { name = "tests rate-limiting 4", request_host = "test6.com", upstream_url = "http://mockbin.com" }
       },
       consumer = {
         { custom_id = "provider_123" },

--- a/spec/plugins/rate-limiting/api_spec.lua
+++ b/spec/plugins/rate-limiting/api_spec.lua
@@ -9,7 +9,7 @@ describe("Rate Limiting API", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests rate-limiting 1", inbound_dns = "test1.com", upstream_url = "http://mockbin.com" }
+        { name = "tests rate-limiting 1", request_host = "test1.com", upstream_url = "http://mockbin.com" }
       }
     }
     spec_helper.start_kong()

--- a/spec/plugins/request-size-limiting/access_spec.lua
+++ b/spec/plugins/request-size-limiting/access_spec.lua
@@ -9,7 +9,7 @@ describe("RequestSizeLimiting Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests request-size-limiting 1", inbound_dns = "test3.com", upstream_url = "http://mockbin.com/request" }
+        { name = "tests request-size-limiting 1", request_host = "test3.com", upstream_url = "http://mockbin.com/request" }
       },
       plugin = {
         { name = "request-size-limiting", config = {allowed_payload_size = 10}, __api = 1 }

--- a/spec/plugins/request-transformer/access_spec.lua
+++ b/spec/plugins/request-transformer/access_spec.lua
@@ -11,7 +11,7 @@ describe("Request Transformer", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests request-transformer", inbound_dns = "test5.com", upstream_url = "http://mockbin.com" },
+        { name = "tests request-transformer", request_host = "test5.com", upstream_url = "http://mockbin.com" },
       },
       plugin = {
         {

--- a/spec/plugins/response-ratelimiting/access_spec.lua
+++ b/spec/plugins/response-ratelimiting/access_spec.lua
@@ -19,9 +19,9 @@ describe("RateLimiting Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests response-ratelimiting 1", inbound_dns = "test1.com", upstream_url = "http://httpbin.org/" },
-        { name = "tests response-ratelimiting 2", inbound_dns = "test2.com", upstream_url = "http://httpbin.org/" },
-        { name = "tests response-ratelimiting 3", inbound_dns = "test3.com", upstream_url = "http://httpbin.org/" }
+        { name = "tests response-ratelimiting 1", request_host = "test1.com", upstream_url = "http://httpbin.org/" },
+        { name = "tests response-ratelimiting 2", request_host = "test2.com", upstream_url = "http://httpbin.org/" },
+        { name = "tests response-ratelimiting 3", request_host = "test3.com", upstream_url = "http://httpbin.org/" }
       },
       consumer = {
         { custom_id = "consumer_123" },

--- a/spec/plugins/response-ratelimiting/api_spec.lua
+++ b/spec/plugins/response-ratelimiting/api_spec.lua
@@ -9,7 +9,7 @@ describe("Response Rate Limiting API", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests response-ratelimiting 1", inbound_dns = "test1.com", upstream_url = "http://mockbin.com" }
+        { name = "tests response-ratelimiting 1", request_host = "test1.com", upstream_url = "http://mockbin.com" }
       }
     }
     spec_helper.start_kong()

--- a/spec/plugins/response-transformer/access_spec.lua
+++ b/spec/plugins/response-transformer/access_spec.lua
@@ -11,8 +11,8 @@ describe("Response Transformer Plugin #proxy", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "tests response-transformer", inbound_dns = "response.com", upstream_url = "http://httpbin.org" },
-        { name = "tests response-transformer 2", inbound_dns = "response2.com", upstream_url = "http://httpbin.org" },
+        { name = "tests response-transformer", request_host = "response.com", upstream_url = "http://httpbin.org" },
+        { name = "tests response-transformer 2", request_host = "response2.com", upstream_url = "http://httpbin.org" },
       },
       plugin = {
         {

--- a/spec/plugins/ssl/access_spec.lua
+++ b/spec/plugins/ssl/access_spec.lua
@@ -16,9 +16,9 @@ describe("SSL Plugin", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { name = "API TESTS 11 (ssl)", inbound_dns = "ssl1.com", upstream_url = "http://mockbin.com" },
-        { name = "API TESTS 12 (ssl)", inbound_dns = "ssl2.com", upstream_url = "http://mockbin.com" },
-        { name = "API TESTS 13 (ssl)", inbound_dns = "ssl3.com", upstream_url = "http://mockbin.com" }
+        { name = "API TESTS 11 (ssl)", request_host = "ssl1.com", upstream_url = "http://mockbin.com" },
+        { name = "API TESTS 12 (ssl)", request_host = "ssl2.com", upstream_url = "http://mockbin.com" },
+        { name = "API TESTS 13 (ssl)", request_host = "ssl3.com", upstream_url = "http://mockbin.com" }
       },
       plugin = {
         { name = "ssl", config = { cert = ssl_fixtures.cert, key = ssl_fixtures.key }, __api = 1 },
@@ -89,7 +89,7 @@ describe("SSL Plugin", function()
   end)
 
   describe("should work with curl", function()
-    local response = http_client.get(API_URL.."/apis/", {inbound_dns="ssl3.com"})
+    local response = http_client.get(API_URL.."/apis/", {request_host="ssl3.com"})
     local api_id = cjson.decode(response).data[1].id
 
     local kong_working_dir = spec_helper.get_env(spec_helper.TEST_CONF_FILE).configuration.nginx_working_dir

--- a/spec/plugins/ssl/api_spec.lua
+++ b/spec/plugins/ssl/api_spec.lua
@@ -11,7 +11,7 @@ describe("SSL API", function()
     spec_helper.start_kong()
     spec_helper.insert_fixtures {
       api = {
-        {name = "mockbin", inbound_dns = "mockbin.com", upstream_url = "http://mockbin.com"}
+        {name = "mockbin", request_host = "mockbin.com", upstream_url = "http://mockbin.com"}
       }
     }
     BASE_URL = spec_helper.API_URL.."/apis/mockbin/plugins/"

--- a/spec/unit/dao/cassandra/query_builder_spec.lua
+++ b/spec/unit/dao/cassandra/query_builder_spec.lua
@@ -5,7 +5,7 @@ describe("Query Builder", function()
   local apis_details = {
     primary_key = {"id"},
     clustering_key = {"cluster_key"},
-    indexes = {inbound_dns = true, name = true}
+    indexes = {request_host = true, name = true}
   }
 
   describe("SELECT", function()
@@ -21,8 +21,8 @@ describe("Query Builder", function()
     end)
 
     it("should return the columns of the arguments to bind", function()
-      local _, columns = builder.select("apis", {name="mockbin", inbound_dns="mockbin.com"})
-      assert.same({"name", "inbound_dns"}, columns)
+      local _, columns = builder.select("apis", {name="mockbin", request_host="mockbin.com"})
+      assert.same({"name", "request_host"}, columns)
     end)
 
     describe("WHERE", function()
@@ -50,8 +50,8 @@ describe("Query Builder", function()
       end)
 
       it("should enable filtering when more than one indexed field is being queried", function()
-        local q, _, needs_filtering = builder.select("apis", {name="mockbin", inbound_dns="mockbin.com"}, apis_details)
-        assert.equal("SELECT * FROM apis WHERE name = ? AND inbound_dns = ? ALLOW FILTERING", q)
+        local q, _, needs_filtering = builder.select("apis", {name="mockbin", request_host="mockbin.com"}, apis_details)
+        assert.equal("SELECT * FROM apis WHERE name = ? AND request_host = ? ALLOW FILTERING", q)
         assert.True(needs_filtering)
       end)
     end)
@@ -122,8 +122,8 @@ describe("Query Builder", function()
     end)
 
     it("should return the columns of the arguments to bind", function()
-      local _, columns = builder.update("apis", {inbound_dns="1234", name="mockbin"}, {id="1"}, apis_details)
-      assert.same({"name", "inbound_dns", "id"}, columns)
+      local _, columns = builder.update("apis", {request_host="1234", name="mockbin"}, {id="1"}, apis_details)
+      assert.same({"name", "request_host", "id"}, columns)
     end)
 
     it("should throw an error if no column_family", function()

--- a/spec/unit/dao/entities_schemas_spec.lua
+++ b/spec/unit/dao/entities_schemas_spec.lua
@@ -27,7 +27,7 @@ describe("Entities Schemas", function()
 
     it("should return error with wrong upstream_url", function()
       local valid, errors = validate_entity({
-        inbound_dns = "mockbin.com",
+        request_host = "mockbin.com",
         upstream_url = "asdasd"
       }, api_schema)
       assert.False(valid)
@@ -36,16 +36,16 @@ describe("Entities Schemas", function()
 
     it("should return error with wrong upstream_url protocol", function()
       local valid, errors = validate_entity({
-        inbound_dns = "mockbin.com",
+        request_host = "mockbin.com",
         upstream_url = "wot://mockbin.com/"
       }, api_schema)
       assert.False(valid)
       assert.equal("Supported protocols are HTTP and HTTPS", errors.upstream_url)
     end)
 
-    it("should validate without a path", function()
+    it("should validate without a request_path", function()
       local valid, errors = validate_entity({
-        inbound_dns = "mockbin.com",
+        request_host = "mockbin.com",
         upstream_url = "http://mockbin.com"
       }, api_schema)
       assert.falsy(errors)
@@ -54,32 +54,32 @@ describe("Entities Schemas", function()
 
     it("should validate with upper case protocol", function()
       local valid, errors = validate_entity({
-        inbound_dns = "mockbin.com",
+        request_host = "mockbin.com",
         upstream_url = "HTTP://mockbin.com/world"
       }, api_schema)
       assert.falsy(errors)
       assert.True(valid)
     end)
 
-    it("should complain if missing `inbound_dns` and `path`", function()
+    it("should complain if missing `request_host` and `request_path`", function()
       local valid, errors = validate_entity({
         name = "mockbin"
       }, api_schema)
       assert.False(valid)
-      assert.equal("At least an 'inbound_dns' or a 'path' must be specified", errors.path)
-      assert.equal("At least an 'inbound_dns' or a 'path' must be specified", errors.inbound_dns)
+      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
+      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
 
       local valid, errors = validate_entity({
         name = "mockbin",
-        path = true
+        request_path = true
       }, api_schema)
       assert.False(valid)
-      assert.equal("path is not a string", errors.path)
-      assert.equal("At least an 'inbound_dns' or a 'path' must be specified", errors.inbound_dns)
+      assert.equal("request_path is not a string", errors.request_path)
+      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
     end)
 
-    it("should set the name from inbound_dns if not set", function()
-      local t = { inbound_dns = "mockbin.com", upstream_url = "http://mockbin.com" }
+    it("should set the name from request_host if not set", function()
+      local t = { request_host = "mockbin.com", upstream_url = "http://mockbin.com" }
 
       local valid, errors = validate_entity(t, api_schema)
       assert.falsy(errors)
@@ -87,10 +87,10 @@ describe("Entities Schemas", function()
       assert.equal("mockbin.com", t.name)
     end)
 
-    it("should accept valid wildcard inbound_dns", function()
+    it("should accept valid wildcard request_host", function()
       local valid, errors = validate_entity({
         name = "mockbin",
-        inbound_dns = "*.mockbin.org",
+        request_host = "*.mockbin.org",
         upstream_url = "http://mockbin.com"
       }, api_schema)
       assert.True(valid)
@@ -98,98 +98,98 @@ describe("Entities Schemas", function()
 
       valid, errors = validate_entity({
         name = "mockbin",
-        inbound_dns = "mockbin.*",
+        request_host = "mockbin.*",
         upstream_url = "http://mockbin.com"
       }, api_schema)
       assert.True(valid)
       assert.falsy(errors)
     end)
 
-    it("should refuse invalid wildcard inbound_dns", function()
+    it("should refuse invalid wildcard request_host", function()
       local api_t = {
         name = "mockbin",
-        inbound_dns = "*.mockbin.*",
+        request_host = "*.mockbin.*",
         upstream_url = "http://mockbin.com"
       }
 
       local valid, errors = validate_entity(api_t, api_schema)
       assert.False(valid)
-      assert.equal("Only one wildcard is allowed: *.mockbin.*", errors.inbound_dns)
+      assert.equal("Only one wildcard is allowed: *.mockbin.*", errors.request_host)
 
-      api_t.inbound_dns = "*mockbin.com"
+      api_t.request_host = "*mockbin.com"
       valid, errors = validate_entity(api_t, api_schema)
       assert.False(valid)
-      assert.equal("Invalid wildcard placement: *mockbin.com", errors.inbound_dns)
+      assert.equal("Invalid wildcard placement: *mockbin.com", errors.request_host)
 
-      api_t.inbound_dns = "www.mockbin*"
+      api_t.request_host = "www.mockbin*"
       valid, errors = validate_entity(api_t, api_schema)
       assert.False(valid)
-      assert.equal("Invalid wildcard placement: www.mockbin*", errors.inbound_dns)
+      assert.equal("Invalid wildcard placement: www.mockbin*", errors.request_host)
     end)
 
-    it("should only accept alphanumeric `path`", function()
+    it("should only accept alphanumeric `request_path`", function()
       local valid, errors = validate_entity({
         name = "mockbin",
-        path = "/[a-zA-Z]{3}",
+        request_path = "/[a-zA-Z]{3}",
         upstream_url = "http://mockbin.com"
       }, api_schema)
-      assert.equal("path must only contain alphanumeric and '. -, _, ~, /' characters", errors.path)
+      assert.equal("request_path must only contain alphanumeric and '. -, _, ~, /' characters", errors.request_path)
       assert.False(valid)
 
       valid = validate_entity({
         name = "mockbin",
-        path = "/status/",
+        request_path = "/status/",
         upstream_url = "http://mockbin.com"
       }, api_schema)
       assert.True(valid)
 
       valid = validate_entity({
         name = "mockbin",
-        path = "/abcd~user-2",
+        request_path = "/abcd~user-2",
         upstream_url = "http://mockbin.com"
       }, api_schema)
       assert.True(valid)
     end)
 
-    it("should prefix a `path` with a slash and remove trailing slash", function()
-      local api_t = { name = "mockbin", path = "status", upstream_url = "http://mockbin.com" }
+    it("should prefix a `request_path` with a slash and remove trailing slash", function()
+      local api_t = { name = "mockbin", request_path = "status", upstream_url = "http://mockbin.com" }
       validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.path)
+      assert.equal("/status", api_t.request_path)
 
-      api_t.path = "/status"
+      api_t.request_path = "/status"
       validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.path)
+      assert.equal("/status", api_t.request_path)
 
-      api_t.path = "status/"
+      api_t.request_path = "status/"
       validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.path)
+      assert.equal("/status", api_t.request_path)
 
-      api_t.path = "/status/"
+      api_t.request_path = "/status/"
       validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.path)
+      assert.equal("/status", api_t.request_path)
 
-      api_t.path = "/deep/nested/status/"
+      api_t.request_path = "/deep/nested/status/"
       validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.path)
+      assert.equal("/deep/nested/status", api_t.request_path)
 
-      api_t.path = "deep/nested/status"
+      api_t.request_path = "deep/nested/status"
       validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.path)
+      assert.equal("/deep/nested/status", api_t.request_path)
 
       -- Strip all leading slashes
-      api_t.path = "//deep/nested/status"
+      api_t.request_path = "//deep/nested/status"
       validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.path)
+      assert.equal("/deep/nested/status", api_t.request_path)
 
       -- Strip all trailing slashes
-      api_t.path = "/deep/nested/status//"
+      api_t.request_path = "/deep/nested/status//"
       validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.path)
+      assert.equal("/deep/nested/status", api_t.request_path)
 
-      -- Error if invalid path
-      api_t.path = "/deep//nested/status"
+      -- Error if invalid request_path
+      api_t.request_path = "/deep//nested/status"
       local _, errors = validate_entity(api_t, api_schema)
-      assert.equal("path is invalid: /deep//nested/status", errors.path)
+      assert.equal("request_path is invalid: /deep//nested/status", errors.request_path)
     end)
 
   end)

--- a/spec/unit/dao/error_spec.lua
+++ b/spec/unit/dao/error_spec.lua
@@ -57,11 +57,11 @@ describe("DaoError", function()
     -- example: schema validation returns a table with key/values for errors
     local stub_error = {
       name = "name is required",
-      inbound_dns = "invalid url"
+      request_host = "invalid url"
     }
 
     local err = DaoError(stub_error, "some_type")
-    assert.are.same("name=name is required inbound_dns=invalid url", tostring(err))
+    assert.are.same("name=name is required request_host=invalid url", tostring(err))
   end)
 
 end)

--- a/spec/unit/resolver/access_spec.lua
+++ b/spec/unit/resolver/access_spec.lua
@@ -3,13 +3,13 @@ local resolver_access = require "kong.resolver.access"
 -- Stubs
 require "kong.tools.ngx_stub"
 local APIS_FIXTURES = {
-  {name = "mockbin", inbound_dns = "mockbin.com", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", inbound_dns = "mockbin-auth.com", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", inbound_dns = "*.wildcard.com", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", inbound_dns = "wildcard.*", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", path = "/mockbin", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", path = "/mockbin-with-dashes", upstream_url = "http://mockbin.com"},
-  {name = "mockbin", path = "/some/deep/url", upstream_url = "http://mockbin.com"}
+  {name = "mockbin", request_host = "mockbin.com", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_host = "mockbin-auth.com", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_host = "*.wildcard.com", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_host = "wildcard.*", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_path = "/mockbin", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_path = "/mockbin-with-dashes", upstream_url = "http://mockbin.com"},
+  {name = "mockbin", request_path = "/some/deep/url", upstream_url = "http://mockbin.com"}
 }
 _G.dao = {
   apis = {
@@ -27,25 +27,25 @@ describe("Resolver Access", function()
       apis_dics = resolver_access.load_apis_in_memory()
       assert.equal("table", type(apis_dics))
       assert.truthy(apis_dics.by_dns)
-      assert.truthy(apis_dics.path_arr)
+      assert.truthy(apis_dics.request_path_arr)
       assert.truthy(apis_dics.wildcard_dns_arr)
     end)
-    it("should return a dictionary of APIs by inbound_dns", function()
+    it("should return a dictionary of APIs by request_host", function()
       assert.equal("table", type(apis_dics.by_dns["mockbin.com"]))
       assert.equal("table", type(apis_dics.by_dns["mockbin-auth.com"]))
     end)
-    it("should return an array of APIs by path", function()
-      assert.equal("table", type(apis_dics.path_arr))
-      assert.equal(3, #apis_dics.path_arr)
-      for _, item in ipairs(apis_dics.path_arr) do
-        assert.truthy(item.strip_path_pattern)
-        assert.truthy(item.path)
+    it("should return an array of APIs by request_path", function()
+      assert.equal("table", type(apis_dics.request_path_arr))
+      assert.equal(3, #apis_dics.request_path_arr)
+      for _, item in ipairs(apis_dics.request_path_arr) do
+        assert.truthy(item.strip_request_path_pattern)
+        assert.truthy(item.request_path)
         assert.truthy(item.api)
       end
-      assert.equal("/mockbin", apis_dics.path_arr[1].strip_path_pattern)
-      assert.equal("/mockbin%-with%-dashes", apis_dics.path_arr[2].strip_path_pattern)
+      assert.equal("/mockbin", apis_dics.request_path_arr[1].strip_request_path_pattern)
+      assert.equal("/mockbin%-with%-dashes", apis_dics.request_path_arr[2].strip_request_path_pattern)
     end)
-    it("should return an array of APIs with wildcard inbound_dns", function()
+    it("should return an array of APIs with wildcard request_host", function()
       assert.equal("table", type(apis_dics.wildcard_dns_arr))
       assert.equal(2, #apis_dics.wildcard_dns_arr)
       for _, item in ipairs(apis_dics.wildcard_dns_arr) do
@@ -56,31 +56,31 @@ describe("Resolver Access", function()
       assert.equal("^wildcard%..+$", apis_dics.wildcard_dns_arr[2].pattern)
     end)
   end)
-  describe("find_api_by_path()", function()
+  describe("find_api_by_request_path()", function()
     it("should return nil when no matching API for that URI", function()
-      local api = resolver_access.find_api_by_path("/", apis_dics.path_arr)
+      local api = resolver_access.find_api_by_request_path("/", apis_dics.request_path_arr)
       assert.falsy(api)
     end)
     it("should return the API for a matching URI", function()
-      local api = resolver_access.find_api_by_path("/mockbin", apis_dics.path_arr)
+      local api = resolver_access.find_api_by_request_path("/mockbin", apis_dics.request_path_arr)
       assert.same(APIS_FIXTURES[5], api)
 
-      api = resolver_access.find_api_by_path("/mockbin-with-dashes", apis_dics.path_arr)
+      api = resolver_access.find_api_by_request_path("/mockbin-with-dashes", apis_dics.request_path_arr)
       assert.same(APIS_FIXTURES[6], api)
 
-      api = resolver_access.find_api_by_path("/mockbin-with-dashes/and/some/uri", apis_dics.path_arr)
+      api = resolver_access.find_api_by_request_path("/mockbin-with-dashes/and/some/uri", apis_dics.request_path_arr)
       assert.same(APIS_FIXTURES[6], api)
 
-      api = resolver_access.find_api_by_path("/dashes-mockbin", apis_dics.path_arr)
+      api = resolver_access.find_api_by_request_path("/dashes-mockbin", apis_dics.request_path_arr)
       assert.falsy(api)
 
-      api = resolver_access.find_api_by_path("/some/deep/url", apis_dics.path_arr)
+      api = resolver_access.find_api_by_request_path("/some/deep/url", apis_dics.request_path_arr)
       assert.same(APIS_FIXTURES[7], api)
     end)
   end)
-  describe("find_api_by_inbound_dns()", function()
+  describe("find_api_by_request_host()", function()
     it("should return nil and a list of all the Host headers in the request when no API was found", function()
-      local api, all_hosts = resolver_access.find_api_by_inbound_dns({
+      local api, all_hosts = resolver_access.find_api_by_request_host({
         Host = "foo.com",
         ["X-Host-Override"] = {"bar.com", "hello.com"}
       }, apis_dics)
@@ -88,33 +88,33 @@ describe("Resolver Access", function()
       assert.same({"foo.com", "bar.com", "hello.com"}, all_hosts)
     end)
     it("should return an API when one of the Host headers matches", function()
-      local api = resolver_access.find_api_by_inbound_dns({Host = "mockbin.com"}, apis_dics)
+      local api = resolver_access.find_api_by_request_host({Host = "mockbin.com"}, apis_dics)
       assert.same(APIS_FIXTURES[1], api)
 
-      api = resolver_access.find_api_by_inbound_dns({Host = "mockbin-auth.com"}, apis_dics)
+      api = resolver_access.find_api_by_request_host({Host = "mockbin-auth.com"}, apis_dics)
       assert.same(APIS_FIXTURES[2], api)
     end)
     it("should return an API when one of the Host headers matches a wildcard dns", function()
-      local api = resolver_access.find_api_by_inbound_dns({Host = "wildcard.com"}, apis_dics)
+      local api = resolver_access.find_api_by_request_host({Host = "wildcard.com"}, apis_dics)
       assert.same(APIS_FIXTURES[4], api)
-      api = resolver_access.find_api_by_inbound_dns({Host = "wildcard.fr"}, apis_dics)
+      api = resolver_access.find_api_by_request_host({Host = "wildcard.fr"}, apis_dics)
       assert.same(APIS_FIXTURES[4], api)
 
-      api = resolver_access.find_api_by_inbound_dns({Host = "foobar.wildcard.com"}, apis_dics)
+      api = resolver_access.find_api_by_request_host({Host = "foobar.wildcard.com"}, apis_dics)
       assert.same(APIS_FIXTURES[3], api)
-      api = resolver_access.find_api_by_inbound_dns({Host = "barfoo.wildcard.com"}, apis_dics)
+      api = resolver_access.find_api_by_request_host({Host = "barfoo.wildcard.com"}, apis_dics)
       assert.same(APIS_FIXTURES[3], api)
     end)
   end)
-  describe("strip_path()", function()
-    it("should strip the api's path from the requested URI", function()
-      assert.equal("/status/200", resolver_access.strip_path("/mockbin/status/200", apis_dics.path_arr[1].strip_path_pattern))
-      assert.equal("/status/200", resolver_access.strip_path("/mockbin-with-dashes/status/200", apis_dics.path_arr[2].strip_path_pattern))
-      assert.equal("/", resolver_access.strip_path("/mockbin", apis_dics.path_arr[1].strip_path_pattern))
-      assert.equal("/", resolver_access.strip_path("/mockbin/", apis_dics.path_arr[1].strip_path_pattern))
+  describe("strip_request_path()", function()
+    it("should strip the api's request_path from the requested URI", function()
+      assert.equal("/status/200", resolver_access.strip_request_path("/mockbin/status/200", apis_dics.request_path_arr[1].strip_request_path_pattern))
+      assert.equal("/status/200", resolver_access.strip_request_path("/mockbin-with-dashes/status/200", apis_dics.request_path_arr[2].strip_request_path_pattern))
+      assert.equal("/", resolver_access.strip_request_path("/mockbin", apis_dics.request_path_arr[1].strip_request_path_pattern))
+      assert.equal("/", resolver_access.strip_request_path("/mockbin/", apis_dics.request_path_arr[1].strip_request_path_pattern))
     end)
     it("should only strip the first pattern", function()
-      assert.equal("/mockbin/status/200/mockbin", resolver_access.strip_path("/mockbin/mockbin/status/200/mockbin", apis_dics.path_arr[1].strip_path_pattern))
+      assert.equal("/mockbin/status/200/mockbin", resolver_access.strip_request_path("/mockbin/mockbin/status/200/mockbin", apis_dics.request_path_arr[1].strip_request_path_pattern))
     end)
   end)
 end)

--- a/spec/unit/tools/faker_spec.lua
+++ b/spec/unit/tools/faker_spec.lua
@@ -48,7 +48,7 @@ describe("Faker", function()
 
   describe("#insert_from_table()", function()
     it("should throw a descriptive error if cannot insert an entity", function()
-      local api_t = { name = "tests faker 1", inbound_dns = "foo.com", upstream_url = "http://mockbin.com" }
+      local api_t = { name = "tests faker 1", request_host = "foo.com", upstream_url = "http://mockbin.com" }
 
       local printable_mt = require "kong.tools.printable"
       local entity_to_str = setmetatable(api_t, printable_mt)
@@ -87,8 +87,8 @@ describe("Faker", function()
     it("should create relations between entities_to_insert and inserted entities", function()
       local fixtures = {
         api = {
-          { name = "tests faker 1", inbound_dns = "foo.com", upstream_url = "http://mockbin.com" },
-          { name = "tests faker 2", inbound_dns = "bar.com", upstream_url = "http://mockbin.com" }
+          { name = "tests faker 1", request_host = "foo.com", upstream_url = "http://mockbin.com" },
+          { name = "tests faker 2", request_host = "bar.com", upstream_url = "http://mockbin.com" }
         },
         plugin = {
           { name = "key-auth", config = {key_names={"apikey"}}, __api = 1 },


### PR DESCRIPTION
As discussed last week, renaming to `inbound_dns` and keeping `path` and `strip_path` was not good enough. Now prefixing those with "request" to avoid confusion from users.

- inbound_dns -> request_host
- path -> request_path
- strip_path -> strip_request_path