### PR TITLE
Fix basic auth not generating a random password

### DIFF
--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -38,7 +38,7 @@ function BasicAuthCredentials:insert(params)
     -- inserting the data has encrypted the password field by now, 
     -- so add a new field with the generated plain text password
     -- which will be returned to the requester
-    data.plain_password = newpwd
+    if data then data.plain_password = newpwd end
     return data, err
   end
 end

--- a/spec/plugins/basic-auth/api_spec.lua
+++ b/spec/plugins/basic-auth/api_spec.lua
@@ -41,6 +41,33 @@ describe("Basic Auth Credentials API", function()
         assert.equal(consumer.id, credential.consumer_id)
       end)
 
+      it("[SUCCESS] should create a basicauth credential with password omitted", function()
+        local response, status = http_client.post(BASE_URL, {username = "bob2"})
+        assert.equal(201, status)
+        credential = json.decode(response)
+        assert.equal(consumer.id, credential.consumer_id)
+      end)
+      
+      it("[SUCCESS] should create a basicauth credential with random password", function()
+        credential = {}
+        local response, status = http_client.post(BASE_URL, {username = "bob3"})
+        assert.equal(201, status)
+        credential = json.decode(response)
+        local first_password = credential.password
+        -- delete credential created
+        local dao = spec_helper.get_env().dao_factory
+        local ok, err = dao.basicauth_credentials:delete(credential)
+        assert.True(ok)
+        assert.falsy(err)
+        -- recreate exact same 
+        local response, status = http_client.post(BASE_URL, {username = "bob3"})
+        assert.equal(201, status)
+        credential = json.decode(response)
+        local second_password = credential.password
+        assert.not_equal(first_password, second_password)
+      end)
+
+
       it("[SUCCESS] should encrypt a password", function()
         local base_url = spec_helper.API_URL.."/consumers/alice/basic-auth/"
         local response, status = http_client.post(base_url, {username = "alice", password = "1234"})
@@ -86,7 +113,7 @@ describe("Basic Auth Credentials API", function()
         local response, status = http_client.get(BASE_URL)
         assert.equal(200, status)
         local body = json.decode(response)
-        assert.equal(2, #(body.data))
+        assert.equal(4, #(body.data))
       end)
 
     end)


### PR DESCRIPTION
When no password is provided, one will be generated before inserting the record in the datastore.

The generated password will be returned to the requester in a new field `plain_password`. This field is only returned when no password was provided.

Please review. The point of inserting is in the DAO, though I'd rather fixed it in the `api.lua` file there was no way without duplicating the `crud.post` method.

TODO: 
 - add testcase to prove no plaintext password is returned when a password is given
 - add testcase to check the plaintext password is returned

Please review, I'll fix the todo's after agreement on the solution (point of insertion and adding `plain_password`).