### PR TITLE
Replacing the previous uuid library with our lua_uuid

### DIFF
--- a/kong-0.5.2-1.rockspec
+++ b/kong-0.5.2-1.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "lua ~> 5.1",
   "luasec ~> 0.5-2",
 
-  "uuid ~> 0.2-1",
+  "lua_uuid ~> 0.1-4",
   "luatz ~> 0.3-1",
   "yaml ~> 1.1.2-1",
   "lapis ~> 1.3.0-1",

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -14,15 +14,12 @@ local DaoError = require "kong.dao.error"
 local stringy = require "stringy"
 local Object = require "classic"
 local utils = require "kong.tools.utils"
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 
 local cassandra_constants = cassandra.constants
 local error_types = constants.DATABASE_ERROR_TYPES
 
 local BaseDao = Object:extend()
-
--- This is important to seed the UUID generator
-uuid.seed()
 
 local function session_uniq_addr(session)
   return session.host..":"..session.port

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1,10 +1,7 @@
 ---
 -- Module containing some general utility functions
 
-local uuid = require "uuid"
-
--- This is important to seed the UUID generator
-uuid.seed()
+local uuid = require "lua_uuid"
 
 local _M = {}
 

--- a/spec/integration/dao/cassandra/base_dao_spec.lua
+++ b/spec/integration/dao/cassandra/base_dao_spec.lua
@@ -4,7 +4,7 @@ local constants = require "kong.constants"
 local DaoError = require "kong.dao.error"
 local utils = require "kong.tools.utils"
 local cjson = require "cjson"
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 
 -- Raw session for double-check purposes
 local session

--- a/spec/plugins/key-auth/daos_spec.lua
+++ b/spec/plugins/key-auth/daos_spec.lua
@@ -1,5 +1,5 @@
 local spec_helper = require "spec.spec_helpers"
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 
 local env = spec_helper.get_env()
 local dao_factory = env.dao_factory

--- a/spec/plugins/rate-limiting/daos_spec.lua
+++ b/spec/plugins/rate-limiting/daos_spec.lua
@@ -1,6 +1,6 @@
 local spec_helper = require "spec.spec_helpers"
 local timestamp = require "kong.tools.timestamp"
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 
 local env = spec_helper.get_env()
 local dao_factory = env.dao_factory

--- a/spec/plugins/response-ratelimiting/daos_spec.lua
+++ b/spec/plugins/response-ratelimiting/daos_spec.lua
@@ -1,6 +1,6 @@
 local spec_helper = require "spec.spec_helpers"
 local timestamp = require "kong.tools.timestamp"
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 
 local env = spec_helper.get_env()
 local dao_factory = env.dao_factory

--- a/spec/unit/tools/faker_spec.lua
+++ b/spec/unit/tools/faker_spec.lua
@@ -1,4 +1,4 @@
-local uuid = require "uuid"
+local uuid = require "lua_uuid"
 local Faker = require "kong.tools.faker"
 local DaoError = require "kong.dao.error"
 


### PR DESCRIPTION
This PR replaces https://github.com/Tieske/uuid with https://github.com/Mashape/lua-uuid.

The previous UUID library seemed to produce UUID conflicts that lead to errors like #659. The new library leverages [libuuid](http://linux.die.net/man/3/libuuid) which provides a more solid implementation.

When we decide to merge this PR, we need to update https://github.com/Mashape/kong-distributions to include a dependency to libuuid whenever the operating system doesn't already ship with it.