### PR TITLE
add Konga as community tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Tools:
 - [Kong Dashboard](https://github.com/PGBI/kong-dashboard)
 - [Kongfig](https://github.com/mybuilder/kongfig)
 - [Kongfig on Puppet Forge](https://forge.puppetlabs.com/mybuilder/kongfig)
+- [Konga admin CLI tool](https://github.com/Floby/konga-cli)
 - [Kong on Tutum](https://github.com/Sillelien/docker-kong)
 - [Kong GUI in JS](https://github.com/rsdevigo/jungle)
 - [Kong GUI in Py](https://github.com/vikingco/django-kong-admin)


### PR DESCRIPTION
Opened a new pull request after reviewing the contributing guidelines.

Requesting to pull against `next` now.

Hello this is a pull request following #755

I added Konga just after kongfig as it seems in the same theme, automated configuration.