### PR TITLE
[fix/chore] Fixes `make dev` to not reinstall rocks already available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 
 dev: install
 	@for rock in $(DEV_ROCKS) ; do \
-		if ! command -v $$rock &> /dev/null ; then \
+		if ! command -v $$rock > /dev/null ; then \
       echo $$rock not found, installing via luarocks... ; \
       luarocks install $$rock ; \
     else \


### PR DESCRIPTION
Fixes the check whether development rocks have been installed.
Currently `make dev` fails checking and reinstalls everything, this fixes it and reinstalls only if not installed already