### PR TITLE
[feat/config] add options for keyspace replication strategy

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -38,39 +38,38 @@ database: cassandra
 ## Databases configuration
 databases_available:
   cassandra:
-    properties:
-      contact_points:
-        - "localhost:9042"
-      timeout: 1000
-      keepalive: 60000 # in milliseconds
-      keyspace: kong
+    contact_points:
+      - "localhost:9042"
+    timeout: 1000
+    keepalive: 60000 # in milliseconds
+    keyspace: kong
 
-      ## Keyspace options. Set those before running Kong or any migration.
-      ## Those settings will be used to create a keyspace with the desired options
-      ## when first running the migrations.
-      ##
-      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+    ## Keyspace options. Set those before running Kong or any migration.
+    ## Those settings will be used to create a keyspace with the desired options
+    ## when first running the migrations.
+    ##
+    ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
 
-      ## The name of the replica placement strategy class for the new keyspace.
-      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
-      replication_strategy: SimpleStrategy
+    ## The name of the replica placement strategy class for the new keyspace.
+    ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+    replication_strategy: SimpleStrategy
 
-      ## For SimpleStrategy only.
-      ## The number of replicas of data on multiple nodes.
-      replication_factor: 1
+    ## For SimpleStrategy only.
+    ## The number of replicas of data on multiple nodes.
+    replication_factor: 1
 
-      ## For NetworkTopologyStrategy only.
-      ## The number of replicas of data on multiple nodes in each data center.
-      # data_centers:
-      #   dc1: 2
-      #   dc2: 3
+    ## For NetworkTopologyStrategy only.
+    ## The number of replicas of data on multiple nodes in each data center.
+    # data_centers:
+    #   dc1: 2
+    #   dc2: 3
 
-      ## SSL client-to-node encryption and authentication options.
-      # ssl: false
-      # ssl_verify: false
-      # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
-      # user: cassandra
-      # password: cassandra
+    ## SSL client-to-node encryption and authentication options.
+    # ssl: false
+    # ssl_verify: false
+    # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
+    # user: cassandra
+    # password: cassandra
 
 ## Cassandra cache configuration
 database_cache_expiration: 5 # in seconds

--- a/kong.yml
+++ b/kong.yml
@@ -42,8 +42,30 @@ databases_available:
       contact_points:
         - "localhost:9042"
       timeout: 1000
-      keyspace: kong
       keepalive: 60000 # in milliseconds
+      keyspace: kong
+
+      ## Keyspace options. Set those before running Kong or any migration.
+      ## Those settings will be used to create a keyspace with the desired options
+      ## when first running the migrations.
+      ##
+      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+
+      ## The name of the replica placement strategy class for the new keyspace.
+      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+      replication_strategy: SimpleStrategy
+
+      ## For SimpleStrategy only.
+      ## The number of replicas of data on multiple nodes.
+      replication_factor: 1
+
+      ## For NetworkTopologyStrategy only.
+      ## The number of replicas of data on multiple nodes in each data center.
+      # data_centers:
+      #   dc1: 2
+      #   dc2: 3
+
+      ## SSL client-to-node encryption and authentication options.
       # ssl: false
       # ssl_verify: false
       # ssl_certificate: "/path/to/cluster-ca-certificate.pem"

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -108,7 +108,7 @@ local function prepare_nginx_working_dir(args_config)
 
   ssl.prepare_ssl(kong_config)
   local ssl_cert_path, ssl_key_path = ssl.get_ssl_cert_and_key(kong_config)
-  local trusted_ssl_cert_path = kong_config.databases_available[kong_config.database].properties.ssl_certificate -- DAO ssl cert
+  local trusted_ssl_cert_path = kong_config.dao_config.ssl_certificate -- DAO ssl cert
 
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = kong_config.nginx
@@ -205,7 +205,7 @@ _M.QUIT = QUIT
 
 function _M.prepare_kong(args_config, signal)
   local kong_config = get_kong_config(args_config)
-  local dao_config = kong_config.databases_available[kong_config.database].properties
+  local dao_config = kong_config.dao_config
 
   local printable_mt = require "kong.tools.printable"
   setmetatable(dao_config, printable_mt)

--- a/kong/tools/io.lua
+++ b/kong/tools/io.lua
@@ -137,7 +137,7 @@ function _M.load_configuration_and_dao(configuration_path)
 
   -- Instantiate the DAO Factory along with the configuration
   local DaoFactory = require("kong.dao."..configuration.database..".factory")
-  local dao_factory = DaoFactory(dao_config.properties, configuration.plugins_available)
+  local dao_factory = DaoFactory(dao_config, configuration.plugins_available)
 
   return configuration, dao_factory
 end

--- a/kong/tools/io.lua
+++ b/kong/tools/io.lua
@@ -103,7 +103,7 @@ function _M.file_size(path)
 end
 
 --- Load a yaml configuration file.
--- The return config will get 2 extra fields; `pid_file` of the nginx process 
+-- The return config will get 2 extra fields; `pid_file` of the nginx process
 -- and `dao_config` as a shortcut to the dao configuration
 -- @param configuration_path path to configuration file to load
 -- @return config Loaded configuration table

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -13,7 +13,6 @@ local env = spec_helper.get_env() -- test environment
 local faker = env.faker
 local dao_factory = env.dao_factory
 local configuration = env.configuration
-configuration.cassandra = configuration.databases_available[configuration.database].properties
 
 -- An utility function to apply tests on core collections.
 local function describe_core_collections(tests_cb)
@@ -46,9 +45,9 @@ describe("Cassandra", function()
 
     -- Create a parallel session to verify the dao's behaviour
     session = cassandra:new()
-    session:set_timeout(configuration.cassandra.timeout)
+    session:set_timeout(configuration.dao_config.timeout)
 
-    local _, err = session:connect(configuration.cassandra.contact_points)
+    local _, err = session:connect(configuration.dao_config.contact_points)
     assert.falsy(err)
 
     local _, err = session:set_keyspace("kong_tests")

--- a/spec/integration/dao/cassandra/migrations_spec.lua
+++ b/spec/integration/dao/cassandra/migrations_spec.lua
@@ -71,7 +71,7 @@ local CORE_MIGRATIONS_STUB = {
 
 local test_env = spec_helper.get_env() -- test environment
 local test_configuration = test_env.configuration
-local test_cassandra_properties = test_configuration.databases_available[test_configuration.database].properties
+local test_cassandra_properties = test_configuration.dao_config
 test_cassandra_properties.keyspace = TEST_KEYSPACE
 
 local test_dao = DAO(test_cassandra_properties)

--- a/spec/integration/dao/cassandra/migrations_spec.lua
+++ b/spec/integration/dao/cassandra/migrations_spec.lua
@@ -61,9 +61,9 @@ local CORE_MIGRATIONS_STUB = {
       ]]
     end,
     down = function()
-       return [[
-         DROP TABLE users2;
-       ]]
+      return [[
+        DROP TABLE users2;
+      ]]
     end
   }
 
@@ -99,6 +99,37 @@ say:set("assertion.has_table.positive", "Expected keyspace to have table %s")
 say:set("assertion.has_table.negative", "Expected keyspace not to have table %s")
 assert:register("assertion", "has_table", has_table, "assertion.has_table.positive", "assertion.has_table.negative")
 
+local function has_keyspace(state, arguments)
+  local rows, err = session:execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?", {arguments[1]})
+  if err then
+    error(err)
+  end
+
+  return #rows > 0
+end
+
+say:set("assertion.has_keyspace.positive", "Expected keyspace %s to exist")
+say:set("assertion.has_keyspace.negative", "Expected keyspace %s to not exist")
+assert:register("assertion", "has_keyspace", has_keyspace, "assertion.has_keyspace.positive", "assertion.has_keyspace.negative")
+
+local function has_replication_options(state, arguments)
+  local rows, err = session:execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?", {arguments[1]})
+  if err then
+    error(err)
+  end
+
+  if #rows > 0 then
+    local keyspace = rows[1]
+    assert.equal("org.apache.cassandra.locator."..arguments[2], keyspace.strategy_class)
+    assert.equal(arguments[3], keyspace.strategy_options)
+    return true
+  end
+end
+
+say:set("assertion.has_replication_options.positive", "Expected keyspace %s to have given replication options")
+say:set("assertion.has_replication_options.negative", "Expected keyspace %s to not have given replication options")
+assert:register("assertion", "has_replication_options", has_replication_options, "assertion.has_replication_options.positive", "assertion.has_replication_options.negative")
+
 local function has_migration(state, arguments)
   local identifier = arguments[1]
   local migration = arguments[2]
@@ -121,7 +152,6 @@ local function has_migration(state, arguments)
   return false
 end
 
-local say = require "say"
 say:set("assertion.has_migration.positive", "Expected keyspace to have migration %s record")
 say:set("assertion.has_migration.negative", "Expected keyspace not to have migration %s recorded")
 assert:register("assertion", "has_migration", has_migration, "assertion.has_migration.positive", "assertion.has_migration.negative")
@@ -230,6 +260,31 @@ describe("Migrations", function()
 
       assert.has_table("plugins2")
       assert.has_migration("fixtures", "stub_fixture_mig2")
+    end)
+  end)
+  describe("keyspace replication strategy", function()
+    local KEYSPACE_NAME = "kong_replication_strategy_tests"
+
+    setup(function()
+      migrations = Migrations(test_dao)
+      migrations.dao_properties.keyspace = KEYSPACE_NAME
+    end)
+
+    after_each(function()
+      session:execute("DROP KEYSPACE "..KEYSPACE_NAME)
+    end)
+
+    it("should create a keyspace with SimpleStrategy by default", function()
+      local err = migrations:migrate("core")
+      assert.falsy(err)
+      assert.has_keyspace(KEYSPACE_NAME)
+      assert.has_replication_options(KEYSPACE_NAME, "SimpleStrategy", "{\"replication_factor\":\"1\"}")
+    end)
+    it("should catch an invalid replication strategy", function()
+      migrations.dao_properties.replication_strategy = "foo"
+      local err = migrations:migrate("core")
+      assert.truthy(err)
+      assert.equal("invalid replication_strategy class", err)
     end)
   end)
 end)

--- a/spec/unit/dao/cassandra/migrations_spec.lua
+++ b/spec/unit/dao/cassandra/migrations_spec.lua
@@ -1,0 +1,52 @@
+local stringy = require "stringy"
+local migrations = require "kong.dao.cassandra.schema.migrations"
+local first_migration = migrations[1]
+
+local function strip_query(str)
+  str = stringy.split(str, ";")[1]
+  str = str:gsub("\n", " "):gsub("%s+", " ")
+  return stringy.strip(str)
+end
+
+describe("Cassandra migrations", function()
+  describe("Keyspace options", function()
+    it("should default to SimpleStrategy class with replication_factor of 1", function()
+      local queries = first_migration.up({keyspace = "kong"})
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace_query)
+    end)
+    it("should be possible to set a custom replication_factor", function()
+      local queries = first_migration.up({keyspace = "kong", replication_factor = 2})
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 2}", keyspace_query)
+    end)
+    it("should accept NetworkTopologyStrategy", function()
+      local queries = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "NetworkTopologyStrategy"
+      })
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy'}", keyspace_query)
+    end)
+    it("should be possible to set data centers for NetworkTopologyStrategy", function()
+      local queries = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "NetworkTopologyStrategy",
+        data_centers = {
+          dc1 = 2,
+          dc2 = 3
+        }
+      })
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 3}", keyspace_query)
+    end)
+    it("should return an error if an invalid replication_strategy is given", function()
+      local queries, err = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "foo"
+      })
+      assert.falsy(queries)
+      assert.equal("invalid replication_strategy class", err)
+    end)
+  end)
+end)

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -80,39 +80,38 @@ database: cassandra
 ## Databases configuration
 databases_available:
   cassandra:
-    properties:
-      contact_points:
-        - "localhost:9042"
-      timeout: 1000
-      keepalive: 60000 # in milliseconds
-      keyspace: kong
+    contact_points:
+      - "localhost:9042"
+    timeout: 1000
+    keepalive: 60000 # in milliseconds
+    keyspace: kong
 
-      ## Keyspace options. Set those before running Kong or any migration.
-      ## Those settings will be used to create a keyspace with the desired options
-      ## when first running the migrations.
-      ##
-      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+    ## Keyspace options. Set those before running Kong or any migration.
+    ## Those settings will be used to create a keyspace with the desired options
+    ## when first running the migrations.
+    ##
+    ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
 
-      ## The name of the replica placement strategy class for the new keyspace.
-      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
-      replication_strategy: SimpleStrategy
+    ## The name of the replica placement strategy class for the new keyspace.
+    ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+    replication_strategy: SimpleStrategy
 
-      ## For SimpleStrategy only.
-      ## The number of replicas of data on multiple nodes.
-      replication_factor: 1
+    ## For SimpleStrategy only.
+    ## The number of replicas of data on multiple nodes.
+    replication_factor: 1
 
-      ## For NetworkTopologyStrategy only.
-      ## The number of replicas of data on multiple nodes in each data center.
-      # data_centers:
-      #   dc1: 2
-      #   dc2: 3
+    ## For NetworkTopologyStrategy only.
+    ## The number of replicas of data on multiple nodes in each data center.
+    # data_centers:
+    #   dc1: 2
+    #   dc2: 3
 
-      ## SSL client-to-node encryption and authentication options.
-      # ssl: false
-      # ssl_verify: false
-      # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
-      # user: cassandra
-      # password: cassandra
+    ## SSL client-to-node encryption and authentication options.
+    # ssl: false
+    # ssl_verify: false
+    # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
+    # user: cassandra
+    # password: cassandra
 
 ## Cassandra cache configuration
 database_cache_expiration: 5 # in seconds

--- a/spec/unit/statics_spec.lua
+++ b/spec/unit/statics_spec.lua
@@ -84,8 +84,30 @@ databases_available:
       contact_points:
         - "localhost:9042"
       timeout: 1000
-      keyspace: kong
       keepalive: 60000 # in milliseconds
+      keyspace: kong
+
+      ## Keyspace options. Set those before running Kong or any migration.
+      ## Those settings will be used to create a keyspace with the desired options
+      ## when first running the migrations.
+      ##
+      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+
+      ## The name of the replica placement strategy class for the new keyspace.
+      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+      replication_strategy: SimpleStrategy
+
+      ## For SimpleStrategy only.
+      ## The number of replicas of data on multiple nodes.
+      replication_factor: 1
+
+      ## For NetworkTopologyStrategy only.
+      ## The number of replicas of data on multiple nodes in each data center.
+      # data_centers:
+      #   dc1: 2
+      #   dc2: 3
+
+      ## SSL client-to-node encryption and authentication options.
       # ssl: false
       # ssl_verify: false
       # ssl_certificate: "/path/to/cluster-ca-certificate.pem"


### PR DESCRIPTION
Possibility to configure the replication strategy used by the created
keyspace and its options.

Added options:

```yaml
## Keyspace options. Set those before running Kong or any migration.
## Those settings will be used to create a keyspace with the desired options
## when first running the migrations.
##
## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html

## The name of the replica placement strategy class for the new keyspace.
## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
replication_strategy: SimpleStrategy

## For SimpleStrategy only.
## The number of replicas of data on multiple nodes.
replication_factor: 1

## For NetworkTopologyStrategy only.
## The number of replicas of data on multiple nodes in each data center.
# data_centers:
#   dc1: 2
#   dc2: 3
```

Implements #543 and #350