### PR TITLE
refactor(schema) stronger request_path validation

### DIFF
--- a/spec/integration/admin_api/kong_routes_spec.lua
+++ b/spec/integration/admin_api/kong_routes_spec.lua
@@ -15,7 +15,7 @@ describe("Admin API", function()
   teardown(function()
     spec_helper.stop_kong()
   end)
-  
+
   describe("Kong routes", function()
     describe("/", function()
       local constants = require "kong.constants"
@@ -86,11 +86,10 @@ describe("Admin API", function()
 
   describe("Request size", function()
     it("should properly hanlde big POST bodies < 10MB", function()
-      local response, status = http_client.post(spec_helper.API_URL.."/apis", { request_path = "hello.com", upstream_url = "http://mockbin.org" })
+      local response, status = http_client.post(spec_helper.API_URL.."/apis", {request_host = "hello.com", upstream_url = "http://mockbin.org"})
       assert.equal(201, status)
       local api_id = json.decode(response).id
       assert.truthy(api_id)
-
 
       local big_value = string.rep("204.48.16.0,", 1000)
       big_value = string.sub(big_value, 1, string.len(big_value) - 1)
@@ -101,7 +100,7 @@ describe("Admin API", function()
     end)
 
     it("should fail with requests > 10MB", function()
-      local response, status = http_client.post(spec_helper.API_URL.."/apis", { request_path = "hello2.com", upstream_url = "http://mockbin.org" })
+      local response, status = http_client.post(spec_helper.API_URL.."/apis", {request_host = "hello2.com", upstream_url = "http://mockbin.org"})
       assert.equal(201, status)
       local api_id = json.decode(response).id
       assert.truthy(api_id)

--- a/spec/unit/dao/entities_schemas_spec.lua
+++ b/spec/unit/dao/entities_schemas_spec.lua
@@ -23,45 +23,203 @@ describe("Entities Schemas", function()
     end)
   end
 
-  describe("APIs", function()
+  --
+  -- API
+  --
 
+  describe("APIs", function()
     it("should refuse an empty object", function()
       local valid, errors = validate_entity({}, api_schema)
       assert.False(valid)
       assert.truthy(errors)
     end)
 
-    it("should return error with wrong upstream_url", function()
-      local valid, errors = validate_entity({
-        request_host = "mockbin.com",
-        upstream_url = "asdasd"
-      }, api_schema)
-      assert.False(valid)
-      assert.equal("upstream_url is not a url", errors.upstream_url)
+    describe("name", function()
+      it("should not accept a name with reserved URI characters in it", function()
+        for _, name in ipairs({"mockbin#2", "mockbin/com", "mockbin\"", "mockbin:2", "mockbin?", "[mockbin]"}) do
+          local t = {name = name, upstream_url = "http://mockbin.com", request_host = "mockbin.com"}
+
+          local valid, errors = validate_entity(t, api_schema)
+          assert.False(valid)
+          assert.truthy(errors)
+          assert.equal("name must only contain alphanumeric and '., -, _, ~' characters", errors.name)
+        end
+      end)
     end)
 
-    it("should return error with wrong upstream_url protocol", function()
-      local valid, errors = validate_entity({
-        request_host = "mockbin.com",
-        upstream_url = "wot://mockbin.com/"
-      }, api_schema)
-      assert.False(valid)
-      assert.equal("Supported protocols are HTTP and HTTPS", errors.upstream_url)
+    describe("upstream_url", function()
+      it("should return error with wrong upstream_url", function()
+        local valid, errors = validate_entity({
+          name = "mockbin",
+          request_host = "mockbin.com",
+          upstream_url = "asdasd"
+        }, api_schema)
+        assert.False(valid)
+        assert.equal("upstream_url is not a url", errors.upstream_url)
+      end)
+      it("should return error with wrong upstream_url protocol", function()
+        local valid, errors = validate_entity({
+          name = "mockbin",
+          request_host = "mockbin.com",
+          upstream_url = "wot://mockbin.com/"
+        }, api_schema)
+        assert.False(valid)
+        assert.equal("Supported protocols are HTTP and HTTPS", errors.upstream_url)
+      end)
+      it("should validate with upper case protocol", function()
+        local valid, errors = validate_entity({
+          name = "mockbin",
+          request_host = "mockbin.com",
+          upstream_url = "HTTP://mockbin.com/world"
+        }, api_schema)
+        assert.falsy(errors)
+        assert.True(valid)
+      end)
+    end)
+
+    describe("request_host", function()
+      it("should complain if it is an empty string", function()
+        local t = {request_host = "", upstream_url = "http://mockbin.com", name = "mockbin"}
+
+        local valid, errors = validate_entity(t, api_schema)
+        assert.False(valid)
+        assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
+        assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
+      end)
+      it("should not accept an invalid request_host", function()
+        local invalids = {"/mockbin", ".mockbin", "mockbin.", "mockbin.f", "mock;bin",
+                          "mockbin.com-org", "mockbin.com/org", "mockbin.com_org",
+                          "-mockbin.org", "mockbin-.org", "mockbin.or-g", "mockbin.org-",
+                          "mockbin.-org", "hello.-mockbin.com", "hello..mockbin.com", "hello-.mockbin.com"}
+
+        for _, v in ipairs(invalids) do
+          local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.equal("Invalid value: "..v, (errors and errors.request_host or ""))
+          assert.falsy(errors.request_path)
+          assert.False(valid)
+        end
+      end)
+      it("should accept valid request_host", function()
+        local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
+                        "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
+                        "hello.abcd", "mockbin_api.com"}
+
+        for _, v in ipairs(valids) do
+          local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.falsy(errors)
+          assert.True(valid)
+        end
+      end)
+      it("should accept valid wildcard request_host", function()
+        local valids = {"mockbin.*", "*.mockbin.org"}
+
+        for _, v in ipairs(valids) do
+          local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.falsy(errors)
+          assert.True(valid)
+        end
+      end)
+      it("should refuse request_host with more than one wildcard", function()
+        local api_t = {
+          name = "mockbin",
+          request_host = "*.mockbin.*",
+          upstream_url = "http://mockbin.com"
+        }
+
+        local valid, errors = validate_entity(api_t, api_schema)
+        assert.False(valid)
+        assert.equal("Only one wildcard is allowed: *.mockbin.*", errors.request_host)
+      end)
+      it("should refuse invalid wildcard request_host", function()
+        local invalids = {"*mockbin.com", "www.mockbin*", "mock*bin.com"}
+
+        for _, v in ipairs(invalids) do
+          local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.equal("Invalid wildcard placement: "..v, (errors and errors.request_host or ""))
+          assert.False(valid)
+        end
+      end)
+    end)
+
+    describe("request_path", function()
+      it("should complain if it is an empty string", function()
+        local t = {request_path = "", upstream_url = "http://mockbin.com"}
+
+        local valid, errors = validate_entity(t, api_schema)
+        assert.False(valid)
+        assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
+        assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
+      end)
+      it("should not accept reserved characters from RFC 3986", function()
+        local invalids = {"/[a-z]{3}"}
+
+        for _, v in ipairs(invalids) do
+          local t = {request_path = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.False(valid)
+          assert.equal("must only contain alphanumeric and '., -, _, ~, /' characters", errors.request_path)
+        end
+      end)
+      it("should accept unreserved characters from RFC 3986", function()
+        local valids = {"/abcd~user-2"}
+
+        for _, v in ipairs(valids) do
+          local t = {request_path = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.falsy(errors)
+          assert.True(valid)
+        end
+      end)
+      it("should not accept without prefix slash", function()
+        local invalids = {"status", "status/123"}
+
+        for _, v in ipairs(invalids) do
+          local t = {request_path = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.False(valid)
+          assert.equal("must be prefixed with slash: '"..v.."'", errors.request_path)
+        end
+      end)
+      it("should not accept root (no prefix slash)", function()
+        local valid, errors = validate_entity({
+          name = "mockbin",
+          request_path = "/",
+          upstream_url = "http://mockbin.com"
+        }, api_schema)
+        assert.False(valid)
+        assert.equal("cannot be an empty path: '/'", errors.request_path)
+      end)
+      it("should not accept invalid URI", function()
+        local invalids = {"//status", "/status//123", "/status/123//"}
+
+        for _, v in ipairs(invalids) do
+          local t = {request_path = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.False(valid)
+          assert.equal("invalid: '"..v.."'", errors.request_path)
+        end
+      end)
+      it("should remove trailing slash", function()
+        local valids = {"/status/", "/status/123/"}
+
+        for _, v in ipairs(valids) do
+          local t = {request_path = v, upstream_url = "http://mockbin.com", name = "mockbin"}
+          local valid, errors = validate_entity(t, api_schema)
+          assert.falsy(errors)
+          assert.equal(string.sub(v, 1, -2), t.request_path)
+          assert.True(valid)
+        end
+      end)
     end)
 
     it("should validate without a request_path", function()
       local valid, errors = validate_entity({
         request_host = "mockbin.com",
         upstream_url = "http://mockbin.com"
-      }, api_schema)
-      assert.falsy(errors)
-      assert.True(valid)
-    end)
-
-    it("should validate with upper case protocol", function()
-      local valid, errors = validate_entity({
-        request_host = "mockbin.com",
-        upstream_url = "HTTP://mockbin.com/world"
       }, api_schema)
       assert.falsy(errors)
       assert.True(valid)
@@ -84,86 +242,6 @@ describe("Entities Schemas", function()
       assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
     end)
 
-    it("should complain if request_host is an empty string", function()
-      local t = {request_host = "", upstream_url = "http://mockbin.com"}
-
-      local valid, errors = validate_entity(t, api_schema)
-      assert.False(valid)
-      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
-      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
-    end)
-
-    it("should complain if request_path is an empty string", function()
-      local t = {request_path = "", upstream_url = "http://mockbin.com"}
-
-      local valid, errors = validate_entity(t, api_schema)
-      assert.False(valid)
-      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_host)
-      assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
-    end)
-
-    it("should not accept an invalid request_host", function()
-      local invalids = {"/mockbin", ".mockbin", "mockbin.", "mockbin.f", "mock;bin",
-                        "mockbin.com-org", "mockbin.com/org", "mockbin.com_org",
-                        "-mockbin.org", "mockbin-.org", "mockbin.or-g", "mockbin.org-",
-                        "mockbin.-org", "hello.-mockbin.com", "hello..mockbin.com", "hello-.mockbin.com"}
-
-      for _, v in ipairs(invalids) do
-        local t = {request_host = v, upstream_url = "http://mockbin.com"}
-        local valid, errors = validate_entity(t, api_schema)
-        assert.equal("Invalid value: "..v, (errors and errors.request_host or ""))
-        assert.falsy(errors.request_path)
-        assert.False(valid)
-      end
-    end)
-
-    it("should accept valid request_host", function()
-      local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
-                      "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
-                      "hello.abcd", "mockbin_api.com"}
-
-      for _, v in ipairs(valids) do
-        local t = {request_host = v, upstream_url = "http://mockbin.com"}
-        local valid, errors = validate_entity(t, api_schema)
-        assert.falsy(errors)
-        assert.True(valid)
-      end
-    end)
-
-    it("should accept valid wildcard request_host", function()
-      local valids = {"mockbin.*", "*.mockbin.org"}
-
-      for _, v in ipairs(valids) do
-        local t = {request_host = v, upstream_url = "http://mockbin.com"}
-        local valid, errors = validate_entity(t, api_schema)
-        assert.falsy(errors)
-        assert.True(valid)
-      end
-    end)
-
-    it("should refuse request_host with more than one wildcard", function()
-      local api_t = {
-        name = "mockbin",
-        request_host = "*.mockbin.*",
-        upstream_url = "http://mockbin.com"
-      }
-
-      local valid, errors = validate_entity(api_t, api_schema)
-      assert.False(valid)
-      assert.equal("Only one wildcard is allowed: *.mockbin.*", errors.request_host)
-    end)
-
-    it("should refuse invalid wildcard request_host", function()
-      local invalids = {"*mockbin.com", "www.mockbin*", "mock*bin.com"}
-
-      for _, v in ipairs(invalids) do
-        local t = {request_host = v, upstream_url = "http://mockbin.com"}
-        local valid, errors = validate_entity(t, api_schema)
-        assert.equal("Invalid wildcard placement: "..v, (errors and errors.request_host or ""))
-        assert.False(valid)
-      end
-    end)
-
     it("should set the name from request_host if not set", function()
       local t = {request_host = "mockbin.com", upstream_url = "http://mockbin.com"}
 
@@ -182,17 +260,6 @@ describe("Entities Schemas", function()
       assert.equal("mockbin", t.name)
     end)
 
-    it("should not accept a name with reserved URI characters in it", function()
-      for _, name in ipairs({"mockbin#2", "mockbin/com", "mockbin\"", "mockbin:2", "mockbin?", "[mockbin]"}) do
-        local t = {name = name, upstream_url = "http://mockbin.com", request_host = "mockbin.com"}
-
-        local valid, errors = validate_entity(t, api_schema)
-        assert.False(valid)
-        assert.truthy(errors)
-        assert.equal("name must only contain alphanumeric and '., -, _, ~' characters", errors.name)
-      end
-    end)
-
     it("should normalize a name for URI if coming from request_host or request_path", function()
       local t = {upstream_url = "http://mockbin.com", request_host = "mockbin.com"}
 
@@ -208,76 +275,13 @@ describe("Entities Schemas", function()
       assert.falsy(errors)
       assert.equal("mockbin-status", t.name)
     end)
-
-    it("should only accept alphanumeric request_path", function()
-      local valid, errors = validate_entity({
-        name = "mockbin",
-        request_path = "/[a-zA-Z]{3}",
-        upstream_url = "http://mockbin.com"
-      }, api_schema)
-      assert.equal("request_path must only contain alphanumeric and '., -, _, ~, /' characters", errors.request_path)
-      assert.False(valid)
-
-      valid = validate_entity({
-        name = "mockbin",
-        request_path = "/status/",
-        upstream_url = "http://mockbin.com"
-      }, api_schema)
-      assert.True(valid)
-
-      valid = validate_entity({
-        name = "mockbin",
-        request_path = "/abcd~user-2",
-        upstream_url = "http://mockbin.com"
-      }, api_schema)
-      assert.True(valid)
-    end)
-
-    it("should prefix a request_path with a slash and remove trailing slash", function()
-      local api_t = { name = "mockbin", request_path = "status", upstream_url = "http://mockbin.com" }
-      validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.request_path)
-
-      api_t.request_path = "/status"
-      validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.request_path)
-
-      api_t.request_path = "status/"
-      validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.request_path)
-
-      api_t.request_path = "/status/"
-      validate_entity(api_t, api_schema)
-      assert.equal("/status", api_t.request_path)
-
-      api_t.request_path = "/deep/nested/status/"
-      validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.request_path)
-
-      api_t.request_path = "deep/nested/status"
-      validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.request_path)
-
-      -- Strip all leading slashes
-      api_t.request_path = "//deep/nested/status"
-      validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.request_path)
-
-      -- Strip all trailing slashes
-      api_t.request_path = "/deep/nested/status//"
-      validate_entity(api_t, api_schema)
-      assert.equal("/deep/nested/status", api_t.request_path)
-
-      -- Error if invalid request_path
-      api_t.request_path = "/deep//nested/status"
-      local _, errors = validate_entity(api_t, api_schema)
-      assert.equal("request_path is invalid: /deep//nested/status", errors.request_path)
-    end)
-
   end)
 
-  describe("Consumers", function()
+  --
+  -- Consumer
+  --
 
+  describe("Consumers", function()
     it("should require a `custom_id` or `username`", function()
       local valid, errors = validate_entity({}, consumer_schema)
       assert.False(valid)
@@ -294,8 +298,11 @@ describe("Entities Schemas", function()
       assert.equal("username is not a string", errors.username)
       assert.equal("At least a 'custom_id' or a 'username' must be specified", errors.custom_id)
     end)
-
   end)
+
+  --
+  -- Plugins
+  --
 
   describe("Plugins Configurations", function()
 
@@ -312,7 +319,6 @@ describe("Entities Schemas", function()
       assert.False(valid)
       assert.equal("Plugin \"world domination\" not found", errors.config)
     end)
-
     it("should validate a plugin configuration's `config` field", function()
       -- Success
       local plugin = {name = "key-auth", api_id = "stub", config = {key_names = {"x-kong-key"}}}
@@ -326,7 +332,6 @@ describe("Entities Schemas", function()
       assert.False(valid)
       assert.equal("second is not a number", errors["config.second"])
     end)
-
     it("should have an empty config if none is specified and if the config schema does not have default", function()
       -- Insert key-auth, whose config has some default values that should be set
       local plugin = {name = "key-auth", api_id = "stub"}
@@ -334,7 +339,6 @@ describe("Entities Schemas", function()
       assert.same({key_names = {"apikey"}, hide_credentials = false}, plugin.config)
       assert.True(valid)
     end)
-
     it("should be valid if no value is specified for a subfield and if the config schema has default as empty array", function()
       -- Insert response-transformer, whose default config has no default values, and should be empty
       local plugin2 = {name = "response-transformer", api_id = "stub"}


### PR DESCRIPTION
- Stronger validation of an API's request_path
- Stronger test suite for API schema validation (and sorted the mess)
- Prevent '/' from being considered a valid request_path

Fix #880