### PR TITLE
[file-log] perf fix and new file permissions on O_CREAT

### DIFF
--- a/kong-0.5.4-1.rockspec
+++ b/kong-0.5.4-1.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "luasec ~> 0.5-2",
 
   "lua_uuid ~> 0.2.0-2",
-  "lua_system_constants ~> 0.1-3",
+  "lua_system_constants ~> 0.1.1-0",
   "luatz ~> 0.3-1",
   "yaml ~> 1.1.2-1",
   "lapis ~> 1.3.1-1",

--- a/kong/plugins/file-log/log.lua
+++ b/kong/plugins/file-log/log.lua
@@ -6,6 +6,18 @@ local fd_util = require "kong.plugins.file-log.fd_util"
 local system_constants = require "lua_system_constants"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 
+local ngx_timer = ngx.timer.at
+local string_len = string.len
+local O_CREAT = system_constants.O_CREAT()
+local O_WRONLY = system_constants.O_WRONLY()
+local O_APPEND = system_constants.O_APPEND()
+local S_IWUSR = system_constants.S_IWUSR()
+local S_IRUSR = system_constants.S_IRUSR()
+local S_IXUSR = system_constants.S_IXUSR()
+
+local oflags = bit.bor(O_WRONLY, O_CREAT, O_APPEND)
+local mode = bit.bor(S_IWUSR, S_IRUSR, S_IXUSR)
+
 ffi.cdef[[
 int open(char * filename, int flags, int mode);
 int write(int fd, void * ptr, int numbytes);
@@ -26,9 +38,7 @@ local function log(premature, conf, message)
 
   local fd = fd_util.get_fd(conf.path)
   if not fd then
-    fd = ffi.C.open(string_to_char(conf.path), 
-                    bit.bor(system_constants.O_WRONLY(), system_constants.O_CREAT(), system_constants.O_APPEND()), 
-                    bit.bor(system_constants.S_IWUSR(), system_constants.S_IRUSR(), system_constants.S_IXUSR()))
+    fd = ffi.C.open(string_to_char(conf.path), oflags, mode)
     if fd < 0 then
       local errno = ffi.errno()
       ngx.log(ngx.ERR, "[file-log] failed to open the file: ", ffi.string(ffi.C.strerror(errno)))
@@ -37,7 +47,7 @@ local function log(premature, conf, message)
     end
   end
 
-  ffi.C.write(fd, string_to_char(message), string.len(message))
+  ffi.C.write(fd, string_to_char(message), string_len(message))
 end
 
 local _M = {}
@@ -45,7 +55,7 @@ local _M = {}
 function _M.execute(conf)
   local message = basic_serializer.serialize(ngx)
 
-  local ok, err = ngx.timer.at(0, log, conf, message)
+  local ok, err = ngx_timer(0, log, conf, message)
   if not ok then
     ngx.log(ngx.ERR, "[file-log] failed to create timer: ", err)
   end

--- a/kong/plugins/file-log/log.lua
+++ b/kong/plugins/file-log/log.lua
@@ -11,12 +11,13 @@ local string_len = string.len
 local O_CREAT = system_constants.O_CREAT()
 local O_WRONLY = system_constants.O_WRONLY()
 local O_APPEND = system_constants.O_APPEND()
-local S_IWUSR = system_constants.S_IWUSR()
 local S_IRUSR = system_constants.S_IRUSR()
-local S_IXUSR = system_constants.S_IXUSR()
+local S_IWUSR = system_constants.S_IWUSR()
+local S_IRGRP = system_constants.S_IRGRP()
+local S_IROTH = system_constants.S_IROTH()
 
 local oflags = bit.bor(O_WRONLY, O_CREAT, O_APPEND)
-local mode = bit.bor(S_IWUSR, S_IRUSR, S_IXUSR)
+local mode = bit.bor(S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH)
 
 ffi.cdef[[
 int open(char * filename, int flags, int mode);


### PR DESCRIPTION
- Caching the oflags and mode arguments of open() avoids the invoke the C
binding on every execution of `log_by_lua`.
- It is more common to create a log file with 644 permissions. This needed
an update of lua-system-constants.