### PR TITLE
[docs] document the new gitflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,7 @@ First version running with Cassandra.
 - CLI `bin/kong` script.
 - Database migrations (using `db.lua`).
 
-[unreleased]: https://github.com/mashape/kong/compare/0.5.1...HEAD
+[unreleased]: https://github.com/mashape/kong/compare/0.5.1...next
 [0.5.1]: https://github.com/mashape/kong/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/mashape/kong/compare/0.4.2...0.5.0
 [0.4.2]: https://github.com/mashape/kong/compare/0.4.1...0.4.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Discuss it on the [Google Group](https://groups.google.com/forum/#!forum/konglay
 
 ## Found a bug?
 
-We would like to hear about it. Please [submit an issue][new-issue] on GitHub and we will follow up. Even better, we would appreaciate a [Pull Request][new-pr] with a fix for it.
+We would like to hear about it. Please [submit an issue][new-issue] on GitHub and we will follow up. Even better, we would appreaciate a [Pull Request][new-pr] with a fix for it. If the fix is urgent, feel free to open the PR against the `master` branch.
 
 ## Want a feature?
 
@@ -36,7 +36,7 @@ Before submitting your Pull Request please make sure to:
 - Consider squashing your commits. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review. As a final step before merging we will either ask you to squash all commits yourself or we'll do it for you.
 - Run the test suite with `make test-all`.
 
-If all went well, we are eager to see your contribution, feel free to submit your Pull Request!
+If all went well, we are eager to see your contribution, feel free to submit your Pull Request against the `next` branch.
 
 [new-issue]: #submitting-an-issue
 [new-pr]: #submitting-a-pull-request

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can find a detailed Roadmap of Kong on the [Wiki](https://github.com/Mashape
 
 ## Development
 
-If you are planning on developing on Kong (writing your own plugin or contribute to the core), you'll need a development installation.
+If you are planning on developing on Kong (writing your own plugin or contribute to the core), you'll need a development installation. The `next` branch holds the latest unreleased source code.
 
 #### Vagrant
 
@@ -107,11 +107,13 @@ You can use a Vagrant box running Kong and Cassandra that you can find at [Masha
 
 #### Source Install
 
-First, you will need to already have Kong installed. Install Kong by following one of the methods described at [getkong.org/download](http://getkong.org/download). Then, make sure you have downloaded [Cassandra](http://cassandra.apache.org/download/) and that it is running. These steps will override your Kong installation with the latest source from the master branch:
+First, you will need to already have Kong installed. Install Kong by following one of the methods described at [getkong.org/download](http://getkong.org/download). Then, make sure you have downloaded [Cassandra](http://cassandra.apache.org/download/) and that it is running. These steps will override your Kong installation with the latest source code:
 
 ```shell
+# clone the repo and use the next branch
 $ git clone https://github.com/Mashape/kong
 $ cd kong/
+$ git checkout next
 
 # Build and install Kong globally using Luarocks, overriding the version previously installed
 $ [sudo] make install


### PR DESCRIPTION
As discussed internally, we decided to change the git flow of Kong. This PR introduces the documentation changes in the development instructions.

- The `master` branch is to hold only production-ready, released code. Release tags are to be created on this branch. **No direct commit** is to be made to this branch.
- The `next` branch is to hold development, unreleased code. **No direct commit** is to be made to it either.
- **New features** are to be introduced through a pull request against the `next` branch. (Ideally the branch is named `feat/xxx`)
- **Bug fixes** must either be proposed in a pull request against the `next` branch, or, depending on the urgency of it, against the `master` branch. If made against the `master` branch, it is considered a hotfix and must be manually merged in `master` and `next` at the same time. (Ideally the branch is either named `fix/xxx` or `hotfix/xxx`).
- **New releases** are created in a `release/xxx` branch created from `next`. Once created, the "release manager" updates the necessary informations (version bump, CHANGELOG updates, last minute fixes...) and must manually merge back it into both `next` and `master` before creating the release tag on `master`.

Pinging @thefosk @shashiranjan84 @sinzone @ahmadnassri since you are the principal committers on this project. Please review and acknowledge those changes and checkout the new `next` branch in your clones.

Related:
Mashape/homebrew-kong#12
Mashape/kong-vagrant#13

Current PRs are to be re-opened against `next`.