### PR TITLE
Separate `prepare_all()` from `start_all()` in kong.cli.utils.services

### DIFF
--- a/kong/cli/utils/services.lua
+++ b/kong/cli/utils/services.lua
@@ -81,17 +81,31 @@ function _M.stop_all(configuration, configuration_path)
   end
 end
 
-function _M.start_all(configuration, configuration_path)
+function _M.prepare_all(configuration, configuration_path)
   -- Prepare database if not initialized yet
   local _, err = prepare_database(configuration)
   if err then
     return false, err
   end
 
+  local prepared_services = {}
   for _, v in ipairs(services) do
     local obj = v(configuration, configuration_path)
     obj:prepare()
-    local ok, err = obj:start()
+    prepared_services[obj._name] = obj
+  end
+
+  return prepared_services, nil
+end
+
+function _M.start_all(configuration, configuration_path)
+  local prepared_services, err = _M.prepare_all(configuration, configuration_path)
+  if err then
+    return false, err
+  end
+
+  for _, service in pairs(prepared_services) do
+    local ok, err = service:start()
     if not ok then
       return ok, err
     end


### PR DESCRIPTION
This revision cleanly separates the preparation of the database and each service from the act of starting them.

The motivation is to allow experimentation with external [process management](https://github.com/Mashape/kong/issues/928), without impacting Kong's existing service control.