### PR TITLE
[feat/cli] keyspace options in configuration and un-nesting

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 ######
 ## Kong configuration file. All commented values are default values.
 ## Uncomment and update a value to configure Kong to your needs.
@@ -59,61 +58,60 @@
 ## Databases configuration.
 # databases_available:
   # cassandra:
-    # properties:
-      ######
-      ## Contact points to your Cassandra cluster.
-      # contact_points:
-      #   - "localhost:9042"
+    ######
+    ## Contact points to your Cassandra cluster.
+    # contact_points:
+    #   - "localhost:9042"
 
-      # timeout: 1000
+    # timeout: 1000
 
-      # keyspace: kong
+    # keyspace: kong
 
-      ######
-      ## Time (in milliseconds) for which sockets will be keep alive.
-      ## for being eventually re-used before being closed.
-      # keepalive: 60000
+    ######
+    ## Time (in milliseconds) for which sockets will be keep alive.
+    ## for being eventually re-used before being closed.
+    # keepalive: 60000
 
-      ######
-      ## Keyspace options. Set those before running Kong or any migration.
-      ## Those settings will be used to create a keyspace with the desired options
-      ## when first running the migrations.
-      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+    ######
+    ## Keyspace options. Set those before running Kong or any migration.
+    ## Those settings will be used to create a keyspace with the desired options
+    ## when first running the migrations.
+    ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
 
-      ######
-      ## The name of the replica placement strategy class for the new keyspace.
-      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
-      # replication_strategy: SimpleStrategy
+    ######
+    ## The name of the replica placement strategy class for the new keyspace.
+    ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+    # replication_strategy: SimpleStrategy
 
-      ######
-      ## For SimpleStrategy only.
-      ## The number of replicas of data on multiple nodes.
-      # replication_factor: 1
+    ######
+    ## For SimpleStrategy only.
+    ## The number of replicas of data on multiple nodes.
+    # replication_factor: 1
 
-      ######
-      ## For NetworkTopologyStrategy only.
-      ## The number of replicas of data on multiple nodes in each data center.
-      # data_centers:
-      #   dc1: 2
-      #   dc2: 3
+    ######
+    ## For NetworkTopologyStrategy only.
+    ## The number of replicas of data on multiple nodes in each data center.
+    # data_centers:
+    #   dc1: 2
+    #   dc2: 3
 
-      ######
-      ## If true, will enable client-to-node encryption.
-      # ssl: false
+    ######
+    ## If true, will enable client-to-node encryption.
+    # ssl: false
 
-      ######
-      ## If true, will verify the SSL certificate in use.
-      ## `ssl_certificate` must be provided.
-      # ssl_verify: false
+    ######
+    ## If true, will verify the SSL certificate in use.
+    ## `ssl_certificate` must be provided.
+    # ssl_verify: false
 
-      ######
-      ## **Absolute path** to the certificate authority file for your cluster.
-      # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
+    ######
+    ## **Absolute path** to the certificate authority file for your cluster.
+    # ssl_certificate: "/path/to/cluster-ca-certificate.pem"
 
-      ######
-      ## If the cluster as authentication enabled, provide a user and a password here.
-      # user: cassandra
-      # password: cassandra
+    ######
+    ## If the cluster as authentication enabled, provide a user and a password here.
+    # user: cassandra
+    # password: cassandra
 
 ######
 ## Time (in seconds) for which entities from the database (APIs, plugins configurations...)

--- a/kong.yml
+++ b/kong.yml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 ######
 ## Kong configuration file. All commented values are default values.
 ## Uncomment and update a value to configure Kong to your needs.
@@ -72,6 +73,29 @@
       ## Time (in milliseconds) for which sockets will be keep alive.
       ## for being eventually re-used before being closed.
       # keepalive: 60000
+
+      ######
+      ## Keyspace options. Set those before running Kong or any migration.
+      ## Those settings will be used to create a keyspace with the desired options
+      ## when first running the migrations.
+      ## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html
+
+      ######
+      ## The name of the replica placement strategy class for the new keyspace.
+      ## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
+      # replication_strategy: SimpleStrategy
+
+      ######
+      ## For SimpleStrategy only.
+      ## The number of replicas of data on multiple nodes.
+      # replication_factor: 1
+
+      ######
+      ## For NetworkTopologyStrategy only.
+      ## The number of replicas of data on multiple nodes in each data center.
+      # data_centers:
+      #   dc1: 2
+      #   dc2: 3
 
       ######
       ## If true, will enable client-to-node encryption.

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -95,7 +95,7 @@ local function prepare_nginx_working_dir(args_config)
 
   ssl.prepare_ssl(kong_config)
   local ssl_cert_path, ssl_key_path = ssl.get_ssl_cert_and_key(kong_config)
-  local trusted_ssl_cert_path = kong_config.dao_config.properties.ssl_certificate -- DAO ssl cert
+  local trusted_ssl_cert_path = kong_config.dao_config.ssl_certificate -- DAO ssl cert
 
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = kong_config.nginx
@@ -193,7 +193,7 @@ _M.QUIT = QUIT
 
 function _M.prepare_kong(args_config, signal)
   local kong_config = get_kong_config(args_config)
-  local dao_config = kong_config.databases_available[kong_config.database].properties
+  local dao_config = kong_config.dao_config
 
   local printable_mt = require "kong.tools.printable"
   setmetatable(dao_config, printable_mt)

--- a/kong/dao/cassandra/schema/migrations.lua
+++ b/kong/dao/cassandra/schema/migrations.lua
@@ -1,32 +1,10 @@
-local DEFAULTS = {
-  ["SimpleStrategy"] = {
-    replication_factor = 1
-  },
-  ["NetworkTopologyStrategy"] = {
-    data_centers = {}
-  }
-}
-
 local Migrations = {
   {
     init = true,
     name = "2015-01-12-175310_skeleton",
     up = function(options)
-      if not options.replication_strategy then options.replication_strategy = "SimpleStrategy" end
       local keyspace_name = options.keyspace
-      local strategy, strategy_properties = "", ""
-
-      -- Find strategy and retrieve default options
-      for strategy_name, strategy_defaults in pairs(DEFAULTS) do
-        if options.replication_strategy == strategy_name then
-          strategy = strategy_name
-          for opt_name, opt_value in pairs(strategy_defaults) do
-            if not options[opt_name] then
-              options[opt_name] = opt_value
-            end
-          end
-        end
-      end
+      local strategy, strategy_properties = options.replication_strategy, ""
 
       -- Format strategy options
       if strategy == "SimpleStrategy" then

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -17,20 +17,18 @@ return {
       ["cassandra"] = {
         type = "table",
         content = {
-          ["properties"] = {
-            type = "table",
-            content = {
-              ["contact_points"] = {type = "array", default = {"localhost:9042"}},
-              ["timeout"] = {type = "number", default = 1000},
-              ["keyspace"] = {type = "string", default = "kong"},
-              ["keepalive"] = {type = "number", default = 60000},
-              ["ssl"] = {type = "boolean", default = false},
-              ["ssl_verify"] = {type = "boolean", default = false},
-              ["ssl_certificate"] = {type = "string", nullable = true},
-              ["user"] = {type = "string", nullable = true},
-              ["password"] = {type = "string", nullable = true}
-            }
-          }
+          ["contact_points"] = {type = "array", default = {"localhost:9042"}},
+          ["timeout"] = {type = "number", default = 1000},
+          ["keyspace"] = {type = "string", default = "kong"},
+          ["keepalive"] = {type = "number", default = 60000},
+          ["replication_strategy"] = {type = "string", default = "SimpleStrategy"},
+          ["replication_factor"] = {type = "number", default = 1},
+          ["data_centers"] = {type = "table", default = {}},
+          ["ssl"] = {type = "boolean", default = false},
+          ["ssl_verify"] = {type = "boolean", default = false},
+          ["ssl_certificate"] = {type = "string", nullable = true},
+          ["user"] = {type = "string", nullable = true},
+          ["password"] = {type = "string", nullable = true}
         }
       }
     }

--- a/kong/tools/config_loader.lua
+++ b/kong/tools/config_loader.lua
@@ -23,7 +23,7 @@ local function validate_config_schema(config, config_schema)
     property = config[config_key] or key_infos.default
 
     -- Recursion on table values
-    if key_infos.type == "table" then
+    if key_infos.type == "table" and key_infos.content ~= nil then
       if property == nil then
         property = {}
       end

--- a/kong/tools/dao_loader.lua
+++ b/kong/tools/dao_loader.lua
@@ -2,7 +2,7 @@ local _M = {}
 
 function _M.load(config)
   local DaoFactory = require("kong.dao."..config.database..".factory")
-  return DaoFactory(config.dao_config.properties, config.plugins_available)
+  return DaoFactory(config.dao_config, config.plugins_available)
 end
 
 return _M

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -13,7 +13,6 @@ local env = spec_helper.get_env() -- test environment
 local faker = env.faker
 local dao_factory = env.dao_factory
 local configuration = env.configuration
-configuration.cassandra = configuration.databases_available[configuration.database].properties
 
 -- An utility function to apply tests on core collections.
 local function describe_core_collections(tests_cb)
@@ -46,9 +45,9 @@ describe("Cassandra", function()
 
     -- Create a parallel session to verify the dao's behaviour
     session = cassandra:new()
-    session:set_timeout(configuration.cassandra.timeout)
+    session:set_timeout(configuration.dao_config.timeout)
 
-    local _, err = session:connect(configuration.cassandra.contact_points)
+    local _, err = session:connect(configuration.dao_config.contact_points)
     assert.falsy(err)
 
     local _, err = session:set_keyspace("kong_tests")

--- a/spec/integration/dao/cassandra/migrations_spec.lua
+++ b/spec/integration/dao/cassandra/migrations_spec.lua
@@ -71,7 +71,7 @@ local CORE_MIGRATIONS_STUB = {
 
 local test_env = spec_helper.get_env() -- test environment
 local test_configuration = test_env.configuration
-local test_cassandra_properties = test_configuration.databases_available[test_configuration.database].properties
+local test_cassandra_properties = test_configuration.dao_config
 test_cassandra_properties.keyspace = TEST_KEYSPACE
 
 local test_dao = DAO(test_cassandra_properties)

--- a/spec/integration/dao/cassandra/migrations_spec.lua
+++ b/spec/integration/dao/cassandra/migrations_spec.lua
@@ -61,9 +61,9 @@ local CORE_MIGRATIONS_STUB = {
       ]]
     end,
     down = function()
-       return [[
-         DROP TABLE users2;
-       ]]
+      return [[
+        DROP TABLE users2;
+      ]]
     end
   }
 
@@ -99,6 +99,37 @@ say:set("assertion.has_table.positive", "Expected keyspace to have table %s")
 say:set("assertion.has_table.negative", "Expected keyspace not to have table %s")
 assert:register("assertion", "has_table", has_table, "assertion.has_table.positive", "assertion.has_table.negative")
 
+local function has_keyspace(state, arguments)
+  local rows, err = session:execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?", {arguments[1]})
+  if err then
+    error(err)
+  end
+
+  return #rows > 0
+end
+
+say:set("assertion.has_keyspace.positive", "Expected keyspace %s to exist")
+say:set("assertion.has_keyspace.negative", "Expected keyspace %s to not exist")
+assert:register("assertion", "has_keyspace", has_keyspace, "assertion.has_keyspace.positive", "assertion.has_keyspace.negative")
+
+local function has_replication_options(state, arguments)
+  local rows, err = session:execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?", {arguments[1]})
+  if err then
+    error(err)
+  end
+
+  if #rows > 0 then
+    local keyspace = rows[1]
+    assert.equal("org.apache.cassandra.locator."..arguments[2], keyspace.strategy_class)
+    assert.equal(arguments[3], keyspace.strategy_options)
+    return true
+  end
+end
+
+say:set("assertion.has_replication_options.positive", "Expected keyspace %s to have given replication options")
+say:set("assertion.has_replication_options.negative", "Expected keyspace %s to not have given replication options")
+assert:register("assertion", "has_replication_options", has_replication_options, "assertion.has_replication_options.positive", "assertion.has_replication_options.negative")
+
 local function has_migration(state, arguments)
   local identifier = arguments[1]
   local migration = arguments[2]
@@ -121,7 +152,6 @@ local function has_migration(state, arguments)
   return false
 end
 
-local say = require "say"
 say:set("assertion.has_migration.positive", "Expected keyspace to have migration %s record")
 say:set("assertion.has_migration.negative", "Expected keyspace not to have migration %s recorded")
 assert:register("assertion", "has_migration", has_migration, "assertion.has_migration.positive", "assertion.has_migration.negative")
@@ -230,6 +260,31 @@ describe("Migrations", function()
 
       assert.has_table("plugins2")
       assert.has_migration("fixtures", "stub_fixture_mig2")
+    end)
+  end)
+  describe("keyspace replication strategy", function()
+    local KEYSPACE_NAME = "kong_replication_strategy_tests"
+
+    setup(function()
+      migrations = Migrations(test_dao)
+      migrations.dao_properties.keyspace = KEYSPACE_NAME
+    end)
+
+    after_each(function()
+      session:execute("DROP KEYSPACE "..KEYSPACE_NAME)
+    end)
+
+    it("should create a keyspace with SimpleStrategy by default", function()
+      local err = migrations:migrate("core")
+      assert.falsy(err)
+      assert.has_keyspace(KEYSPACE_NAME)
+      assert.has_replication_options(KEYSPACE_NAME, "SimpleStrategy", "{\"replication_factor\":\"1\"}")
+    end)
+    it("should catch an invalid replication strategy", function()
+      migrations.dao_properties.replication_strategy = "foo"
+      local err = migrations:migrate("core")
+      assert.truthy(err)
+      assert.equal("invalid replication_strategy class", err)
     end)
   end)
 end)

--- a/spec/unit/dao/cassandra/migrations_spec.lua
+++ b/spec/unit/dao/cassandra/migrations_spec.lua
@@ -1,0 +1,52 @@
+local stringy = require "stringy"
+local migrations = require "kong.dao.cassandra.schema.migrations"
+local first_migration = migrations[1]
+
+local function strip_query(str)
+  str = stringy.split(str, ";")[1]
+  str = str:gsub("\n", " "):gsub("%s+", " ")
+  return stringy.strip(str)
+end
+
+describe("Cassandra migrations", function()
+  describe("Keyspace options", function()
+    it("should default to SimpleStrategy class with replication_factor of 1", function()
+      local queries = first_migration.up({keyspace = "kong"})
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace_query)
+    end)
+    it("should be possible to set a custom replication_factor", function()
+      local queries = first_migration.up({keyspace = "kong", replication_factor = 2})
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 2}", keyspace_query)
+    end)
+    it("should accept NetworkTopologyStrategy", function()
+      local queries = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "NetworkTopologyStrategy"
+      })
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy'}", keyspace_query)
+    end)
+    it("should be possible to set data centers for NetworkTopologyStrategy", function()
+      local queries = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "NetworkTopologyStrategy",
+        data_centers = {
+          dc1 = 2,
+          dc2 = 3
+        }
+      })
+      local keyspace_query = strip_query(queries)
+      assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 3}", keyspace_query)
+    end)
+    it("should return an error if an invalid replication_strategy is given", function()
+      local queries, err = first_migration.up({
+        keyspace = "kong",
+        replication_strategy = "foo"
+      })
+      assert.falsy(queries)
+      assert.equal("invalid replication_strategy class", err)
+    end)
+  end)
+end)

--- a/spec/unit/dao/cassandra/migrations_spec.lua
+++ b/spec/unit/dao/cassandra/migrations_spec.lua
@@ -1,4 +1,5 @@
 local stringy = require "stringy"
+local spec_helper = require "spec.spec_helpers"
 local migrations = require "kong.dao.cassandra.schema.migrations"
 local first_migration = migrations[1]
 
@@ -8,43 +9,41 @@ local function strip_query(str)
   return stringy.strip(str)
 end
 
+local test_config = spec_helper.get_env().configuration
+local dao_config = test_config.dao_config
+dao_config.keyspace = "kong"
+
 describe("Cassandra migrations", function()
   describe("Keyspace options", function()
     it("should default to SimpleStrategy class with replication_factor of 1", function()
-      local queries = first_migration.up({keyspace = "kong"})
+      local queries = first_migration.up(dao_config)
       local keyspace_query = strip_query(queries)
       assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace_query)
     end)
     it("should be possible to set a custom replication_factor", function()
-      local queries = first_migration.up({keyspace = "kong", replication_factor = 2})
+      dao_config.replication_factor = 2
+      local queries = first_migration.up(dao_config)
       local keyspace_query = strip_query(queries)
       assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 2}", keyspace_query)
     end)
     it("should accept NetworkTopologyStrategy", function()
-      local queries = first_migration.up({
-        keyspace = "kong",
-        replication_strategy = "NetworkTopologyStrategy"
-      })
+      dao_config.replication_strategy = "NetworkTopologyStrategy"
+      local queries = first_migration.up(dao_config)
       local keyspace_query = strip_query(queries)
       assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy'}", keyspace_query)
     end)
     it("should be possible to set data centers for NetworkTopologyStrategy", function()
-      local queries = first_migration.up({
-        keyspace = "kong",
-        replication_strategy = "NetworkTopologyStrategy",
-        data_centers = {
-          dc1 = 2,
-          dc2 = 3
-        }
-      })
+      dao_config.data_centers = {
+        dc1 = 2,
+        dc2 = 3
+      }
+      local queries = first_migration.up(dao_config)
       local keyspace_query = strip_query(queries)
       assert.equal("CREATE KEYSPACE IF NOT EXISTS \"kong\" WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 3}", keyspace_query)
     end)
     it("should return an error if an invalid replication_strategy is given", function()
-      local queries, err = first_migration.up({
-        keyspace = "kong",
-        replication_strategy = "foo"
-      })
+      dao_config.replication_strategy = "foo"
+      local queries, err = first_migration.up(dao_config)
       assert.falsy(queries)
       assert.equal("invalid replication_strategy class", err)
     end)

--- a/spec/unit/tools/config_loader_spec.lua
+++ b/spec/unit/tools/config_loader_spec.lua
@@ -44,10 +44,8 @@ describe("Configuration validation", function()
       database = 666,
       databases_available = {
         cassandra = {
-          properties = {
-            timeout = "foo",
-            ssl = "true"
-          }
+          timeout = "foo",
+          ssl = "true"
         }
       }
     })
@@ -55,8 +53,8 @@ describe("Configuration validation", function()
     assert.truthy(errors)
     assert.equal("must be a number", errors.proxy_port)
     assert.equal("must be a string", errors.database)
-    assert.equal("must be a number", errors["databases_available.cassandra.properties.timeout"])
-    assert.equal("must be a boolean", errors["databases_available.cassandra.properties.ssl"])
+    assert.equal("must be a number", errors["databases_available.cassandra.timeout"])
+    assert.equal("must be a boolean", errors["databases_available.cassandra.ssl"])
     assert.falsy(errors.ssl_cert_path)
     assert.falsy(errors.ssl_key_path)
   end)


### PR DESCRIPTION
Reopening of #589 against feat/commented-config this time.

Possibility to configure the replication strategy used by the created
keyspace and its options.

Added options:

```yaml
######
## Keyspace options. Set those before running Kong or any migration.
## Those settings will be used to create a keyspace with the desired options
## when first running the migrations.
## See http://docs.datastax.com/en/cql/3.1/cql/cql_reference/create_keyspace_r.html

######
## The name of the replica placement strategy class for the new keyspace.
## Can be "SimpleStrategy" or "NetworkTopologyStrategy".
# replication_strategy: SimpleStrategy

######
## For SimpleStrategy only.
## The number of replicas of data on multiple nodes.
# replication_factor: 1

######
## For NetworkTopologyStrategy only.
## The number of replicas of data on multiple nodes in each data center.
# data_centers:
#   dc1: 2
#   dc2: 3
```

Implements #543 and #350