### PR TITLE
Better handling of system constants in the file-log plugin

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,6 @@
 redefined = false
 unused_args = false
-globals = {"ngx", "dao", "app", "configuration"}
+globals = {"ngx", "dao", "app", "configuration", "process_id"}
 
 files["kong/"] = {
   std = "luajit"

--- a/kong-0.5.4-1.rockspec
+++ b/kong-0.5.4-1.rockspec
@@ -15,6 +15,7 @@ dependencies = {
   "luasec ~> 0.5-2",
 
   "lua_uuid ~> 0.1-8",
+  "lua_system_constants ~> 0.1-2",
   "luatz ~> 0.3-1",
   "yaml ~> 1.1.2-1",
   "lapis ~> 1.3.1-1",


### PR DESCRIPTION
This PR better handles the system constants being used by the file-log plugin, and also introduces better error handling if the file cannot be created/opened.

It also introduces a new dependency, because LuaFFI does not allow to access system constants, and the only solution would be to hard-code them. Problem is the constants values change depending on the system where Kong is being compiled, so the new dependency [`lua_system_constants`](https://github.com/Mashape/lua-system-constants) always makes sure that the constants are correct and not hard-coded with the wrong value.