### PR TITLE
standardizes naming in kong core modules

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -192,21 +192,17 @@ nginx: |
 
     init_by_lua '
       kong = require "kong"
-      local status, err = pcall(kong.init)
-      if not status then
-        ngx.log(ngx.ERR, "Startup error: "..err)
-        os.exit(1)
-      end
+      kong.init()
     ';
 
-    init_worker_by_lua 'kong.exec_plugins_init_worker()';
+    init_worker_by_lua 'kong.init_worker()';
 
     server {
       server_name _;
       listen {{proxy_port}};
       listen {{proxy_ssl_port}} ssl;
 
-      ssl_certificate_by_lua 'kong.exec_plugins_certificate()';
+      ssl_certificate_by_lua 'kong.ssl_certificate()';
 
       ssl_certificate {{ssl_cert}};
       ssl_certificate_key {{ssl_key}};
@@ -220,7 +216,7 @@ nginx: |
         set $upstream_url nil;
 
         # Authenticate the user and load the API info
-        access_by_lua 'kong.exec_plugins_access()';
+        access_by_lua 'kong.access()';
 
         # Proxy the request
         # Proxy the request
@@ -232,13 +228,13 @@ nginx: |
         proxy_pass_header Server;
 
         # Add additional response headers
-        header_filter_by_lua 'kong.exec_plugins_header_filter()';
+        header_filter_by_lua 'kong.header_filter()';
 
         # Change the response body
-        body_filter_by_lua 'kong.exec_plugins_body_filter()';
+        body_filter_by_lua 'kong.body_filter()';
 
         # Log the request
-        log_by_lua 'kong.exec_plugins_log()';
+        log_by_lua 'kong.log()';
       }
 
       location /robots.txt {

--- a/kong/cli/config.lua
+++ b/kong/cli/config.lua
@@ -13,7 +13,7 @@ Usage: kong config [options]
 
 Options:
   -c,--config (default %s) path to configuration file
-  -o,--output (default .)                  ouput
+  -o,--output (default .)                  output
   -e,--env    (string)                     environment name
 ]], constants.CLI.GLOBAL_KONG_CONF))
 

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -1,6 +1,6 @@
 -- Kong core
 --
--- This consists of events than need to
+-- This consists of events that need to
 -- be ran at the very beginning and very end of the lua-nginx-module contexts.
 -- It mainly carries information related to a request from one context to the next one,
 -- through the `ngx.ctx` table.
@@ -30,13 +30,18 @@ local function get_now()
   return ngx_now() * 1000 -- time is kept in seconds with millisecond resolution.
 end
 
+-- in the table below the `before` and `after` is to indicate when they run; before or after the plugins
 return {
-  init_worker = function()
-    reports.init_worker()
-  end,
-  certificate = function()
-    ngx.ctx.api = certificate.execute()
-  end,
+  init_worker = {
+    before = function()
+      reports.init_worker()
+    end
+  },
+  certificate = {
+    before = function()
+      ngx.ctx.api = certificate.execute()
+    end
+  },
   access = {
     before = function()
       ngx.ctx.KONG_ACCESS_START = get_now()
@@ -91,7 +96,9 @@ return {
       end
     end
   },
-  log = function()
-    reports.log()
-  end
+  log = {
+    after = function()
+      reports.log()
+    end
+  }
 }

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -163,7 +163,7 @@ function Kong.body_filter()
   core.body_filter.after()
 end
 
-function Kong.exec_plugins_log()
+function Kong.log()
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, "log") do
     plugin.handler:log(plugin_conf)
   end

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -104,32 +104,38 @@ local Kong = {}
 --     - sort the plugins by priority
 --
 -- If any error happens during the initialization of the DAO or plugins,
--- it will be thrown and needs to be catched in `init_by_lua`.
+-- it return an nginx error and exit.
 function Kong.init()
-  configuration = config_loader.load(os.getenv("KONG_CONF"))
-  dao = dao_loader.load(configuration, true)
-  loaded_plugins = load_node_plugins(configuration)
-  process_id = utils.random_string()
-  ngx.update_time()
+  local status, err = pcall(function() 
+      configuration = config_loader.load(os.getenv("KONG_CONF"))
+      dao = dao_loader.load(configuration, true)
+      loaded_plugins = load_node_plugins(configuration)
+      process_id = utils.random_string()
+      ngx.update_time()
+    end)
+  if not status then
+    ngx.log(ngx.ERR, "Startup error: "..err)
+    os.exit(1)
+  end
 end
 
-function Kong.exec_plugins_init_worker()
-  core.init_worker()
+function Kong.init_worker()
+  core.init_worker.before()
 
   for _, plugin in ipairs(loaded_plugins) do
     plugin.handler:init_worker()
   end
 end
 
-function Kong.exec_plugins_certificate()
-  core.certificate()
+function Kong.ssl_certificate()
+  core.certificate.before()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, "certificate") do
     plugin.handler:certificate(plugin_conf)
   end
 end
 
-function Kong.exec_plugins_access()
+function Kong.access()
   core.access.before()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, "access") do
@@ -139,7 +145,7 @@ function Kong.exec_plugins_access()
   core.access.after()
 end
 
-function Kong.exec_plugins_header_filter()
+function Kong.header_filter()
   core.header_filter.before()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, "header_filter") do
@@ -149,7 +155,7 @@ function Kong.exec_plugins_header_filter()
   core.header_filter.after()
 end
 
-function Kong.exec_plugins_body_filter()
+function Kong.body_filter()
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, "body_filter") do
     plugin.handler:body_filter(plugin_conf)
   end
@@ -162,7 +168,7 @@ function Kong.exec_plugins_log()
     plugin.handler:log(plugin_conf)
   end
 
-  core.log()
+  core.log.after()
 end
 
 return Kong


### PR DESCRIPTION
one exception; `ssl_certificate` is still `certificate` as that is part of the public api for plugins