### PR TITLE
fix(specs) correct alf_serializer_spec fixture

### DIFF
--- a/spec/plugins/mashape-analytics/fixtures/requests.lua
+++ b/spec/plugins/mashape-analytics/fixtures/requests.lua
@@ -237,7 +237,7 @@ return {
             {name = "hello", value = "world"},
             {name = "hello", value = "earth"}
           },
-          text = "hello=world&hello=earth"
+          text = "base64_hello=world&hello=earth"
         },
         queryString = {
           {name = "foo", value = "bar"},
@@ -250,7 +250,7 @@ return {
         content = {
           mimeType = "application/www-form-urlencoded",
           size = 934,
-          text = "{\"message\":\"response body\"}"
+          text = "base64_{\"message\":\"response body\"}"
         },
         cookies = {EMPTY_ARRAY_PLACEHOLDER},
         headers = {


### PR DESCRIPTION
One fixture body was missing a 'base64_' prefix since #747