### PR TITLE
Add 'WWW-Authenticate' header for reponses w/ status code 401 Unauthorized.

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -85,6 +85,7 @@ function _M.execute(conf)
   -- If both headers are missing, return 401
   if not (ngx.req.get_headers()[AUTHORIZATION] or ngx.req.get_headers()[PROXY_AUTHORIZATION]) then
     ngx.ctx.stop_phases = true
+    ngx.header["WWW-Authenticate"] = "Basic realm=\""..constants.NAME.."\""
     return responses.send_HTTP_UNAUTHORIZED()
   end
 

--- a/kong/plugins/key-auth/access.lua
+++ b/kong/plugins/key-auth/access.lua
@@ -72,6 +72,7 @@ function _M.execute(conf)
   -- No key found in the request's headers or parameters
   if not key_found then
     ngx.ctx.stop_phases = true
+    ngx.header["WWW-Authenticate"] = "Key realm=\""..constants.NAME.."\""
     return responses.send_HTTP_UNAUTHORIZED("No API Key found in headers, body or querystring")
   end
 

--- a/spec/plugins/basic-auth/access_spec.lua
+++ b/spec/plugins/basic-auth/access_spec.lua
@@ -1,5 +1,6 @@
 local spec_helper = require "spec.spec_helpers"
 local http_client = require "kong.tools.http_client"
+local constants = require "kong.constants"
 local cjson = require "cjson"
 
 local PROXY_URL = spec_helper.PROXY_URL
@@ -32,10 +33,11 @@ describe("Authentication Plugin", function()
 
   describe("Basic Authentication", function()
 
-    it("should return invalid credentials when the credential is missing", function()
-      local response, status = http_client.get(PROXY_URL.."/get", {}, {host = "basicauth.com"})
+    it("should return invalid credentials and www-authenticate header when the credential is missing", function()
+      local response, status, headers = http_client.get(PROXY_URL.."/get", {}, {host = "basicauth.com"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Basic realm=\""..constants.NAME.."\"")
       assert.equal("Unauthorized", body.message)
     end)
 
@@ -67,10 +69,11 @@ describe("Authentication Plugin", function()
       assert.equal("Invalid authentication credentials", body.message)
     end)
 
-    it("should reply 401 when authorization is missing", function()
-      local response, status = http_client.get(PROXY_URL.."/get", {}, {host = "basicauth.com", authorization123 = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="})
+    it("should reply 401 and www-authenticate header when authorization is missing", function()
+      local response, status, headers = http_client.get(PROXY_URL.."/get", {}, {host = "basicauth.com", authorization123 = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Basic realm=\""..constants.NAME.."\"")
       assert.equal("Unauthorized", body.message)
     end)
 

--- a/spec/plugins/key-auth/access_spec.lua
+++ b/spec/plugins/key-auth/access_spec.lua
@@ -1,5 +1,6 @@
 local spec_helper = require "spec.spec_helpers"
 local http_client = require "kong.tools.http_client"
+local constants = require "kong.constants"
 local cjson = require "cjson"
 
 local STUB_GET_URL = spec_helper.STUB_GET_URL
@@ -35,10 +36,11 @@ describe("Authentication Plugin", function()
 
   describe("Query Authentication", function()
 
-     it("should return invalid credentials when the credential is missing", function()
-      local response, status = http_client.get(STUB_GET_URL, {}, {host = "keyauth1.com"})
+     it("should return invalid credentials and www-authenticate header when the credential is missing", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, {}, {host = "keyauth1.com"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 
@@ -49,24 +51,27 @@ describe("Authentication Plugin", function()
       assert.equal("Invalid authentication credentials", body.message)
     end)
 
-    it("should reply 401 when the credential parameter is missing", function()
-      local response, status = http_client.get(STUB_GET_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
+    it("should reply with 401 and www-authenticate header when the credential parameter is missing", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 
-    it("should reply 401 when the credential parameter name is wrong in GET", function()
-      local response, status = http_client.get(STUB_GET_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
+    it("should reply 401 and www-authenticate header when the credential parameter name is wrong in GET", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 
-    it("should reply 401 when the credential parameter name is wrong in POST", function()
-      local response, status = http_client.post(STUB_POST_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
+    it("should reply 401 and www-authenticate header when the credential parameter name is wrong in POST", function()
+      local response, status, headers = http_client.post(STUB_POST_URL, {apikey123 = "apikey123"}, {host = "keyauth1.com"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 
@@ -77,17 +82,19 @@ describe("Authentication Plugin", function()
       assert.equal("apikey123", parsed_response.queryString.apikey)
     end)
 
-    it("should reply 401 when the credential parameter name is wrong in GET header", function()
-      local response, status = http_client.get(STUB_GET_URL, {}, {host = "keyauth1.com", apikey123 = "apikey123"})
+    it("should reply 401 and www-authenticate header when the credential parameter name is wrong in GET header", function()
+      local response, status, headers = http_client.get(STUB_GET_URL, {}, {host = "keyauth1.com", apikey123 = "apikey123"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 
-    it("should reply 401 when the credential parameter name is wrong in POST header", function()
-      local response, status = http_client.post(STUB_POST_URL, {}, {host = "keyauth1.com", apikey123 = "apikey123"})
+    it("should reply 401 and www-authenticate header when the credential parameter name is wrong in POST header", function()
+      local response, status, headers = http_client.post(STUB_POST_URL, {}, {host = "keyauth1.com", apikey123 = "apikey123"})
       local body = cjson.decode(response)
       assert.equal(401, status)
+      assert.equal(headers["www-authenticate"], "Key realm=\""..constants.NAME.."\"")
       assert.equal("No API Key found in headers, body or querystring", body.message)
     end)
 


### PR DESCRIPTION
Adds a new header 'WWW-Authenticate' for 401 responses, the header value typically should include a [challenge](http://stackoverflow.com/questions/17687876/authorization-in-restful-http-api-401-www-authenticate?answertab=votes#tab-top) with some information about the authentication scheme (key-auth) #587 