### PR TITLE
Added "accept_http_if_already_terminated" to SSL and OAuth 2.0

### DIFF
--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -26,6 +26,7 @@ return {
     enable_implicit_grant = { required = true, type = "boolean", default = false },
     enable_client_credentials = { required = true, type = "boolean", default = false },
     enable_password_grant = { required = true, type = "boolean", default = false },
-    hide_credentials = { type = "boolean", default = false }
+    hide_credentials = { type = "boolean", default = false },
+    accept_http_if_already_terminated = { required = false, type = "boolean", default = false }
   }
 }

--- a/kong/plugins/ssl/access.lua
+++ b/kong/plugins/ssl/access.lua
@@ -2,8 +2,19 @@ local responses = require "kong.tools.responses"
 
 local _M = {}
 
+local HTTPS = "https"
+
+local function is_https(conf)
+  local result = ngx.var.scheme:lower() == HTTPS
+  if not result and conf.accept_http_if_already_terminated then
+    local forwarded_proto_header = ngx.req.get_headers()["x-forwarded-proto"]
+    result = forwarded_proto_header and forwarded_proto_header:lower() == HTTPS
+  end
+  return result
+end
+
 function _M.execute(conf)
-  if conf.only_https and ngx.var.scheme:lower() ~= "https" then
+  if conf.only_https and not is_https(conf) then
     ngx.header["connection"] = { "Upgrade" }
     ngx.header["upgrade"] = "TLS/1.0, HTTP/1.1"
     return responses.send(426, {message="Please use HTTPS protocol"})

--- a/kong/plugins/ssl/schema.lua
+++ b/kong/plugins/ssl/schema.lua
@@ -23,6 +23,7 @@ return {
     cert = { required = true, type = "string", func = validate_cert },
     key = { required = true, type = "string", func = validate_key },
     only_https = { required = false, type = "boolean", default = false },
+    accept_http_if_already_terminated = { required = false, type = "boolean", default = false },
 
     -- Internal use
     _cert_der_cache = { type = "string", immutable = true },


### PR DESCRIPTION
Added the `accept_http_if_already_terminated` to the SSL and OAuth 2.0 plugins to accept HTTP requests with a `X-Forwaded-Proto: https` header when the request was supposed to be sent on HTTPs.

* Makes the SSL and OAuth 2.0 plugins work behind a Load Balancer that already does SSL termination, like the ELB.
* Fixes the previous OAuth 2.0 check which allowed every client to bypass the check by simply sending `X-Forwaded-Proto: https`. Now that check needs to be explicitly enabled only when the server cannot be reached from the outside, and the only point of entry is a Load Balancer that already terminates SSL.