### PR TITLE
Allow for configuration of the JWT field from which secret key is drawn

### DIFF
--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -65,10 +65,7 @@ function _M.execute(conf)
 
   local claims = jwt.claims
 
-  local jwt_secret_key_field = "iss"
-  if conf.secret_key_field then
-    jwt_secret_key_field = conf.secret_key_field
-  end
+  local jwt_secret_key_field = conf.secret_key_field
 
   local jwt_secret_key = claims[jwt_secret_key_field]
   if not jwt_secret_key then

--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -70,8 +70,6 @@ function _M.execute(conf)
     jwt_secret_key_field = conf.secret_key_field
   end
 
-  ngx.log(ngx.DEBUG, "Looking for secret in "..jwt_secret_key_field)
-
   local jwt_secret_key = claims[jwt_secret_key_field]
   if not jwt_secret_key then
     ngx.ctx.stop_phases = true

--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -65,10 +65,17 @@ function _M.execute(conf)
 
   local claims = jwt.claims
 
-  local jwt_secret_key = claims.iss
+  local jwt_secret_key_field = "iss"
+  if conf.secret_key_field then
+    jwt_secret_key_field = conf.secret_key_field
+  end
+
+  ngx.log(ngx.DEBUG, "Looking for secret in "..jwt_secret_key_field)
+
+  local jwt_secret_key = claims[jwt_secret_key_field]
   if not jwt_secret_key then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_UNAUTHORIZED("No mandatory 'iss' in claims")
+    return responses.send_HTTP_UNAUTHORIZED("No mandatory '"..jwt_secret_key_field.."' in claims")
   end
 
   -- Retrieve the secret
@@ -83,7 +90,7 @@ function _M.execute(conf)
 
   if not jwt_secret then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_FORBIDDEN("No credentials found for given 'iss'")
+    return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..jwt_secret_key_field.."'")
   end
 
   -- Now verify the JWT signature
@@ -111,7 +118,7 @@ function _M.execute(conf)
   -- However this should not happen
   if not consumer then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", "iss", jwt_secret_key))
+    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", jwt_secret_key_field, jwt_secret_key))
   end
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)

--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -65,12 +65,10 @@ function _M.execute(conf)
 
   local claims = jwt.claims
 
-  local jwt_secret_key_field = conf.secret_key_field
-
-  local jwt_secret_key = claims[jwt_secret_key_field]
+  local jwt_secret_key = claims[conf.secret_key_field]
   if not jwt_secret_key then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_UNAUTHORIZED("No mandatory '"..jwt_secret_key_field.."' in claims")
+    return responses.send_HTTP_UNAUTHORIZED("No mandatory '"..conf.secret_key_field.."' in claims")
   end
 
   -- Retrieve the secret
@@ -85,7 +83,7 @@ function _M.execute(conf)
 
   if not jwt_secret then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..jwt_secret_key_field.."'")
+    return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..conf.secret_key_field.."'")
   end
 
   -- Now verify the JWT signature
@@ -113,7 +111,7 @@ function _M.execute(conf)
   -- However this should not happen
   if not consumer then
     ngx.ctx.stop_phases = true
-    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", jwt_secret_key_field, jwt_secret_key))
+    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", conf.secret_key_field, jwt_secret_key))
   end
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -2,6 +2,7 @@ return {
   no_consumer = true,
   fields = {
     uri_param_names = {type = "array", default = {"jwt"}},
+    secret_key_field = {type = "string", default = "iss"},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}}
   }
 }


### PR DESCRIPTION
The default remains `iss`, but this gives users more flexibility.  For example, we are using Auth0 as our source of JWT.  We will have a bunch of different APIs with different `aud` values but the same `iss`, so it is much better for us to key off of `aud`.