### PR TITLE
Adding wait time before rate-limiting tests

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KONG_VERSION=0.4.1
+KONG_VERSION=0.5.0
 
 sudo apt-get update
 

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -10,16 +10,19 @@ function _M.get_utc()
   return math.floor(luatz.time()) * 1000
 end
 
---- Creates a timestamp
--- @param now (optional) Time to generate a timestamp from, if omitted current UTC time will be used
--- @return Timestamp table containing fields; second, minute, hour, day, month, year
-function _M.get_timestamps(now)
+function _M.get_timetable(now)
   local timestamp = now and now or _M.get_utc()
   if string.len(tostring(timestamp)) == 13 then
     timestamp = timestamp / 1000
   end
+  return luatz.timetable.new_from_timestamp(timestamp)
+end
 
-  local timetable = luatz.timetable.new_from_timestamp(timestamp)
+--- Creates a timestamp
+-- @param now (optional) Time to generate a timestamp from, if omitted current UTC time will be used
+-- @return Timestamp table containing fields; second, minute, hour, day, month, year
+function _M.get_timestamps(now)
+  local timetable = _M.get_timetable(now)
 
   local second = luatz.timetable.new(timetable.year, timetable.month,
                                      timetable.day, timetable.hour,

--- a/spec/plugins/rate-limiting/access_spec.lua
+++ b/spec/plugins/rate-limiting/access_spec.lua
@@ -1,15 +1,17 @@
 local spec_helper = require "spec.spec_helpers"
 local http_client = require "kong.tools.http_client"
+local timestamp = require "kong.tools.timestamp"
 local cjson = require "cjson"
 
 local STUB_GET_URL = spec_helper.STUB_GET_URL
 
 local function wait()
-  -- Wait til the beginning of a new second before starting the test
-  -- to avoid ending up in an edge case when the second is about to end
-  local now = os.time()
-  while os.time() < now + 1 do
-    -- Nothing
+  -- If the minute elapses in the middle of the test, then the test will
+  -- fail. So we give it this test 30 seconds to execute, and if the second
+  -- of the current minute is > 30, then we wait till the new minute kicks in
+  local current_second = timestamp.get_timetable().sec
+  if current_second > 30 then
+    os.execute("sleep "..tostring(60 - current_second))
   end
 end
 
@@ -43,6 +45,8 @@ describe("RateLimiting Plugin", function()
     }
 
     spec_helper.start_kong()
+
+    wait()
   end)
 
   teardown(function()
@@ -52,8 +56,6 @@ describe("RateLimiting Plugin", function()
   describe("Without authentication (IP address)", function()
 
     it("should get blocked if exceeding limit", function()
-      wait()
-
       -- Default rate-limiting plugin for this API says 6/minute
       local limit = 6
 
@@ -76,8 +78,6 @@ describe("RateLimiting Plugin", function()
         minute = 3,
         hour = 5
       }
-
-      wait()
 
       for i = 1, 3 do
         local _, status, headers = http_client.get(STUB_GET_URL, {}, {host = "test5.com"})
@@ -104,8 +104,6 @@ describe("RateLimiting Plugin", function()
     describe("Default plugin", function()
 
       it("should get blocked if exceeding limit", function()
-        wait()
-
         -- Default rate-limiting plugin for this API says 6/minute
         local limit = 6
 
@@ -128,8 +126,6 @@ describe("RateLimiting Plugin", function()
     describe("Plugin customized for specific consumer", function()
 
       it("should get blocked if exceeding limit", function()
-        wait()
-
         -- This plugin says this consumer can make 4 requests/minute, not 6 like the default
         local limit = 8
 


### PR DESCRIPTION
This will fix the occasional test failure in rate-limiting plugins.