### PR TITLE
[JWT] support for base64 encoded secrets and arbitrary claim for secret

### DIFF
--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -83,8 +83,13 @@ function _M.execute(conf)
     return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..conf.secret_key_field.."'")
   end
 
+  local jwt_secret_value = jwt_secret.secret
+  if conf.secret_is_base64 then
+    jwt_secret_value = jwt:b64_decode(jwt_secret_value)
+  end
+
   -- Now verify the JWT signature
-  if not jwt:verify_signature(jwt_secret.secret) then
+  if not jwt:verify_signature(jwt_secret_value) then
     return responses.send_HTTP_FORBIDDEN("Invalid signature")
   end
 

--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -64,9 +64,9 @@ function _M.execute(conf)
 
   local claims = jwt.claims
 
-  local jwt_secret_key = claims.iss
+  local jwt_secret_key = claims[conf.secret_key_field]
   if not jwt_secret_key then
-    return responses.send_HTTP_UNAUTHORIZED("No mandatory 'iss' in claims")
+    return responses.send_HTTP_UNAUTHORIZED("No mandatory '"..conf.secret_key_field.."' in claims")
   end
 
   -- Retrieve the secret
@@ -80,7 +80,7 @@ function _M.execute(conf)
   end)
 
   if not jwt_secret then
-    return responses.send_HTTP_FORBIDDEN("No credentials found for given 'iss'")
+    return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..conf.secret_key_field.."'")
   end
 
   -- Now verify the JWT signature
@@ -105,7 +105,7 @@ function _M.execute(conf)
 
   -- However this should not happen
   if not consumer then
-    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", "iss", jwt_secret_key))
+    return responses.send_HTTP_FORBIDDEN(string_format("Could not find consumer for '%s=%s'", conf.secret_key_field, jwt_secret_key))
   end
 
   ngx.req.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -174,6 +174,10 @@ function _M:verify_signature(key)
   return alg_verify[self.header.alg](self.header_64.."."..self.claims_64, self.signature, key)
 end
 
+function _M:b64_decode(input)
+  return b64_decode(input)
+end
+
 --- Registered claims according to RFC 7519 Section 4.1
 local registered_claims = {
   ["nbf"] = {

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -3,6 +3,7 @@ return {
   fields = {
     uri_param_names = {type = "array", default = {"jwt"}},
     secret_key_field = {type = "string", default = "iss"},
+    secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}}
   }
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -2,6 +2,7 @@ return {
   no_consumer = true,
   fields = {
     uri_param_names = {type = "array", default = {"jwt"}},
+    secret_key_field = {type = "string", default = "iss"},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}}
   }
 }


### PR DESCRIPTION
This patch adds support for a configurable JWT secret key field,
defaulting to 'iss'.