### PR TITLE
fix(dao) do not spawn cluster when outside of ngx_lua

### DIFF
--- a/kong/dao/cassandra/factory.lua
+++ b/kong/dao/cassandra/factory.lua
@@ -11,7 +11,7 @@ local stringy = require "stringy"
 local Object = require "classic"
 local utils = require "kong.tools.utils"
 
-if ngx ~= nil and type(ngx.get_phase) == "function" and ngx.get_phase() == "init" then
+if ngx ~= nil and type(ngx.get_phase) == "function" and ngx.get_phase() == "init" and not ngx.stub then
   cassandra.set_log_level("INFO")
 else
   cassandra.set_log_level("QUIET")
@@ -30,14 +30,16 @@ end
 
 -- Instantiate a Cassandra Factory and all its DAOs for various entities
 -- @param `properties` Cassandra properties
-function CassandraFactory:new(properties, plugins)
+function CassandraFactory:new(properties, plugins, spawn_cluster)
   self.properties = properties
   self.type = "cassandra"
   self.daos = {}
 
-  local ok, err = cassandra.spawn_cluster(self:get_session_options())
-  if not ok then
-    error(err)
+  if spawn_cluster then
+    local ok, err = cassandra.spawn_cluster(self:get_session_options())
+    if not ok then
+      error(err)
+    end
   end
 
   -- Load core entities DAOs

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -107,7 +107,7 @@ local Kong = {}
 -- it will be thrown and needs to be catched in `init_by_lua`.
 function Kong.init()
   configuration = config_loader.load(os.getenv("KONG_CONF"))
-  dao = dao_loader.load(configuration)
+  dao = dao_loader.load(configuration, true)
   loaded_plugins = load_node_plugins(configuration)
   process_id = utils.random_string()
   ngx.update_time()

--- a/kong/tools/dao_loader.lua
+++ b/kong/tools/dao_loader.lua
@@ -1,8 +1,8 @@
 local _M = {}
 
-function _M.load(config)
+function _M.load(config, spawn_cluster)
   local DaoFactory = require("kong.dao."..config.database..".factory")
-  return DaoFactory(config.dao_config, config.plugins_available)
+  return DaoFactory(config.dao_config, config.plugins_available, spawn_cluster)
 end
 
 return _M

--- a/kong/tools/ngx_stub.lua
+++ b/kong/tools/ngx_stub.lua
@@ -103,10 +103,11 @@ local shared_mt = {
 }
 
 _G.ngx = {
+  stub = true,
   req = {},
   ctx = {},
   header = {},
-  get_phase = function() return "not_ngx_lua" end,
+  get_phase = function() return "init" end,
   exit = function() end,
   say = function() end,
   log = function() end,


### PR DESCRIPTION
- Cluster is only spawned when inside if ngx_lua (when starting Kong).
- Ensure LuaSocket is used by the driver by changing the return value of
  `ngx_stub.get_phase()` to `init`.
- Ensure lua-cassandra does not output logs when in the `init` phase
  (which is the case because of change #2) and inside of the specs.
  Which is why `ngx.stub` is a new property.

@shashiranjan84 