### PR TITLE
hotfix(cass) insertion of SSL certificate in nginx.conf for C* cluster

### DIFF
--- a/kong/cli/services/nginx.lua
+++ b/kong/cli/services/nginx.lua
@@ -57,6 +57,13 @@ local function get_current_user()
 end
 
 local function prepare_nginx_configuration(configuration, ssl_config)
+  -- DAO SSL certificate
+  local lua_ssl_trusted_certificate = (configuration[configuration.database] and 
+                                       configuration[configuration.database].ssl and
+                                       configuration[configuration.database].ssl.enabled and
+                                       configuration[configuration.database].ssl.certificate_authority) and 
+                                       configuration[configuration.database].ssl.certificate_authority or nil
+
   -- Extract nginx config from kong config, replace any needed value
   local nginx_config = configuration.nginx
   local nginx_inject = {
@@ -68,7 +75,7 @@ local function prepare_nginx_configuration(configuration, ssl_config)
     memory_cache_size = configuration.memory_cache_size,
     ssl_cert = ssl_config.ssl_cert_path,
     ssl_key = ssl_config.ssl_key_path,
-    lua_ssl_trusted_certificate = ssl_config.trusted_ssl_cert_path ~= nil and "lua_ssl_trusted_certificate \""..ssl_config.trusted_ssl_cert_path.."\";" or ""
+    lua_ssl_trusted_certificate = lua_ssl_trusted_certificate ~= nil and "lua_ssl_trusted_certificate \""..lua_ssl_trusted_certificate.."\";" or ""
   }
 
   -- Auto-tune


### PR DESCRIPTION
C* client-to-node CA file was not inserted in nginx.conf since 0.6.0 and the CLI services refactoring. Sadly this is not tested in CI because we do not maintain an SSL cluster for testing.

PS: @mars Here it is!