### PR TITLE
hotfix(galileo) missing shared dict and skipped access phase fixes

### DIFF
--- a/kong/plugins/log-serializers/alf.lua
+++ b/kong/plugins/log-serializers/alf.lua
@@ -89,7 +89,7 @@ function _M.serialize_entry(ngx)
   -- other properties are used to compute the ALF properties.
 
   -- bodies
-  local analytics_data = ngx.ctx.analytics
+  local analytics_data = ngx.ctx.analytics or {}
 
   local alf_req_body = analytics_data.req_body or ""
   local alf_res_body = analytics_data.res_body or ""

--- a/kong/plugins/mashape-analytics/buffer.lua
+++ b/kong/plugins/mashape-analytics/buffer.lua
@@ -48,7 +48,7 @@ local EMPTY_ARRAY_PLACEHOLDER = "__empty_array_placeholder__"
 -- The policy will give a delay that grows everytime
 -- Galileo fails to respond. As soon as Galileo responds,
 -- the delay is reset to its base.
-local dict = ngx.shared.locks
+local dict = ngx.shared.cache
 local RETRY_INDEX_KEY = "mashape_analytics_retry_index"
 local RETRY_BASE_DELAY = 1 -- seconds
 local RETRY_MAX_DELAY = 60 -- seconds

--- a/kong/plugins/mashape-analytics/buffer.lua
+++ b/kong/plugins/mashape-analytics/buffer.lua
@@ -194,7 +194,7 @@ end
 -- If the connection to the collector fails, use the retry policy.
 function buffer_mt.send_batch(premature, self)
   if premature or self.lock_sending then return end
-  
+
   self.lock_sending = true -- simple lock
 
   if table_getn(self.sending_queue) < 1 then

--- a/kong/plugins/mashape-analytics/handler.lua
+++ b/kong/plugins/mashape-analytics/handler.lua
@@ -69,10 +69,12 @@ end
 function AnalyticsHandler:body_filter(conf)
   AnalyticsHandler.super.body_filter(self)
 
-  local chunk = ngx.arg[1]
   -- concatenate response chunks for ALF's `response.content.text`
   if conf.log_body then
-    ngx.ctx.analytics.res_body = ngx.ctx.analytics.res_body..chunk
+    local chunk = ngx.arg[1]
+    local analytics_data = ngx.ctx.analytics or {res_body = ""} -- minimize the number of calls to ngx.ctx while fallbacking on default value
+    analytics_data.res_body = analytics_data.res_body..chunk
+    ngx.ctx.analytics = analytics_data
   end
 end
 


### PR DESCRIPTION
- If the access phase of the galileo handler is not executed, we are
missing the ngx.ctx.analytics data in the ALF serializer. This fallsback
on an empty ctx.
- 4720b7b renamed the previous 'locks' shm and broke the galileo retry
policy relying on it. To avoid users to modify their nginx config if
they use a custom one, this makes galileo use the already present (and
huge) 'cache' shm.