### PR TITLE
Fixing body encoding for boolean parameters in http_client

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -69,8 +69,8 @@ function _M.encode_args(args, raw)
         query[#query+1] = encode_args_value(key, sub_value, raw)
       end
     elseif value == true then
-      query[#query+1] = encode_args_value(key, nil, raw)
-    elseif value ~= false and value ~= nil then
+      query[#query+1] = encode_args_value(key, raw and true or nil, raw)
+    elseif value ~= false and value ~= nil or raw then
       value = tostring(value)
       if value ~= "" then
         query[#query+1] = encode_args_value(key, value, raw)

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -48,9 +48,11 @@ end
 --- Encode a Lua table to a querystring
 -- Tries to mimic ngx_lua's `ngx.encode_args`, but also percent-encode querystring values.
 -- Supports multi-value query args, boolean values.
+-- It also supports encoding for bodies (only because it is used in http_client for specs.
 -- @TODO drop and use `ngx.encode_args` once it implements percent-encoding.
 -- @see https://github.com/Mashape/kong/issues/749
--- @param[type=table] args A key/value table containing the query args to encode
+-- @param[type=table] args A key/value table containing the query args to encode.
+-- @param[type=boolean] raw If true, will not percent-encode any key/value and will ignore special boolean rules.
 -- @treturn string A valid querystring (without the prefixing '?')
 function _M.encode_args(args, raw)
   local query = {}

--- a/spec/integration/admin_api/apis_routes_spec.lua
+++ b/spec/integration/admin_api/apis_routes_spec.lua
@@ -362,6 +362,22 @@ describe("Admin API", function()
             assert.same({"key_set_null_test_updated"}, body.config.key_names)
             assert.equal(true, body.config.hide_credentials)
           end)
+          it("should be possible to disable it", function()
+            local response, status = http_client.patch(BASE_URL..plugin.id, {
+              enabled = false
+            })
+            assert.equal(200, status)
+            local body = json.decode(response)
+            assert.False(body.enabled)
+          end)
+          it("should be possible to enabled it", function()
+            local response, status = http_client.patch(BASE_URL..plugin.id, {
+              enabled = true
+            })
+            assert.equal(200, status)
+            local body = json.decode(response)
+            assert.True(body.enabled)
+          end)
         end)
 
         describe("DELETE", function()

--- a/spec/integration/admin_api/plugins_routes_spec.lua
+++ b/spec/integration/admin_api/plugins_routes_spec.lua
@@ -7,7 +7,7 @@ describe("Admin API", function()
     spec_helper.prepare_db()
     spec_helper.insert_fixtures {
       api = {
-        { request_host = "test.com", upstream_url = "http://mockbin.com" }
+        {request_host = "test.com", upstream_url = "http://mockbin.com"}
       }
     }
     spec_helper.start_kong()
@@ -26,32 +26,6 @@ describe("Admin API", function()
       local body = json.decode(response)
       assert.equal("table", type(body.enabled_plugins))
     end)
-  end)
-
-  describe("CRUD", function()
-
-    local res = http_client.get(spec_helper.API_URL.."/apis/")
-    local api = json.decode(res).data[1]
-    assert.truthy(api)
-
-    local BASE_URL = spec_helper.API_URL.."/apis/"..api.id.."/plugins/"
-
-    it("PATCH", function()
-      local response, status = http_client.post(BASE_URL, {
-        name = "rate-limiting",
-        ["config.second"] = 3
-      })
-
-      assert.equals(201, status)
-      local plugin = json.decode(response)
-      assert.True(plugin.enabled)
-
-      local response, status = http_client.patch(BASE_URL..plugin.id, {enabled = false})
-      assert.equals(200, status)
-      plugin = json.decode(response)
-      assert.False(plugin.enabled)
-    end)
-
   end)
 
   describe("/plugins/schema/:name", function()

--- a/spec/unit/tools/utils_spec.lua
+++ b/spec/unit/tools/utils_spec.lua
@@ -78,8 +78,23 @@ describe("Utils", function()
         }, true)
         assert.equal("hello world=foo, bar", str)
       end)
-      describe("raw encoding", function()
-        it("should ignore nil and false values", function()
+      -- while this method's purpose is to mimic 100% the behavior of ngx.encode_args,
+      -- it is also used by Kong specs' http_client, to encode both querystrings and *bodies*.
+      -- Hence, a `raw` parameter allows encoding for bodies.
+      describe("raw", function()
+        it("should not percent-encode values", function()
+          local str = utils.encode_args({
+            foo = "hello world"
+          }, true)
+          assert.equal("foo=hello world", str)
+        end)
+        it("should not percent-encode keys", function()
+          local str = utils.encode_args({
+            ["hello world"] = "foo"
+          }, true)
+          assert.equal("hello world=foo", str)
+        end)
+        it("should plainly include true and false values", function()
           local str = utils.encode_args({
             a = true,
             b = false

--- a/spec/unit/tools/utils_spec.lua
+++ b/spec/unit/tools/utils_spec.lua
@@ -78,6 +78,15 @@ describe("Utils", function()
         }, true)
         assert.equal("hello world=foo, bar", str)
       end)
+      describe("raw encoding", function()
+        it("should ignore nil and false values", function()
+          local str = utils.encode_args({
+            a = true,
+            b = false
+          }, true)
+          assert.equal("a=true&b=false", str)
+        end)
+      end)
     end)
   end)
 


### PR DESCRIPTION
Fixes the encoding of boolean parameters in the body of HTTP requests generated by `http_client`.