### PR TITLE
additional metadata for consumer (issue #550)

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -37,6 +37,7 @@ return {
     UPSTREAM_LATENCY = "X-Kong-Upstream-Latency",
     CONSUMER_ID = "X-Consumer-ID",
     CONSUMER_CUSTOM_ID = "X-Consumer-Custom-ID",
+    CONSUMER_CUSTOM_DATA = "X-Consumer-Custom-Data",
     CONSUMER_USERNAME = "X-Consumer-Username",
     CREDENTIAL_USERNAME = "X-Credential-Username",
     RATELIMIT_LIMIT = "X-RateLimit-Limit",

--- a/kong/dao/cassandra/schema/migrations.lua
+++ b/kong/dao/cassandra/schema/migrations.lua
@@ -51,6 +51,7 @@ local Migrations = {
         CREATE TABLE IF NOT EXISTS consumers(
           id uuid,
           custom_id text,
+          custom_data text,
           username text,
           created_at timestamp,
           PRIMARY KEY (id)

--- a/kong/dao/schemas/consumers.lua
+++ b/kong/dao/schemas/consumers.lua
@@ -18,6 +18,7 @@ return {
     id = { type = "id", dao_insert_value = true },
     created_at = { type = "timestamp", dao_insert_value = true },
     custom_id = { type = "string", unique = true, queryable = true, func = check_custom_id_and_username },
+    custom_data = { type = "text" },
     username = { type = "string", unique = true, queryable = true, func = check_custom_id_and_username }
   }
 }

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -115,6 +115,7 @@ function _M.execute(conf)
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_DATA, consumer.custom_data)
   ngx.req.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   ngx.req.set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
   ngx.ctx.authenticated_credential = credential

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -184,6 +184,7 @@ function _M.execute(conf)
 
   ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_DATA, consumer.custom_data)
   ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   ngx.req.set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
   ngx.ctx.authenticated_credential = credential

--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -110,6 +110,7 @@ function _M.execute(conf)
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_DATA, consumer.custom_data)
   ngx.req.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   ngx.ctx.authenticated_credential = jwt_secret
 end

--- a/kong/plugins/key-auth/access.lua
+++ b/kong/plugins/key-auth/access.lua
@@ -91,6 +91,7 @@ function _M.execute(conf)
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx.req.set_header(constants.HEADERS.CONSUMER_CUSTOM_DATA, consumer.custom_data)
   ngx.req.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   ngx.ctx.authenticated_credential = credential
 end


### PR DESCRIPTION
This pull request add the 'custom_data' field to consumer.

when the custom data field is not empty, its value is sent to the upstream via header: 'X-Consumer-Custom-Data'.
