### PR TITLE
move CLI from Puc Lua to LuaJit, reducing dependencies

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -5,10 +5,10 @@ KONG_VERSION=0.5.0
 sudo apt-get update
 
 # Installing dependencies required to build development rocks
-sudo apt-get install wget curl tar make gcc unzip git liblua5.1-0-dev
+sudo apt-get install wget curl tar make gcc unzip git
 
 # Installing dependencies required for Kong
-sudo apt-get install sudo netcat lua5.1 openssl libpcre3 dnsmasq uuid-dev
+sudo apt-get install sudo netcat openssl libpcre3 dnsmasq uuid-dev
 
 # Installing Kong and its dependencies
 sudo apt-get install lsb-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,22 @@
 ## [Unreleased][unreleased]
 
+### Breaking changes
+
+- Drop the Lua 5.1 dependency which was only used for Kong's CLI. The CLI now runs against LuaJIT, which is consistent with other Kong components (Luarocks and OpenResty) already relying on LuaJIT. Make sure the LuaJIT interpreter is included in your `$PATH`. [#799](https://github.com/Mashape/kong/pull/799)
+
 ### Added
 
-- Added a `total` field in API responses, that counts the total number of entities in the table. [#635](https://github.com/Mashape/kong/pull/635)
-- You can now specify a custom DNS resolver address that Kong will use when resolving hostnames. [#625](https://github.com/Mashape/kong/pull/635)
+- A new `total` field in API responses, that counts the total number of entities in the response body. [#635](https://github.com/Mashape/kong/pull/635)
+- Dnsmasq is now optional. You can specify a custom DNS resolver address that Kong will use when resolving hostnames. This can be configured in `kong.yml`. [#625](https://github.com/Mashape/kong/pull/635)
 
 ### Changed
 
-- Removed the `dnsmasq_port` property, and introduced `dns_resolver` that also allows to specify a custom DNS server. [#625](https://github.com/Mashape/kong/pull/635)
+- Disable access logs for `/status` endpoint.
 - The `/status` endpoint now includes `database` statistics, while the previous stats have been moved to a `server` field. [#635](https://github.com/Mashape/kong/pull/635)
-- Disabled access logs for `/status` endpoint
-- Removed the Lua 5.1 dependency, cli scripts updated to run against the LuaJit engine included with OpenResty/Nginx [#799](https://github.com/Mashape/kong/pull/799)
 
 ### Fixed
 
-- In the API, the `next` link is not being displayed anymore if there are no more entities to return. [#635](https://github.com/Mashape/kong/pull/635)
+- In the Admin API responses, the `next` link is not being displayed anymore if there are no more entities to be returned. [#635](https://github.com/Mashape/kong/pull/635)
 
 ## [0.5.4] - 2015/12/03
 
@@ -30,8 +32,8 @@
 ### Fixed
 
 - Avoids additional URL encoding when proxying to an upstream service. [#691](https://github.com/Mashape/kong/pull/691)
-- Fixing potential timing comparison bug in HMAC plugin. [#704](https://github.com/Mashape/kong/pull/704)
-- Fixed a missing "env" statement in the Nginx configuration. [#706](https://github.com/Mashape/kong/pull/706)
+- Potential timing comparison bug in HMAC plugin. [#704](https://github.com/Mashape/kong/pull/704)
+- A missing "env" statement in the Nginx configuration. [#706](https://github.com/Mashape/kong/pull/706)
 
 ### Added
 
@@ -89,7 +91,6 @@ Several breaking changes are introduced. You will have to slightly change your c
   - `strip_path` -> `strip_request_path`
   - `target_url` -> `upstream_url`
 - `plugins_configurations` have been renamed to `plugins`, and their `value` property has been renamed to `config` to avoid confusions. [#513](https://github.com/Mashape/kong/issues/513)
->>>>>>> dbocs(changelog) 0.5.0 changes
 - The database schema has been updated to handle the separation of plugins outside of the core repository.
 - The Key authentication and Basic authentication plugins routes have changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Removed the `dnsmasq_port` property, and introduced `dns_resolver` that also allows to specify a custom DNS server. [#625](https://github.com/Mashape/kong/pull/635)
 - The `/status` endpoint now includes `database` statistics, while the previous stats have been moved to a `server` field. [#635](https://github.com/Mashape/kong/pull/635)
 - Disabled access logs for `/status` endpoint
+- Removed the Lua 5.1 dependency, cli scripts updated to run against the LuaJit engine included with OpenResty/Nginx [#799](https://github.com/Mashape/kong/pull/799)
 
 ### Fixed
 

--- a/bin/kong
+++ b/bin/kong
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 -- Kong CLI entry-point (bin/kong).
 --

--- a/kong/cli/config.lua
+++ b/kong/cli/config.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/db.lua
+++ b/kong/cli/db.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local Faker = require "kong.tools.faker"
 local constants = require "kong.constants"

--- a/kong/cli/migrations.lua
+++ b/kong/cli/migrations.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local Migrations = require "kong.tools.migrations"
 local constants = require "kong.constants"

--- a/kong/cli/quit.lua
+++ b/kong/cli/quit.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/reload.lua
+++ b/kong/cli/reload.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/restart.lua
+++ b/kong/cli/restart.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/start.lua
+++ b/kong/cli/start.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/stop.lua
+++ b/kong/cli/stop.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local constants = require "kong.constants"
 local cutils = require "kong.cli.utils"

--- a/kong/cli/version.lua
+++ b/kong/cli/version.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env lua
+#!/usr/bin/env luajit
 
 local cutils = require "kong.cli.utils"
 local constants = require "kong.constants"


### PR DESCRIPTION
The dev package was already obsolete, dropped Lua dependency from Kong install script and changed CLI to use the LuaJit engine.