### PR TITLE
#732 Add message body to response-ratelimiting plugin, block requests…

### DIFF
--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -55,9 +55,9 @@ function _M.execute(conf)
 
   -- Load current metric for configured period
   local usage = get_current_usage(api_id, identifier, current_timestamp, conf.limits)
-  ngx.ctx.usage = usage -- For later use
+  ngx.ctx.usage = usage -- For use to determine whether to block, and later when the upstream-response headers come back
 
-  --local usage = ngx.ctx.usage -- Load current usage
+  -- 
   local stop
   for limit_name, v in pairs(usage) do
     for period_name, lv in pairs(usage[limit_name]) do

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -56,6 +56,21 @@ function _M.execute(conf)
   -- Load current metric for configured period
   local usage = get_current_usage(api_id, identifier, current_timestamp, conf.limits)
   ngx.ctx.usage = usage -- For later use
+
+  --local usage = ngx.ctx.usage -- Load current usage
+  local stop
+  for limit_name, v in pairs(usage) do
+    for period_name, lv in pairs(usage[limit_name]) do
+      if lv.remaining <= 0 then
+        stop = true -- No more
+      end
+    end
+  end
+
+  if stop then
+    ngx.ctx.stop_log = true
+    return responses.send(429, "API quota exceeded")
+  end
 end
 
 return _M

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -33,26 +33,17 @@ function _M.execute(conf)
 
   local usage = ngx.ctx.usage -- Load current usage
 
-  local stop
+  -- Set headers describing the relevant limits to API users
   for limit_name, v in pairs(usage) do
     for period_name, lv in pairs(usage[limit_name]) do
       ngx.header[constants.HEADERS.RATELIMIT_LIMIT.."-"..limit_name.."-"..period_name] = lv.limit
       ngx.header[constants.HEADERS.RATELIMIT_REMAINING.."-"..limit_name.."-"..period_name] = math.max(0, lv.remaining - (increments[limit_name] and increments[limit_name] or 0)) -- increment_value for this current request
-
-      if increments[limit_name] and increments[limit_name] > 0 and lv.remaining <= 0 then
-        stop = true -- No more
-      end
     end
   end
 
   -- Remove header
   ngx.header[conf.header_name] = nil
 
-  -- If limit is exceeded, terminate the request
-  if stop then
-    ngx.ctx.stop_log = true
-    return responses.send(429) -- Don't set a body
-  end
 end
 
 return _M

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -1,7 +1,6 @@
 local stringy = require "stringy"
 local utils = require "kong.tools.utils"
 local constants = require "kong.constants"
-local responses = require "kong.tools.responses"
 
 local _M = {}
 

--- a/spec/integration/admin_api/kong_routes_spec.lua
+++ b/spec/integration/admin_api/kong_routes_spec.lua
@@ -1,7 +1,6 @@
 local json = require "cjson"
 local http_client = require "kong.tools.http_client"
 local spec_helper = require "spec.spec_helpers"
-local IO = require "kong.tools.io"
 local utils = require "kong.tools.utils"
 local env = spec_helper.get_env() -- test environment
 local dao_factory = env.dao_factory


### PR DESCRIPTION
… via access.lua, not header_filter.lua


I modified the plugin to block requests from access.lua rather than dropping a 429 in the status via the header_filter.lua component.  Seems like header filters were receiving the response from the upstream server and THEN issuing a 429 from Kong, which is really bad.  You may have created an object or something but got a 429.

Now access is blocked on the front-end.

