### PR TITLE
Properly printing DAO errors

### DIFF
--- a/kong/core/certificate.lua
+++ b/kong/core/certificate.lua
@@ -29,7 +29,7 @@ function _M.execute()
   if server_name then -- Only support SNI requests
     local api, err = find_api({server_name})
     if err then
-      ngx.log(ngx.ERR, err)
+      ngx.log(ngx.ERR, tostring(err))
     end
 
     return api

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -598,7 +598,7 @@ function BaseDao:_execute(query, args, options, keyspace)
 
   -- Handle unprepared queries
   if err and err.cassandra_err_code == cassandra_constants.error_codes.UNPREPARED then
-    ngx.log(ngx.NOTICE, "Cassandra did not recognize prepared statement \""..cache_key.."\". Re-preparing it and re-trying the query. (Error: "..err..")")
+    ngx.log(ngx.NOTICE, "Cassandra did not recognize prepared statement \""..cache_key.."\". Re-preparing it and re-trying the query. (Error: "..tostring(err)..")")
     -- If the statement was declared unprepared, clear it from the cache, and try again.
     self._statements_cache[session_uniq_addr(session)][cache_key] = nil
     return self:_execute(query, args, options)

--- a/kong/plugins/response-ratelimiting/log.lua
+++ b/kong/plugins/response-ratelimiting/log.lua
@@ -4,7 +4,7 @@ local function increment(api_id, identifier, current_timestamp, value, name)
   -- Increment metrics for all periods if the request goes through
   local _, stmt_err = dao.response_ratelimiting_metrics:increment(api_id, identifier, current_timestamp, value, name)
   if stmt_err then
-    ngx.log(ngx.ERR, stmt_err)
+    ngx.log(ngx.ERR, tostring(stmt_err))
   end
 end
 


### PR DESCRIPTION
Makes sure that DAO errors are printed with `tostring(err)`. Also fixes the little logging quirk reported in #734. 