### PR TITLE
Fix a "[ERR] Cassandra error" bug

### DIFF
--- a/kong/dao/cassandra/migrations.lua
+++ b/kong/dao/cassandra/migrations.lua
@@ -8,7 +8,7 @@ function Migrations:new(properties)
   self._table = "schema_migrations"
   self.queries = {
     get_keyspace = [[
-      SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?;
+      SELECT * FROM system_schema.keyspaces WHERE keyspace_name = ?;
     ]],
     add_migration = [[
       UPDATE schema_migrations SET migrations = migrations + ? WHERE id = ?;


### PR DESCRIPTION
when I run kong start after install, I got an Error:
~~~
[ERR] Cassandra error: Failed to prepare statement: "SELECT * FROM
system.schema_keyspaces WHERE keyspace_name = ?;". Cassandra returned
error (Invalid): unconfigured table schema_keyspaces
~~~
then I update the Cql to ```SELECT * FROM system_schema.keyspaces WHERE keyspace_name = ?;```, it works Well.

My Cassandra Version is  ```3.1.1```
<img width="1334" alt="kong_error" src="https://cloud.githubusercontent.com/assets/2113827/12016516/d0e3af26-ad86-11e5-8039-0b4ae0eb70bb.png">
