### PR TITLE
docs(changelog) 0.6.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,71 @@
 ## [Unreleased][unreleased]
 
+## [0.6.0]
+
 ### Breaking changes
 
-- Drop the Lua 5.1 dependency which was only used for Kong's CLI. The CLI now runs against LuaJIT, which is consistent with other Kong components (Luarocks and OpenResty) already relying on LuaJIT. Make sure the LuaJIT interpreter is included in your `$PATH`. [#799](https://github.com/Mashape/kong/pull/799)
+- The configuration file format changed. Some properties were slightly moved, many others are new. For example, the cassandra properties are not nested under `cassandra.properties` anymore, but rather directly under `cassandra`. Since many new properties are available, it is wise to consult the new configuration file while updating yours.
+- Drop the Lua 5.1 dependency which was only used by the CLI. The CLI now runs with LuaJIT, which is consistent with other Kong components (Luarocks and OpenResty) already relying on LuaJIT. Make sure the LuaJIT interpreter is included in your `$PATH`. [#799](https://github.com/Mashape/kong/pull/799)
 
 ### Added
 
-- A new `total` field in API responses, that counts the total number of entities in the response body. [#635](https://github.com/Mashape/kong/pull/635)
-- Dnsmasq is now optional. You can specify a custom DNS resolver address that Kong will use when resolving hostnames. This can be configured in `kong.yml`. [#625](https://github.com/Mashape/kong/pull/635)
+- New Cassandra driver which enables cluster-awareness of the Cassandra cluster. Kong is now protected if one of your Cassandra nodes goes down as long as a replica is available on another node. Load balancing policies also improve the performance along with many other smaller improvements. [#803](https://github.com/Mashape/kong/pull/803)
+- Admin API
+  - A new `total` field in API responses, that counts the total number of entities in the response body. [#635](https://github.com/Mashape/kong/pull/635)
+- Configuration
+  - Possibility to configure the keyspace replication strategy for Cassandra. It will be taken into account by the migrations when the configured keyspace does not already exist. [#350](https://github.com/Mashape/kong/issues/350)
+  - Dnsmasq is now optional. You can specify a custom DNS resolver address that Kong will use when resolving hostnames. This can be configured in `kong.yml`. [#625](https://github.com/Mashape/kong/pull/625)
+- Plugins
+  - **New syslog plugin**: send logs to local sytem log. [#698](https://github.com/Mashape/kong/pull/698)
+  - **New loggly plugin**: send logs to Loggly over UDP. [#698](https://github.com/Mashape/kong/pull/698)
+  - **New statsd plugin**: send logs to statsd server. [#758](https://github.com/Mashape/kong/pull/758)
+  - OAuth2: add support for `X-Forwarded-Proto` header. [#650](https://github.com/Mashape/kong/pull/650)
+  - Request transformer
+    - Support for more transformation options: `remove`, `replace`, `add`, `append` motivated by [#393](https://github.com/Mashape/kong/pull/393). See [#824](https://github.com/Mashape/kong/pull/824)
+    - Support to transform a JSON body. [#569](https://github.com/Mashape/kong/issues/569)
+  - Response transformer
+    - Support for more transformation options: `remove`, `replace`, `add`, `append` motivated by [#393](https://github.com/Mashape/kong/pull/393). See [#822](https://github.com/Mashape/kong/pull/822)
 
 ### Changed
 
-- Disable access logs for `/status` endpoint.
-- The `/status` endpoint now includes `database` statistics, while the previous stats have been moved to a `server` field. [#635](https://github.com/Mashape/kong/pull/635)
+- As mentioned in the breaking changes section, a new configuration file format and validation. All properties are now documented and commented out with their default values. This allows for a lighter configuration file and more clarity as to what properties relate to. It also catches configuration mistakes. [#633](https://github.com/Mashape/kong/pull/633)
+- Replace the UUID generator library with a new implementation wrapping lib-uuid, fixing eventual conflicts happening in cases such as described in [#659](https://github.com/Mashape/kong/pull/659). See [#695](https://github.com/Mashape/kong/pull/695)
+- Admin API
+  - Increase the maximum body size to 10MB in order to handle configuration requests with heavy payloads. [#700](https://github.com/Mashape/kong/pull/700)
+  - Disable access logs for the `/status` endpoint.
+  - The `/status` endpoint now includes `database` statistics, while the previous stats have been moved to a `server` response field. [#635](https://github.com/Mashape/kong/pull/635)
 
 ### Fixed
 
-- In the Admin API responses, the `next` link is not being displayed anymore if there are no more entities to be returned. [#635](https://github.com/Mashape/kong/pull/635)
+- Behaviors described in [#603](https://github.com/Mashape/kong/issues/603) related to the failure of Cassandra nodes thanks to the new driver. [#803](https://github.com/Mashape/kong/issues/803)
+- Latency headers are now properly included in responses sent to the client. [#708](https://github.com/Mashape/kong/pull/708)
+- `strip_request_path` does not add a trailing slash to the API's `upstream_url` anymore before proxying. [#675](https://github.com/Mashape/kong/issues/675)
+- Do not URL decode querystring before proxying the request to the upstream service. [#749](https://github.com/Mashape/kong/issues/749)
+- Handle cases when the request would be terminated prior to the Kong execution (that is, before ngx_lua reaches the `access_by_lua` context) in cases such as the use of a custom nginx module. [#594](https://github.com/Mashape/kong/issues/594)
+- Admin API
+  - The PUT method now correctly updates boolean fields (such as `strip_request_path`). [#765](https://github.com/Mashape/kong/pull/765)
+  - The PUT method now correctly resets a plugin configuration. [#720](https://github.com/Mashape/kong/pull/720)
+  - In the responses, the `next` link is not being displayed anymore if there are no more entities to be returned. [#635](https://github.com/Mashape/kong/pull/635)
+  - Prevent the update of `created_at` fields. [#820](https://github.com/Mashape/kong/pull/820)
+- Plugins:
+  - Galileo: ensure the `mimeType` value is always a string in ALFs. [#584](https://github.com/Mashape/kong/issues/584)
+  - JWT: allow to update JWT credentials using the PATCH method. It previously used to reply with `405 Method not allowed` because the PATCH method was not implemented. [#667](https://github.com/Mashape/kong/pull/667)
+  - Rate limiting: fix a warning when many periods are configured. [#681](https://github.com/Mashape/kong/issues/681)
+  - OAuth2
+    - Implement correct responses when the OAuth2 challenges are refused. [#737](https://github.com/Mashape/kong/issues/737)
+    - Handle querystring on `/authorize` and `/token` URLs. [#687](https://github.com/Mashape/kong/pull/667)
+    - Handle punctuation in scopes on `/authorize` and `/token` endpoints. [#658](https://github.com/Mashape/kong/issues/658)
+
+> ***internal***
+> - The Kong Public Lua API (Lua helpers integrated in Kong such as DAO and Admin API helpers) is now documented with [ldoc](http://stevedonovan.github.io/ldoc/) format and published on [the online documentation](https://getkong.org/docs/latest/lua-reference/).
+> - Work has been done to restore the reliability of the CI platforms.
+> - Migrations can now execute DML queries (instead of DDL queries only). Handy for migrations implying plugin configuration changes, plugins renamings etc... [#770](https://github.com/Mashape/kong/pull/770)
 
 ## [0.5.4] - 2015/12/03
 
 ### Fixed
 
-- Mashape Analytics plugin (aka Galileo):
+- Mashape Analytics plugin (renamed Galileo):
   - Improve stability under heavy load. [#757](https://github.com/Mashape/kong/issues/757)
   - base64 encode ALF request/response bodies, enabling proper support for Galileo bodies inspection capabilities. [#747](https://github.com/Mashape/kong/pull/747)
   - Do not include JSON bodies in ALF `postData.params` field. [#766](https://github.com/Mashape/kong/pull/766)
@@ -33,7 +76,6 @@
 
 - Avoids additional URL encoding when proxying to an upstream service. [#691](https://github.com/Mashape/kong/pull/691)
 - Potential timing comparison bug in HMAC plugin. [#704](https://github.com/Mashape/kong/pull/704)
-- A missing "env" statement in the Nginx configuration. [#706](https://github.com/Mashape/kong/pull/706)
 
 ### Added
 
@@ -384,7 +426,8 @@ First version running with Cassandra.
 - CLI `bin/kong` script.
 - Database migrations (using `db.lua`).
 
-[unreleased]: https://github.com/mashape/kong/compare/0.5.4...next
+[unreleased]: https://github.com/mashape/kong/compare/0.6.0...next
+[0.6.0]: https://github.com/mashape/kong/compare/0.5.4...0.6.0
 [0.5.4]: https://github.com/mashape/kong/compare/0.5.3...0.5.4
 [0.5.3]: https://github.com/mashape/kong/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/mashape/kong/compare/0.5.1...0.5.2

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,7 +22,28 @@ $ kong reload [-c configuration_file]
 
 **Reminder**: `kong reload` leverages the Nginx `reload` signal and seamlessly starts new workers taking over the old ones until they all have been terminated. This will guarantee you no drop in your current incoming traffic.
 
-## Upgrade to Kong `0.5.x`
+## Upgrade to `0.6.x`
+
+The configuration file changed in this release. Make sure to check out the new default one and update it to your needs. In particular, make sure that:
+
+```yaml
+databases_available:
+  cassandra:
+    properties:
+      contact_points:
+        - ...
+```
+
+becomes:
+
+```yaml
+databases_available:
+  cassandra:
+    contact_points:
+      - ...
+```
+
+## Upgrade to `0.5.x`
 
 Migrating to 0.5.x can be done **without downtime** by following those instructions. It is important that you be running Kong `0.4.2` and have the latest release of Python 2.7 on your system when executing those steps.
 
@@ -154,7 +175,7 @@ cassandra:
       - "localhost:9042"
 ```
 
-## Upgrade to Kong `0.3.x`
+## Upgrade to `0.3.x`
 
 Kong now requires a patch on OpenResty for SSL support. On Homebrew you will need to reinstall OpenResty.
 


### PR DESCRIPTION
Changelog for `0.5.4..next`. This does not includes changes in the invalidations branch, which should be, with eventually minor modifications:

```patch
diff --git a/CHANGELOG.md b/CHANGELOG.md
index c073a39..8c610fc 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,25 @@
 
 ### Breaking changes
 
+- [Serf](https://www.serfdom.io/) is now a Kong dependency. It allows Kong node to communicate between each other opening the way to many features and improvements.
 - The configuration file format changed. Some properties were slightly moved, many others are new. For example, the cassandra properties are not nested under `cassandra.properties` anymore, but rather directly under `cassandra`. Since many new properties are available, it is wise to consult the new configuration file while updating yours.
 - Drop the Lua 5.1 dependency which was only used by the CLI. The CLI now runs with LuaJIT, which is consistent with other Kong components (Luarocks and OpenResty) already relying on LuaJIT. Make sure the LuaJIT interpreter is included in your `$PATH`. [#799](https://github.com/Mashape/kong/pull/799)
 
 ### Added
 
+One of the biggest new features of this release is the cluster-awareness added to Kong in [#729](https://github.com/Mashape/kong/pull/729), which deserves its own section:
+
+- Each Kong node is now aware of belonging to a cluster though Serf. Nodes automatically join the specified cluster according to the configuration file's settings.
+- The datastore cache is not invalidated by expiration time anymore, but following an invalidation strategy between the nodes of a same cluster, leading to improved performance.
+- Admin API
+  - Exposes a `/cache` endpoint for retrieving elements stored in the in-memory cache of a node.
+  - Exposes a `/cluster` endpoint used to add/remove/list members of the cluster, and also used internally for data propagation.
+- CLI
+  - New `kong cluster` command for cluster management.
+  - New `kong status` command for cluster healthcheck.
+
+Other additions include:
+
 - New Cassandra driver which enables cluster-awareness of the Cassandra cluster. Kong is now protected if one of your Cassandra nodes goes down as long as a replica is available on another node. Load balancing policies also improve the performance along with many other smaller improvements. [#803](https://github.com/Mashape/kong/pull/803)
 - Admin API
   - A new `total` field in API responses, that counts the total number of entities in the response body. [#635](https://github.com/Mashape/kong/pull/635)
@@ -19,7 +33,9 @@
   - **New syslog plugin**: send logs to local sytem log. [#698](https://github.com/Mashape/kong/pull/698)
   - **New loggly plugin**: send logs to Loggly over UDP. [#698](https://github.com/Mashape/kong/pull/698)
   - **New statsd plugin**: send logs to statsd server. [#758](https://github.com/Mashape/kong/pull/758)
   - OAuth2: add support for `X-Forwarded-Proto` header. [#650](https://github.com/Mashape/kong/pull/650)
+  - OAuth2
+    - Add support for `X-Forwarded-Proto` header. [#650](https://github.com/Mashape/kong/pull/650)
+    - Expose a new `/oauth2_tokens` endpoint with the possibility to retrieve, update or delete OAuth 2.0 access tokens. [#729](https://github.com/Mashape/kong/pull/729)
   - Request transformer
     - Support for more transformation options: `remove`, `replace`, `add`, `append` motivated by [#393](https://github.com/Mashape/kong/pull/393). See [#824](https://github.com/Mashape/kong/pull/824)
     - Support to transform a JSON body. [#569](https://github.com/Mashape/kong/issues/569)
@@ -51,15 +67,18 @@
   - Galileo: ensure the `mimeType` value is always a string in ALFs. [#584](https://github.com/Mashape/kong/issues/584)
   - JWT: allow to update JWT credentials using the PATCH method. It previously used to reply with `405 Method not allowed` because the PATCH method was not implemented. [#667](https://github.com/Mashape/kong/pull/667)
   - Rate limiting: fix a warning when many periods are configured. [#681](https://github.com/Mashape/kong/issues/681)
+  - Basic Authentication: do not re-hash the password when updating a credential. [#726](https://github.com/Mashape/kong/issues/726)
   - OAuth2
     - Implement correct responses when the OAuth2 challenges are refused. [#737](https://github.com/Mashape/kong/issues/737)
     - Handle querystring on `/authorize` and `/token` URLs. [#687](https://github.com/Mashape/kong/pull/667)
     - Handle punctuation in scopes on `/authorize` and `/token` endpoints. [#658](https://github.com/Mashape/kong/issues/658)
 
 > ***internal***
+> Event bus for local and cluster-wide events propagation. Plans for this event bus is to be widely used among Kong in the future.
 > The Kong Public Lua API (Lua helpers integrated in Kong such as DAO and Admin API helpers) is now documented with [ldoc](http://stevedonovan.github.io/ldoc/) format and published on [the online documentation](https://getkong.org/docs/latest/lua-reference/).
 > Work has been done to restore the reliability of the CI platforms.
 > Migrations can now execute DML queries (instead of DDL queries only). Handy for migrations implying plugin configuration changes, plugins renamings etc... [#770](https://github.com/Mashape/kong/pull/770)
+> CLI refactoring: decouple the services started by Kong from the `signal.lua` module.
 
 ## [0.5.4] - 2015/12/03
 

```
