### PR TITLE
Properly handling big request bodies in Admin API

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -265,6 +265,9 @@ nginx: |
     server {
       listen {{admin_api_port}};
 
+      client_max_body_size 10m;
+      client_body_buffer_size 10m;
+
       location / {
         default_type application/json;
         content_by_lua '


### PR DESCRIPTION
This sets the limit of request bodies to the Admin API to 10MB.

Closes #700.