### PR TITLE
fix(api patch) allow PATCH to set an unset field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Other additions include:
 - Admin API
   - The PUT method now correctly updates boolean fields (such as `strip_request_path`). [#765](https://github.com/Mashape/kong/pull/765)
   - The PUT method now correctly resets a plugin configuration. [#720](https://github.com/Mashape/kong/pull/720)
+  - PATCH correctly set previously unset fields. [#861](https://github.com/Mashape/kong/pull/861)
   - In the responses, the `next` link is not being displayed anymore if there are no more entities to be returned. [#635](https://github.com/Mashape/kong/pull/635)
   - Prevent the update of `created_at` fields. [#820](https://github.com/Mashape/kong/pull/820)
 - Plugins:

--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -268,7 +268,7 @@ function BaseDao:update(t, full, where_t)
   end
 
   -- Extract primary key from the entity
-  local t_primary_key, t_no_primary_key = extract_primary_key(old_entity, self._primary_key, self._clustering_key)
+  local t_primary_key, t_no_primary_key = extract_primary_key(t, self._primary_key, self._clustering_key)
 
   -- If full, add CQL `null` to the SET part of the query for nil columns
   if full then

--- a/spec/integration/admin_api/apis_routes_spec.lua
+++ b/spec/integration/admin_api/apis_routes_spec.lua
@@ -185,7 +185,7 @@ describe("Admin API", function()
       end)
 
       describe("PATCH", function()
-        it_content_types("should update if found", function(content_type)
+        it_content_types("should update name if found", function(content_type)
           return function()
             local response, status = http_client.patch(BASE_URL..api.id, {
               name = "patch-updated"
@@ -193,9 +193,15 @@ describe("Admin API", function()
             assert.equal(200, status)
             local body = json.decode(response)
             assert.equal("patch-updated", body.name)
+
+            local rows, err = dao_factory.apis:find_by_keys {id = api.id}
+            assert.falsy(err)
+            assert.equal(1, #rows)
+            local api = rows[1]
+            assert.equal("patch-updated", api.name)
           end
         end)
-        it_content_types("should update by name", function(content_type)
+        it_content_types("should update name by its old name", function(content_type)
           return function()
             local response, status = http_client.patch(BASE_URL..api.name, {
               name = "patch-updated"
@@ -203,6 +209,63 @@ describe("Admin API", function()
             assert.equal(200, status)
             local body = json.decode(response)
             assert.equal("patch-updated", body.name)
+
+            local rows, err = dao_factory.apis:find_by_keys {id = api.id}
+            assert.falsy(err)
+            assert.equal(1, #rows)
+            local api = rows[1]
+            assert.equal("patch-updated", api.name)
+          end
+        end)
+        it_content_types("should update request_path", function(content_type)
+          return function()
+            local response, status = http_client.patch(BASE_URL..api.id, {
+              request_path = "/httpbin-updated"
+            }, {["content-type"] = content_type})
+            assert.equal(200, status)
+            local body = json.decode(response)
+            assert.equal("/httpbin-updated", body.request_path)
+
+            local rows, err = dao_factory.apis:find_by_keys {id = api.id}
+            assert.falsy(err)
+            assert.equal(1, #rows)
+            local api = rows[1]
+            assert.equal("/httpbin-updated", api.request_path)
+          end
+        end)
+        it_content_types("should update strip_request_path if it was not previously set", function(content_type)
+          return function()
+            local response, status = http_client.patch(BASE_URL..api.id, {
+              strip_request_path = true
+            }, {["content-type"] = content_type})
+            assert.equal(200, status)
+            local body = json.decode(response)
+            assert.True(body.strip_request_path)
+
+            local rows, err = dao_factory.apis:find_by_keys {id = api.id}
+            assert.falsy(err)
+            assert.equal(1, #rows)
+            local api = rows[1]
+            assert.True(api.strip_request_path)
+          end
+        end)
+        it_content_types("should update request_host and request_path at once", function(content_type)
+          return function()
+            local response, status = http_client.patch(BASE_URL..api.id, {
+              request_path = "/httpbin-updated-path",
+              request_host = "httpbin-updated.org"
+            }, {["content-type"] = content_type})
+            assert.equal(200, status)
+            local body = json.decode(response)
+            assert.equal("/httpbin-updated-path", body.request_path)
+            assert.equal("httpbin-updated.org", body.request_host)
+
+            local rows, err = dao_factory.apis:find_by_keys {id = api.id}
+            assert.falsy(err)
+            assert.equal(1, #rows)
+            local api = rows[1]
+            assert.equal("/httpbin-updated-path", api.request_path)
+            assert.equal("httpbin-updated.org", api.request_host)
           end
         end)
         describe("errors", function()


### PR DESCRIPTION
The base_dao `update()` method used the old entity table to build the
UPDATE query instead of the one merged with the new parameters. If a
field was previously unset, PATCH would then not set it to the new value
(because the old entity table did not have the field present).

Fix #857