### PR TITLE
[chore/ci] bump cassandra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 
 env:
   global:
-    - CASSANDRA_VERSION=2.1.10
+    - CASSANDRA_VERSION=2.1.11
   matrix:
     - LUA=lua5.1
 


### PR DESCRIPTION
2.1.11 since 2.1.10 has been removed from the Apache downloads.