### PR TITLE
[hotfix/path] search nginx executable in $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ A few fixes requested by the community!
 
 ### Fixed
 
-- Plugins
-- OAuth2: can detect that the originating protocol for a request was HTTPS through the `X-Forwarded-Proto` header and work behind another reverse proxy (load balancer). [#650](https://github.com/Mashape/kong/pull/650)
-- HMAC signature: support for `X-Date` header to sign the request for usage in browsers (since the `Date` header is protected). [#641](https://github.com/Mashape/kong/issues/641)
+- Kong properly search the `nginx` in your $PATH variable.
+- Plugins:
+  - OAuth2: can detect that the originating protocol for a request was HTTPS through the `X-Forwarded-Proto` header and work behind another reverse proxy (load balancer). [#650](https://github.com/Mashape/kong/pull/650)
+  - HMAC signature: support for `X-Date` header to sign the request for usage in browsers (since the `Date` header is protected). [#641](https://github.com/Mashape/kong/issues/641)
 
 ## [0.5.1] - 2015/10/13
 

--- a/kong/cli/utils/signal.lua
+++ b/kong/cli/utils/signal.lua
@@ -37,33 +37,28 @@ end
 -- @param path_to_check Path to the binary
 -- @return true or false
 local function is_openresty(path_to_check)
-  if IO.file_exists(path_to_check) then
-    local cmd = path_to_check.." -v"
-    local out, code = IO.os_execute(cmd)
-    if code ~= 0 then
-      cutils.logger:error_exit(out)
-    end
-    return out:match("^nginx version: ngx_openresty/")
-        or out:match("^nginx version: openresty/")
-        or out:match("^nginx version: nginx/[%w.%s]+%(nginx%-plus%-extras.+%)")
-  end
-  return false
+  local cmd = path_to_check.." -v"
+  local out = IO.os_execute(cmd)
+  return out:match("^nginx version: ngx_openresty/")
+      or out:match("^nginx version: openresty/")
+      or out:match("^nginx version: nginx/[%w.%s]+%(nginx%-plus%-extras.+%)")
 end
 
--- Paths where to search for an `nginx` executable in addition to the usual $PATH
+-- Preferred paths where to search for an `nginx` executable in priority to the $PATH
 local NGINX_BIN = "nginx"
 local NGINX_SEARCH_PATHS = {
   "/usr/local/openresty/nginx/sbin/",
   "/usr/local/opt/openresty/bin/",
   "/usr/local/bin/",
-  "/usr/sbin/"
+  "/usr/sbin/",
+  "" -- to check the $PATH
 }
 
 -- Try to find an `nginx` executable in defined paths, or in $PATH
 -- @return Path to found executable or nil if none was found
 local function find_nginx()
-  for i = 1, #NGINX_SEARCH_PATHS + 1 do
-    local prefix = NGINX_SEARCH_PATHS[i] and NGINX_SEARCH_PATHS[i] or ""
+  for i = 1, #NGINX_SEARCH_PATHS do
+    local prefix = NGINX_SEARCH_PATHS[i]
     local to_check = prefix..NGINX_BIN
     if is_openresty(to_check) then
       return to_check

--- a/kong/tools/io.lua
+++ b/kong/tools/io.lua
@@ -103,7 +103,7 @@ function _M.file_size(path)
 end
 
 --- Load a yaml configuration file.
--- The return config will get 2 extra fields; `pid_file` of the nginx process 
+-- The return config will get 2 extra fields; `pid_file` of the nginx process
 -- and `dao_config` as a shortcut to the dao configuration
 -- @param configuration_path path to configuration file to load
 -- @return config Loaded configuration table


### PR DESCRIPTION
Since IO.file_exists was being called and of course returned false when
called with just `nginx`, the command was never executed, and no chance
was given to the shell to try to find the executable in the $PATH.

Fix #610