### PR TITLE
fix cli tests

### DIFF
--- a/spec/integration/cli/reload_spec.lua
+++ b/spec/integration/cli/reload_spec.lua
@@ -4,6 +4,7 @@ describe("CLI", function()
 
   setup(function()
     pcall(spec_helper.stop_kong)
+    spec_helper.prepare_db()
   end)
 
   teardown(function()


### PR DESCRIPTION
fix cli tests to cleanup db in between tests, preventing data from spilling over to the next test.