### PR TITLE
[feature/POC] Gelato.io integration plugin

### DIFF
--- a/kong-0.5.2-1.rockspec
+++ b/kong-0.5.2-1.rockspec
@@ -114,6 +114,10 @@ build = {
     ["kong.plugins.key-auth.api"] = "kong/plugins/key-auth/api.lua",
     ["kong.plugins.key-auth.daos"] = "kong/plugins/key-auth/daos.lua",
 
+    ["kong.plugins.gelato.handler"] = "kong/plugins/gelato/handler.lua",
+    ["kong.plugins.gelato.access"] = "kong/plugins/gelato/access.lua",
+    ["kong.plugins.gelato.schema"] = "kong/plugins/gelato/schema.lua",
+
     ["kong.plugins.oauth2.migrations.cassandra"] = "kong/plugins/oauth2/migrations/cassandra.lua",
     ["kong.plugins.oauth2.handler"] = "kong/plugins/oauth2/handler.lua",
     ["kong.plugins.oauth2.access"] = "kong/plugins/oauth2/access.lua",

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -321,7 +321,6 @@ function BaseDao:count_by_keys(where_t, paging_state)
   local res, err = self:execute(count_q, where_columns, where_t, {
     paging_state = paging_state
   })
-
   return (#res >= 1 and table.remove(res, 1).count or 0), err, filtering
 end
 

--- a/kong/plugins/gelato/access.lua
+++ b/kong/plugins/gelato/access.lua
@@ -1,0 +1,305 @@
+local responses = require "kong.tools.responses"
+local utils = require "kong.tools.utils"
+local stringy = require "stringy"
+local constants = require "kong.constants"
+
+local _M = {}
+
+local GELATO_URL = "^%s/_gelato(/?(\\?[^\\s]*)?)$"
+
+local BASIC_AUTH = "basic-auth"
+local KEY_AUTH = "key-auth"
+local OAUTH2 = "oauth2"
+
+local RATE_LIMITING = "rate-limiting"
+local REQUEST_SIZE_LIMITING = "request-size-limiting"
+local RESPONSE_RATE_LIMITING = "response-ratelimiting"
+
+local AUTHENTICATIONS = {
+  [KEY_AUTH] = "keyauth_credentials",
+  [BASIC_AUTH] = "basicauth_credentials",
+  [OAUTH2] = "oauth2_credentials"
+}
+
+local function retrieve_parameters()
+  ngx.req.read_body()
+  -- Parameters could be in both the querystring or body
+  return utils.table_merge(ngx.req.get_uri_args(), ngx.req.get_post_args())
+end
+
+local function get_authentication(api_id)
+  local authentication
+
+  for k, v in pairs(AUTHENTICATIONS) do
+    local plugins, err = dao.plugins:find_by_keys({
+      api_id = api_id,
+      name = k,
+      enabled = true
+    })
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+    if #plugins == 1 and authentication then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR("The API has more than one authentication")
+    elseif #plugins == 1 then
+      authentication = plugins[1]
+    end
+  end
+
+  return authentication
+end
+
+local function sanitize_credential(authentication, credential)
+  if authentication.name == BASIC_AUTH then
+    return {
+      id = credential.id,
+      keys = {
+        username = credential.username,
+        password = credential.password
+      }
+    }
+  elseif authentication.name == KEY_AUTH then
+    return {
+      id = credential.id,
+      keys = {
+        [authentication.config.key_names[1]] = credential.key
+      }
+    }
+  elseif authentication.name == OAUTH2 then
+    return {
+      id = credential.id,
+      keys = {
+        client_id = credential.client_id,
+        client_secret = credential.client_secret,
+        redirect_uri = credential.redirect_uri,
+        name = credential.name
+      }
+    }
+  end
+  return credential
+end
+
+local function find_plugin(name, api_id, consumer_id)
+  local plugins, err = dao.plugins:find_by_keys({
+    api_id = api_id,
+    consumer_id = consumer_id,
+    name = name,
+    enabled = true
+  })
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
+  if #plugins == 1 then
+    return plugins[1] -- Return consumer specific
+  else
+    local plugins, err = dao.plugins:find_by_keys({
+      api_id = api_id,
+      name = name,
+      consumer_id = constants.DATABASE_NULL_ID,
+      enabled = true
+    })
+    print(#plugins)
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+    if #plugins == 1 then
+      return plugins[1] -- Return global
+    end
+  end
+end
+
+local function add_notes(authentication, consumer, response)
+  local api_id = authentication.api_id
+  local consumer_id = consumer.id
+
+  local notes = {}
+
+  -- Rate-Limiting
+  local plugin = find_plugin(RATE_LIMITING, api_id, consumer_id)
+  if plugin then
+    local limits = {}
+    for k, v in pairs(plugin.config) do
+      table.insert(limits, v.." requests per "..k)
+    end
+    if #limits > 0 then
+      table.insert(notes, {
+        description = "Rate Limiting",
+        extended = table.concat(limits, ", ")
+      })
+    end
+  end
+
+  -- Request Size Limiting
+  plugin = find_plugin(REQUEST_SIZE_LIMITING, api_id, consumer_id)
+  if plugin then
+    table.insert(notes, {
+      description = "Request Size Limiting",
+      extended = "Maximum allowed request size is "..plugin.config.allowed_payload_size.."MB"
+    })
+  end
+
+  -- Response Rate Limiting
+  local plugin = find_plugin(RESPONSE_RATE_LIMITING, api_id, consumer_id)
+  if plugin then
+    local limits = {}
+    for k, v in pairs(plugin.config.limits) do
+      for l,s in pairs(v) do
+        table.insert(limits, s.." requests per "..l.." for "..k)
+      end
+    end
+    if #limits > 0 then
+      table.insert(notes, {
+        description = "Response Rate Limiting",
+        extended = table.concat(limits, ", ")
+      })
+    end
+  end
+
+  response.notes = notes
+  return response
+end
+
+local function get_consumer(custom_id)
+  -- Get consumer
+  local consumers, err = dao.consumers:find_by_keys({
+    custom_id = custom_id
+  })
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
+
+  if #consumers == 1 then
+    return consumers[1]
+  else
+    return nil
+  end
+end
+
+local function create_credential(authentication, params)
+  -- Retrieve consumer or create new one
+  local consumer_id
+  local consumer = get_consumer(params.custom_id)
+  if consumer then
+    consumer_id = consumer.id
+  else
+    -- Create consumer
+    consumer, err = dao.consumers:insert({
+      custom_id = params.custom_id,
+    })
+    if err then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+    consumer_id = consumer.id
+  end
+
+  local credential_params = {consumer_id = consumer_id}
+  if authentication.name == BASIC_AUTH then
+    credential_params.username = utils.random_string()
+    credential_params.password = utils.random_string()
+  elseif authentication.name == OAUTH2 then
+    credential_params.redirect_uri = params.redirect_uri
+    credential_params.name = params.name
+  end
+
+  local credential, err = dao[AUTHENTICATIONS[authentication.name]]:insert(utils.deep_copy(credential_params))
+  if err then
+    return responses.send_HTTP_BAD_REQUEST(tostring(err))
+  end
+
+  credential_params.id = credential.id
+  local result = {
+    authentication_name = authentication.name,
+    credential = sanitize_credential(authentication, authentication.name == BASIC_AUTH and credential_params or credential)
+  }
+
+  return responses.send_HTTP_OK(add_notes(authentication, consumer, result))
+end
+
+local function retrieve_credentials(authentication, custom_id)
+  -- Get consumer
+  local consumer = get_consumer(custom_id)
+  if not consumer then
+    return responses.send_HTTP_NOT_FOUND("Consumer not found")
+  end
+
+  local credentials, err = dao[AUTHENTICATIONS[authentication.name]]:find_by_keys({
+    consumer_id = consumer.id
+  })
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
+
+  local result = {}
+  for _, v in ipairs(credentials) do
+    if not result.credentials then result.credentials = {} end
+    table.insert(result.credentials, sanitize_credential(authentication, v))
+  end
+
+  result.authentication_name = authentication.name
+  return responses.send_HTTP_OK(add_notes(authentication, consumer, result))
+end
+
+local function delete_credential(authentication, custom_id, credential_id)
+  local consumer = get_consumer(custom_id)
+  if not consumer then
+    return responses.send_HTTP_NOT_FOUND("Consumer not found")
+  end
+
+  local ok, err = dao[AUTHENTICATIONS[authentication.name]]:delete({
+    consumer_id = consumer.id,
+    id = credential_id
+  })
+  if ok then
+    return responses.send_HTTP_OK()
+  end
+  
+  responses.send_HTTP_NOT_FOUND("Credential not found")
+end
+
+local function get_secret(authorization_header)
+  local secret
+  if authorization_header then
+    secret = stringy.split(ngx.decode_base64(authorization_header), ":")[1]
+  end
+  return secret
+end
+
+function _M.execute(conf)
+  -- Check if the API has a request_path and if it's being invoked with the path resolver
+  local path_prefix = (ngx.ctx.api.request_path and stringy.startswith(ngx.var.request_uri, ngx.ctx.api.request_path)) and ngx.ctx.api.request_path or ""
+  if stringy.endswith(path_prefix, "/") then
+    path_prefix = path_prefix:sub(1, path_prefix:len() - 1)
+  end
+
+  if ngx.re.match(ngx.var.request_uri, string.format(GELATO_URL, path_prefix)) then
+    -- Verify secret
+    local secret = get_secret(ngx.req.get_headers()["authorization"])
+    if conf.secret ~= secret then
+      return responses.send_HTTP_FORBIDDEN("Invalid \"secret\"")
+    end
+
+    -- Verify that the API has a valid authentication
+    local authentication = get_authentication(ngx.ctx.api.id)
+    if not authentication then
+      return responses.send_HTTP_BAD_REQUEST("The API either has not authentication, or has an unsupported authentication")
+    else
+      local params = retrieve_parameters()
+      if not params.custom_id or stringy.strip(params.custom_id) == "" then
+        return responses.send_HTTP_BAD_REQUEST("Missing \"custom_id\"")
+      end
+
+      local method = ngx.req.get_method()
+      if method == "POST" then
+        create_credential(authentication, params)
+      elseif method == "GET" then
+        retrieve_credentials(authentication, params.custom_id)
+      elseif method == "DELETE" then
+        delete_credential(authentication, params.custom_id, params.credential_id)
+      else
+        response.send_HTTP_METHOD_NOT_ALLOWED()
+      end
+    end
+  end
+end
+
+return _M

--- a/kong/plugins/gelato/handler.lua
+++ b/kong/plugins/gelato/handler.lua
@@ -1,0 +1,17 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local access = require "kong.plugins.gelato.access"
+
+local GelatoHandler = BasePlugin:extend()
+
+function GelatoHandler:new()
+  GelatoHandler.super.new(self, "gelato")
+end
+
+function GelatoHandler:access(conf)
+  GelatoHandler.super.access(self)
+  access.execute(conf)
+end
+
+GelatoHandler.PRIORITY = 2000
+
+return GelatoHandler

--- a/kong/plugins/gelato/schema.lua
+++ b/kong/plugins/gelato/schema.lua
@@ -1,0 +1,16 @@
+local utils = require "kong.tools.utils"
+local stringy = require "stringy"
+
+local function generate_if_missing(v, t, column)
+  if not v or stringy.strip(v) == "" then
+    return true, nil, { [column] = utils.random_string()}
+  end
+  return true
+end
+
+return {
+  no_consumer = true,
+  fields = {
+    secret = { type = "string", required = false, unique = true, func = generate_if_missing }
+  }
+}

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -3,7 +3,7 @@ return {
     default = {"ssl", "jwt", "acl", "cors", "oauth2", "tcp-log", "udp-log", "file-log",
                "http-log", "key-auth", "hmac-auth", "basic-auth", "ip-restriction",
                "mashape-analytics", "request-transformer", "response-transformer",
-               "request-size-limiting", "rate-limiting", "response-ratelimiting"}
+               "request-size-limiting", "rate-limiting", "response-ratelimiting", "gelato"}
   },
   ["nginx_working_dir"] = {type = "string", default = "/usr/local/kong"},
   ["proxy_port"] = {type = "number", default = 8000},

--- a/spec/plugins/gelato/access_spec.lua
+++ b/spec/plugins/gelato/access_spec.lua
@@ -1,0 +1,261 @@
+local spec_helper = require "spec.spec_helpers"
+local http_client = require "kong.tools.http_client"
+local constants = require "kong.constants"
+local access = require "kong.plugins.gelato.access"
+local cjson = require "cjson"
+
+local PROXY_URL = spec_helper.PROXY_URL
+
+describe("Gelato Plugin", function()
+
+  setup(function()
+    spec_helper.prepare_db()
+    spec_helper.insert_fixtures {
+      api = {
+        {request_host = "gelato.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato2.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato3.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato4.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato5.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato6.com", upstream_url = "http://mockbin.org"},
+        {request_host = "gelato7.com", upstream_url = "http://mockbin.org"}
+      },
+      consumer = {
+        {custom_id = "hello123"}
+      },
+      plugin = {
+        {name = "gelato", config = { secret = "secret123"}, __api = 1},
+        {name = "gelato", config = { secret = "secret123"}, __api = 2},
+        {name = "gelato", config = { secret = "secret123"}, __api = 3},
+        {name = "gelato", config = { secret = "secret123"}, __api = 4},
+        {name = "gelato", config = { secret = "secret123"}, __api = 5},
+        {name = "gelato", config = { secret = "secret123"}, __api = 6},
+        {name = "gelato", config = { secret = "secret123"}, __api = 7},
+        {name = "basic-auth", config = { hide_credentials = false }, __api = 2},
+        {name = "key-auth", config = { hide_credentials = false }, __api = 3},
+        {name = "oauth2", config = { scopes = { "email", "profile" } }, __api = 4 },
+        {name = "basic-auth", config = { hide_credentials = false }, __api = 5},
+        {name = "rate-limiting", config = { minute = 6 }, __api = 5 },
+        {name = "rate-limiting", config = { minute = 3, second = 1}, __api = 5, __consumer = 1 },
+        {name = "basic-auth", config = { hide_credentials = false }, __api = 6},
+        {name = "request-size-limiting", config = {allowed_payload_size = 10}, __api = 6 },
+        {name = "basic-auth", config = { hide_credentials = false }, __api = 7},
+        { name = "response-ratelimiting", config = { limits = { video = { minute = 6, hour = 10 }, image = { minute = 4 } } }, __api = 7 }
+      },
+      basicauth_credential = {
+        --{username = "username", password = "password", __consumer = 1}
+      }
+    }
+
+    spec_helper.start_kong()
+  end)
+
+  teardown(function()
+    spec_helper.stop_kong()
+  end)
+
+  local function get_api_id(host)
+    local response, status = http_client.get(API_URL.."/apis/", { request_host = host })
+    assert.equal(200, status)
+    return cjson.decode(response).data[1].id
+  end
+
+  describe("Gelato", function()
+    
+    it("should return forbidden when secret is not valid", function()
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {}, {host = "gelato.com"})
+      local body = cjson.decode(response)
+      assert.equal(403, status)
+      assert.equal("Invalid \"secret\"", body.message)
+    end)
+
+    it("should return error when secret is valid and API has no authentication", function()
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {}, {host = "gelato.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(400, status)
+      assert.equal("The API either has not authentication, or has an unsupported authentication", body.message)
+    end)
+
+    it("should return success when secret is valid and API has authentication", function()
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(400, status)
+      assert.equal("Missing \"custom_id\"", body.message)
+    end)
+
+    it("should not provision a credential when the custom_id is missing", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(400, status)
+      assert.equal("Missing \"custom_id\"", body.message)
+    end)
+
+    it("should not provision a credential when the custom_id is missing", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="  "}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(400, status)
+      assert.equal("Missing \"custom_id\"", body.message)
+    end)
+
+    it("should provision a credential when the consumer does not exist", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.username)
+      assert.truthy(body.credential.keys.password)
+    end)
+
+    it("should return credentials if they have been created", function()
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credentials)
+      assert.equal(1, #body.credentials)
+      assert.truthy(body.credentials[1].id)
+      assert.truthy(body.credentials[1].keys.username)
+      assert.truthy(body.credentials[1].keys.password)
+    end)
+
+    it("should provision a credential when the consumer exist", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.username)
+      assert.truthy(body.credential.keys.password)
+    end)
+
+    it("should return more than one credential if they have been created", function()
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credentials)
+      assert.equal(2, #body.credentials)
+      assert.truthy(body.credentials[1].id)
+      assert.truthy(body.credentials[1].keys.username)
+      assert.truthy(body.credentials[1].keys.password)
+      assert.truthy(body.credentials[2].id)
+      assert.truthy(body.credentials[2].keys.username)
+      assert.truthy(body.credentials[2].keys.password)
+    end)
+
+    it("should return error when deleting an unexisting credential", function()
+      local response, status = http_client.delete(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(404, status)
+      assert.equal("Credential not found", body.message)
+    end)
+
+    it("should return error when deleting an unexisting consumer", function()
+      local response, status = http_client.delete(PROXY_URL.."/_gelato", {custom_id="user124"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(404, status)
+      assert.equal("Consumer not found", body.message)
+    end)
+
+    it("should return error when deleting an unexisting credential", function()
+      local response, status = http_client.delete(PROXY_URL.."/_gelato", {custom_id="user123", credential_id="asd"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(404, status)
+      assert.equal("Credential not found", body.message)
+    end)
+
+    it("should delete a credential", function()
+      -- Retrieve credential ID
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credentials)
+      assert.equal(2, #body.credentials)
+      assert.truthy(body.credentials[1].id)
+
+      local response, status = http_client.delete(PROXY_URL.."/_gelato", {custom_id="user123", credential_id=body.credentials[1].id}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      assert.equal(200, status)
+
+      local response, status = http_client.get(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato2.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credentials)
+      assert.equal(1, #body.credentials)
+    end)
+
+    it("should provision a key-auth", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato3.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("key-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys["apikey"])
+    end)
+
+    it("should not provision an oauth2 without required parameters", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato4.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(400, status)
+      assert.equal("redirect_uri=redirect_uri is required name=name is required", body.message)
+    end)
+
+     it("should provision an oauth2", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123", name="app", redirect_uri="http://google.com"}, {host = "gelato4.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("oauth2", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.client_id)
+      assert.truthy(body.credential.keys.client_secret)
+      assert.truthy(body.credential.keys.name)
+      assert.truthy(body.credential.keys.redirect_uri)
+    end)
+    
+    it("should provision a credential and return the rate limiting notes", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="user123"}, {host = "gelato5.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.username)
+      assert.truthy(body.credential.keys.password)
+
+      assert.equal(1, #body.notes)
+      assert.equal("Rate Limiting", body.notes[1].description)
+      assert.equal("6 requests per minute", body.notes[1].extended)
+    end)
+
+    it("should provision a credential and return the request size limit notes for the specific consumer", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="hello123"}, {host = "gelato6.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.username)
+      assert.truthy(body.credential.keys.password)
+
+      assert.equal(1, #body.notes)
+      assert.equal("Request Size Limiting", body.notes[1].description)
+      assert.equal("Maximum allowed request size is 10MB", body.notes[1].extended)
+    end)
+
+    it("should provision a credential and return the response rate limiting notes for the specific consumer", function()
+      local response, status = http_client.post(PROXY_URL.."/_gelato", {custom_id="hello123"}, {host = "gelato7.com", authorization = "c2VjcmV0MTIzOg=="})
+      local body = cjson.decode(response)
+      assert.equal(200, status)
+      assert.equal("basic-auth", body.authentication_name)
+      assert.truthy(body.credential.id)
+      assert.truthy(body.credential.keys.username)
+      assert.truthy(body.credential.keys.password)
+
+      assert.equal(1, #body.notes)
+      assert.equal("Response Rate Limiting", body.notes[1].description)
+      assert.equal("6 requests per minute for video, 10 requests per hour for video, 4 requests per minute for image", body.notes[1].extended)
+    end)
+    
+  end)
+
+end)


### PR DESCRIPTION
Gelato integration with the following features:

* Credential Provisioning
* Credential Retrieving
* Credential Deletion
* Notes (global or consumer-specific, if available) for:
 * Rate Limiting plugin
 * Response Rate Limiting plugin
 * Request Size Limiting

Authentications supported:

* Key Authentication Plugin
* Basic Authentication Plugin
* OAuth 2.0 Plugin

Related to https://github.com/Mashape/gelato.io/issues/160

Implements the following specification:

### Provisioning a credential

Provisioning a new credential can be done by executing the following request to the Gelato plugin:

```
curl -X POST -d "secret=ABC&custom_id=USER123" kong:8000/_gelato/
```

Which returns something like (if the API has basic authentication):

```json
{
    "authentication_name": "basic",
    "notes": {},
    "credential": {
        "id": "id123",
        "keys": {
            "username": "hello",
            "password": "world"
        }
    }
}
```

### Retrieving an existing credential

If the user already has a key, the keys can be retrieved like:

```
curl -X GET -d "secret=ABC&custom_id=USER123" kong:8000/_gelato/
```

```json
{
    "authentication_name": "basic",
    "notes": {},
    "credentials": [
        {
            "id": "id123",
            "keys": {
                "username": "hello",
                "password": "world"
            }
        },
        {
            "id": "id124",
            "keys": {
                "username": "user123",
                "password": "pass123"
            }
        }
    ]
}
```

### Deleting a credential

A credential can be deleted by its `credential_id`, with:

```
curl -X DELETE kong:8000/_gelato/?custom_id=consumer123&credential_id=credential123
```

### Gelato Plugin

The Gelato plugin will answer to any request sent to `/_gelato` to either provision or retrieve a credential (similar to how the OAuth 2.0 plugin handles the requests to `/oauth2/..` endpoints).

In the specific case of Kong, the `POST kong:8000/_gelato/` request will:

* Retrieve the `custom_id` from the request, and check if it exists. If it doesn't, creates the consumer on Kong using the Admin API, create a credential, and then return the response.

When executing `GET kong:8000/_gelato/` it will:

* Retrieve the `custom_id` from the request, and retrieve every credential associated to the API and send them back in the response.

And finally `DELETE kong:8000/_gelato/` will:

* Retrieve the credential `credential_id` and delete the credential for that specific `custom_id`.

### Authentication Names

The `authentication_name` property returned in the response can be:

* `basic`
* `key`
* `oauth2`

### Custom Fields

Some authentications follow a specification, like Basic Authentication, but some others don't. For example in the case of Key Authentication, Gelato needs to know what is the parameter name where the key should be appended to. In order to retrieve this information, Gelato needs to properly parse the credential name:

```json
{
    "authentication_name": "key",
    "credential": {
        "id": "id123",
        "keys": {
            "system_apikey": "apikey123"
        }
    }
}
```

In the case of OAuth 2.0, custom fields include the authorization and token URLs which may vary depending on the implementation, the response could be something like:

```json
{
    "authentication_name": "oauth2",
    "credential": {
        "id": "id123",
        "keys": {
            "client_id": "client123",
            "client_secret": "secret123",
            "name": "Test Application",
            "redirect_uri": "http://google.com"
        }
    }
}
```

### The Notes section

If the API has Rate Limiting, Response Rate Limiting or Request Size Limiting, the plugin will return specific notes about them in a `notes` property:

```
curl -X GET -d "secret=ABC&custom_id=USER123" kong:8000/_gelato/
```

Which returns:

```json
{
    "authentication_name": "basic",
    "notes": [
        {
            "description": "Rate Limiting",
            "extended": "6 requests per second, 20 requests per minute"
        },
        {
            "description": "Request Size Limiting",
            "extended": "Maximum allowed request size is 10MB"
        }
    ],
    "credentials": [
        {
            "id": "id123",
            "keys": {
                "username": "hello",
                "password": "world"
            }
        },
        {
            "id": "id124",
            "keys": {
                "username": "user123",
                "password": "pass123"
            }
        }
    ]
}
```

Gelato will just go through the notes and display them on the documentation. Because when retrieving the credentials we are passing a `custom_id`, the notes will be specific to the consumer if, for example, his rate-limiting his different than the global rate-limiting.