### PR TITLE
chore(ci) no more --repeat and setup improvements

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CMD="busted -v -o gtest --exclude-tags=ci --repeat=3"
+CMD="busted -v -o gtest --exclude-tags=ci"
 
 if [ "$TEST_SUITE" == "unit" ]; then
   CMD="$CMD --coverage spec/unit && luacov-coveralls -i kong"

--- a/.ci/setenv_kong.sh
+++ b/.ci/setenv_kong.sh
@@ -1,0 +1,14 @@
+export LUA_DIR=$HOME/lua
+export LUAROCKS_DIR=$HOME/luarocks
+export OPENRESTY_DIR=$HOME/openresty-$OPENRESTY
+export DNSMASQ_DIR=$HOME/dnsmasq
+export SERF_DIR=$HOME/serf
+
+export PATH=$LUA_DIR/bin:$LUAROCKS_DIR/bin:$OPENRESTY_DIR/nginx/sbin:$SERF_DIR:$DNSMASQ_DIR/usr/local/sbin:$PATH
+
+bash .ci/setup_lua.sh
+bash .ci/setup_openresty.sh
+bash .ci/setup_serf.sh
+bash .ci/setup_dnsmasq.sh
+
+eval `luarocks path`

--- a/.ci/setup_cassandra.sh
+++ b/.ci/setup_cassandra.sh
@@ -14,6 +14,6 @@ git clone https://github.com/pcmanus/ccm.git
 pushd ccm
 ./setup.py install --user
 popd
-ccm create test -v binary:$CASSANDRA_VERSION -n ${#arr[@]} -d
+ccm create test -v binary:$CASSANDRA -n ${#arr[@]} -d
 ccm start -v
 ccm status

--- a/.ci/setup_dnsmasq.sh
+++ b/.ci/setup_dnsmasq.sh
@@ -11,10 +11,10 @@ mkdir -p $DNSMASQ_DIR
 
 if [ ! "$(ls -A $DNSMASQ_DIR)" ]; then
   pushd $DNSMASQ_DIR
-  wget http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${DNSMASQ_VERSION}.tar.gz
-  tar xzf dnsmasq-${DNSMASQ_VERSION}.tar.gz
+  wget http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${DNSMASQ}.tar.gz
+  tar xzf dnsmasq-${DNSMASQ}.tar.gz
 
-  pushd dnsmasq-${DNSMASQ_VERSION}
+  pushd dnsmasq-${DNSMASQ}
   make install DESTDIR=$DNSMASQ_DIR
   popd
 

--- a/.ci/setup_lua.sh
+++ b/.ci/setup_lua.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-# A script for setting up environment for travis-ci testing.
-# Sets up Lua and Luarocks.
-# LUA must be "lua5.1", "lua5.2" or "luajit".
-# luajit2.0 - master v2.0
-# luajit2.1 - master v2.1
-
 set -e
 
+mkdir -p $LUA_DIR
+if [ "$(ls -A $LUA_DIR)" ]; then
+  echo "Lua found from cache at $LUA_DIR"
+  exit
+fi
+
 LUAJIT="no"
+LUAJIT_BASE="LuaJIT"
 
 source .ci/platform.sh
 
@@ -16,87 +17,86 @@ source .ci/platform.sh
 # Lua/LuaJIT
 ############
 
-if [ "$LUA_VERSION" == "luajit" ]; then
+if [ "$LUA" == "luajit" ]; then
   LUAJIT="yes"
-  LUA_VERSION="luajit-2.0"
-elif [ "$LUA_VERSION" == "luajit-2.0" ]; then
+  LUA="luajit-2.0"
+elif [ "$LUA" == "luajit-2.0" ]; then
   LUAJIT="yes"
-elif [ "$LUA_VERSION" == "luajit-2.1" ]; then
+elif [ "$LUA" == "luajit-2.1" ]; then
   LUAJIT="yes"
 fi
 
 if [ "$LUAJIT" == "yes" ]; then
-  mkdir -p $LUAJIT_DIR
+  git clone https://github.com/luajit/luajit $LUAJIT_BASE
+  pushd $LUAJIT_BASE
 
-  # If cache is empty, download and compile
-  if [ ! "$(ls -A $LUAJIT_DIR)" ]; then
-    git clone https://github.com/luajit/luajit $LUAJIT_DIR
-    pushd $LUAJIT_DIR
-
-    if [ "$LUA_VERSION" == "luajit-2.0" ]; then
-      git checkout v2.0.4
-    elif [ "$LUA_VERSION" == "luajit-2.1" ]; then
-      git checkout v2.1
-    fi
-
-    make
-    make install PREFIX=$LUAJIT_DIR
-    popd
-
-    if [ "$LUA_VERSION" == "luajit-2.1" ]; then
-      ln -sf $LUAJIT_DIR/bin/luajit-2.1.0-beta1 $LUAJIT_DIR/bin/luajit
-    fi
-
-    ln -sf $LUAJIT_DIR/bin/luajit $LUAJIT_DIR/bin/lua
+  if [ "$LUA" == "luajit-2.0" ]; then
+    git checkout v2.0.4
+  elif [ "$LUA" == "luajit-2.1" ]; then
+    git checkout v2.1
+    perl -i -pe 's/INSTALL_TNAME=.+/INSTALL_TNAME= luajit/' Makefile
   fi
 
-  LUA_INCLUDE="$LUAJIT_DIR/include/$LUA_VERSION"
+  make
+  make install PREFIX=$LUA_DIR
+  popd
+
+  ln -sf $LUA_DIR/bin/luajit $LUA_DIR/bin/lua
 else
-  if [ "$LUA_VERSION" == "lua5.1" ]; then
+  if [ "$LUA" == "lua5.1" ]; then
     curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
     pushd lua-5.1.5
-  elif [ "$LUA_VERSION" == "lua5.2" ]; then
-    curl http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
-    pushd lua-5.2.3
-  elif [ "$LUA_VERSION" == "lua5.3" ]; then
-    curl http://www.lua.org/ftp/lua-5.3.0.tar.gz | tar xz
-    pushd lua-5.3.0
+  elif [ "$LUA" == "lua5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
+    pushd lua-5.2.4
+  elif [ "$LUA" == "lua5.3" ]; then
+    curl http://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
+    pushd lua-5.3.2
   fi
 
   make $PLATFORM
   make install INSTALL_TOP=$LUA_DIR
   popd
-
-  LUA_INCLUDE="$LUA_DIR/include"
 fi
 
 ##########
 # Luarocks
 ##########
 
-LUAROCKS_BASE=luarocks-$LUAROCKS_VERSION
-CONFIGURE_FLAGS=""
+LUAROCKS_BASE=luarocks-$LUAROCKS
 
 git clone https://github.com/keplerproject/luarocks.git $LUAROCKS_BASE
-
 pushd $LUAROCKS_BASE
-git checkout v$LUAROCKS_VERSION
+
+git checkout v$LUAROCKS
 
 if [ "$LUAJIT" == "yes" ]; then
-  LUA_DIR=$LUAJIT_DIR
-elif [ "$LUA_VERSION" == "lua5.1" ]; then
-  CONFIGURE_FLAGS=$CONFIGURE_FLAGS" --lua-version=5.1"
-elif [ "$LUA_VERSION" == "lua5.2" ]; then
-  CONFIGURE_FLAGS=$CONFIGURE_FLAGS" --lua-version=5.2"
-elif [ "$LUA_VERSION" == "lua5.3" ]; then
-  CONFIGURE_FLAGS=$CONFIGURE_FLAGS" --lua-version=5.3"
+  CONFIGURE_FLAGS="--with-lua-include=$LUA_DIR/include/$LUA"
+elif [ "$LUA" == "lua5.1" ]; then
+  CONFIGURE_FLAGS="--lua-version=5.1 --with-lua-include=$LUA_DIR/include"
+elif [ "$LUA" == "lua5.2" ]; then
+  CONFIGURE_FLAGS="--lua-version=5.2 --with-lua-include=$LUA_DIR/include"
+elif [ "$LUA" == "lua5.3" ]; then
+  CONFIGURE_FLAGS="--lua-version=5.3 --with-lua-include=$LUA_DIR/include"
 fi
 
 ./configure \
   --prefix=$LUAROCKS_DIR \
   --with-lua-bin=$LUA_DIR/bin \
-  --with-lua-include=$LUA_INCLUDE \
   $CONFIGURE_FLAGS
 
-make build && make install
+make build
+make install
 popd
+
+rm -rf $LUAROCKS_BASE
+
+if [ "$LUAJIT" == "yes" ]; then
+  rm -rf $LUAJIT_BASE;
+elif [ "$LUA" == "lua5.1" ]; then
+  rm -rf lua-5.1.5;
+elif [ "$LUA" == "lua5.2" ]; then
+  rm -rf lua-5.2.4;
+elif [ "$LUA" == "lua5.3" ]; then
+  rm -rf lua-5.3.2;
+fi

--- a/.ci/setup_openresty.sh
+++ b/.ci/setup_openresty.sh
@@ -11,11 +11,11 @@ mkdir -p $OPENRESTY_DIR
 
 if [ ! "$(ls -A $OPENRESTY_DIR)" ]; then
   # Download OpenSSL
-  OPENSSL_BASE=openssl-$OPENSSL_VERSION
+  OPENSSL_BASE=openssl-$OPENSSL
   curl http://www.openssl.org/source/$OPENSSL_BASE.tar.gz | tar xz
 
   # Download OpenResty
-  OPENRESTY_BASE=ngx_openresty-$OPENRESTY_VERSION
+  OPENRESTY_BASE=ngx_openresty-$OPENRESTY
   curl https://openresty.org/download/$OPENRESTY_BASE.tar.gz | tar xz
   pushd $OPENRESTY_BASE
 
@@ -37,7 +37,7 @@ if [ ! "$(ls -A $OPENRESTY_DIR)" ]; then
 
   ./configure \
     --prefix=$OPENRESTY_DIR \
-    --with-luajit=$LUAJIT_DIR \
+    --with-luajit=$LUA_DIR \
     --with-openssl=../$OPENSSL_BASE \
     --with-pcre-jit \
     --with-ipv6 \

--- a/.ci/setup_serf.sh
+++ b/.ci/setup_serf.sh
@@ -11,7 +11,7 @@ mkdir -p $SERF_DIR
 
 if [ ! "$(ls -A $SERF_DIR)" ]; then
   pushd $SERF_DIR
-  wget https://releases.hashicorp.com/serf/${SERF_VERSION}/serf_${SERF_VERSION}_linux_amd64.zip
-  unzip serf_${SERF_VERSION}_linux_amd64.zip
+  wget https://releases.hashicorp.com/serf/${SERF}/serf_${SERF}_linux_amd64.zip
+  unzip serf_${SERF}_linux_amd64.zip
   popd
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,35 +11,23 @@ addons:
       - build-essential
 env:
   global:
-    - LUA_VERSION=luajit-2.1
-    - CASSANDRA_VERSION=2.2.4
-    - LUAROCKS_VERSION=2.2.2
-    - OPENSSL_VERSION=1.0.2e
-    - OPENRESTY_VERSION=1.9.3.1
-    - SERF_VERSION=0.7.0
-    - DNSMASQ_VERSION=2.75
-    - LUAJIT_DIR=$HOME/luajit
-    - LUAROCKS_DIR=$HOME/luarocks
-    - OPENRESTY_DIR=$HOME/openresty
-    - SERF_DIR=$HOME/serf
-    - DNSMASQ_DIR=$HOME/dnsmasq
+    - LUA=luajit-2.1
+    - LUAROCKS=2.3.0
+    - OPENRESTY=1.9.3.1
+    - CASSANDRA=2.2.4
+    - OPENSSL=1.0.2e
+    - SERF=0.7.0
+    - DNSMASQ=2.75
     - CASSANDRA_HOSTS=127.0.0.1
   matrix:
     - TEST_SUITE=unit
     - TEST_SUITE=integration
     - TEST_SUITE=plugins
 before_install:
-  - bash .ci/setup_lua.sh
-  - bash .ci/setup_openresty.sh
+  - source .ci/setenv_kong.sh
   - bash .ci/setup_cassandra.sh
-  - bash .ci/setup_serf.sh
-  - bash .ci/setup_dnsmasq.sh
-  - export PATH="$LUAJIT_DIR/bin:$LUAROCKS_DIR/bin:$OPENRESTY_DIR/nginx/sbin:$SERF_DIR:$DNSMASQ_DIR/usr/local/sbin:$PATH"
-  - export LUA_PATH="./?.lua;$LUAROCKS_DIR/share/lua/5.1/?.lua;$LUAROCKS_DIR/share/lua/5.1/?/init.lua;$LUAROCKS_DIR/lib/lua/5.1/?.lua;$LUA_PATH"
-  - export LUA_CPATH="./?.so;$LUAROCKS_DIR/lib/lua/5.1/?.so;$LUA_CPATH"
 install:
   - luarocks install busted
-  - luarocks install luacov
   - luarocks install luacov-coveralls
   - luarocks install luacheck
   - luarocks make kong-*.rockspec
@@ -51,9 +39,9 @@ cache:
   apt: true
   pip: true
   directories:
-    - $LUAJIT_DIR
-    - $LUAROCKS_DIR
-    - $OPENRESTY_DIR
+    - $LUA_DIR
     - $SERF_DIR
     - $DNSMASQ_DIR
+    - $LUAROCKS_DIR
+    - $OPENRESTY_DIR
     - $HOME/.ccm/repository


### PR DESCRIPTION
- unfortunately, the tests are really, really too long with a --repeat 3 setting
- update Luarocks version
- simpler .travis.yml with a .ci/setenv_kong.sh script
- allow caching of multiple versions of OpenResty
- luacov in a dependency of luacov-coveralls, hence not needed
- update setup_lua.sh script with latest Lua versions and improvements
- remove "VERSION" suffix from ENV variables