### PR TITLE
[feat/jwt] accept a manually set `secret`

### DIFF
--- a/kong/plugins/jwt/daos.lua
+++ b/kong/plugins/jwt/daos.lua
@@ -1,10 +1,6 @@
 local BaseDao = require "kong.dao.cassandra.base_dao"
 local utils = require "kong.tools.utils"
 
-local function random_string(v, t, column)
-  return true, nil, {[column] = utils.random_string()}
-end
-
 local SCHEMA = {
   primary_key = {"id"},
   fields = {
@@ -12,7 +8,7 @@ local SCHEMA = {
     created_at = {type = "timestamp", dao_insert_value = true},
     consumer_id = {type = "id", required = true, queryable = true, foreign = "consumers:id"},
     key = {type = "string", unique = true, queryable = true, default = utils.random_string},
-    secret = {type = "string", unique = true, func = random_string}
+    secret = {type = "string", unique = true, default = utils.random_string}
   }
 }
 

--- a/spec/plugins/jwt/api_spec.lua
+++ b/spec/plugins/jwt/api_spec.lua
@@ -43,12 +43,12 @@ describe("JWT API", function()
         jwt1 = body
       end)
 
-      it("[SUCCESS] should override any given `secret` and accept a `key` parameter", function()
+      it("[SUCCESS] should accepty any given `secret` and `key` parameters", function()
         local response, status = http_client.post(BASE_URL, {key = "bob2", secret = "tooshort"})
         assert.equal(201, status)
         local body = json.decode(response)
         assert.equal("bob2", body.key)
-        assert.not_equal("tooshort", body.secret)
+        assert.equal("tooshort", body.secret)
 
         jwt2 = body
       end)


### PR DESCRIPTION
Credentials could be migrated from another system, hence both `key` and
`secret` should be possible to manually set. They are still
auto-generated if not specified.