### PR TITLE
[feature/rate-limiting] add rate-limit usage status support

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -55,6 +55,9 @@ return {
       "day",
       "month",
       "year"
-    }
+    },
+    USAGE_STATUS = {
+      NO_LIMIT_VALUE = "unlimited",
+    },
   }
 }

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -8,7 +8,8 @@ return {
     hour = { type = "number" },
     day = { type = "number" },
     month = { type = "number" },
-    year = { type = "number" }
+    year = { type = "number" },
+    usage_status_url = { type = "string", default = "/usage_status" },
   },
   self_check = function(schema, plugin_t, dao, is_update)
     local ordered_periods = { "second", "minute", "hour", "day", "month", "year"}


### PR DESCRIPTION
after some discussions in #517 and #531, this pull request adds a support to fetch current rate-limit usage status.

to fetch the current usage status, user, consumer or admin will request the proxy (port 8000) with a custom url that can be configured in the plugin configuration.