### PR TITLE
Added missing "env PATH" statement

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -73,6 +73,7 @@ nginx: |
   worker_rlimit_nofile {{auto_worker_rlimit_nofile}};
 
   env KONG_CONF;
+  env PATH;
 
   events {
     worker_connections {{auto_worker_connections}};


### PR DESCRIPTION
In the current code we are using the `PATH` environment variable without specifying `env PATH;` in the nginx configuration, required because nginx does not pass along all the system environments unconditionally. This could lead to some problems on certain systems.

**Note**: The environment variable `PATH` will not be used anymore in the next major version. So this hotfix only applies to Kong < 0.6.0.