### PR TITLE
add include/exclude_paths to the auth plugins

### DIFF
--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -1,6 +1,8 @@
 return {
   no_consumer = true,
   fields = {
-    hide_credentials = {type = "boolean", default = false}
+    hide_credentials = {type = "boolean", default = false},
+    include_paths = { required = false, type = "array", default = {} },
+    exclude_paths = { required = false, type = "array", default = {} }
   }
 }

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -2,6 +2,7 @@ local cache = require "kong.tools.database_cache"
 local stringy = require "stringy"
 local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
+local utils = require "kong.tools.utils"
 
 local math_abs = math.abs
 local ngx_time = ngx.time
@@ -138,10 +139,12 @@ local function validate_clock_skew(headers, date_header_name, allowed_clock_skew
 end
 
 function _M.execute(conf)
+  local require_auth = utils.is_path_included(ngx.var.request_uri, conf)
+
   local headers = ngx_set_headers();
   -- If both headers are missing, return 401
   if not (headers[AUTHORIZATION] or headers[PROXY_AUTHORIZATION]) then
-    return responses.send_HTTP_UNAUTHORIZED()
+    return require_auth and responses.send_HTTP_UNAUTHORIZED()
   end
 
   -- validate clock skew

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -9,6 +9,8 @@ return {
   no_consumer = true,
   fields = {
     hide_credentials = { type = "boolean", default = false },
-    clock_skew = { type = "number", default = 300, func = check_clock_skew_positive }
+    clock_skew = { type = "number", default = 300, func = check_clock_skew_positive },
+    include_paths = { required = false, type = "array", default = {} },
+    exclude_paths = { required = false, type = "array", default = {} }
   }
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -4,6 +4,8 @@ return {
     uri_param_names = {type = "array", default = {"jwt"}},
     key_claim_name = {type = "string", default = "iss"},
     secret_is_base64 = {type = "boolean", default = false},
-    claims_to_verify = {type = "array", enum = {"exp", "nbf"}}
+    claims_to_verify = {type = "array", enum = {"exp", "nbf"}},
+    include_paths = { required = false, type = "array", default = {} },
+    exclude_paths = { required = false, type = "array", default = {} }
   }
 }

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -8,6 +8,8 @@ return {
   no_consumer = true,
   fields = {
     key_names = { required = true, type = "array", default = default_key_names },
-    hide_credentials = { type = "boolean", default = false }
+    hide_credentials = { type = "boolean", default = false },
+    include_paths = { required = false, type = "array", default = {} },
+    exclude_paths = { required = false, type = "array", default = {} }
   }
 }

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -362,6 +362,7 @@ local function parse_access_token(conf)
 end
 
 function _M.execute(conf)
+
   -- Check if the API has a request_path and if it's being invoked with the path resolver
   local path_prefix = (ngx.ctx.api.request_path and stringy.startswith(ngx.var.request_uri, ngx.ctx.api.request_path)) and ngx.ctx.api.request_path or ""
   if stringy.endswith(path_prefix, "/") then
@@ -376,9 +377,11 @@ function _M.execute(conf)
     end
   end
 
+  local require_auth = utils.is_path_included(ngx.var.request_uri, conf)
+
   local accessToken = parse_access_token(conf);
   if not accessToken then
-    return responses.send_HTTP_UNAUTHORIZED({}, false, {["WWW-Authenticate"] = 'Bearer realm="service"'})
+    return require_auth and responses.send_HTTP_UNAUTHORIZED({}, false, {["WWW-Authenticate"] = 'Bearer realm="service"'})
   end
 
   local token = retrieve_token(accessToken)

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -27,6 +27,8 @@ return {
     enable_client_credentials = { required = true, type = "boolean", default = false },
     enable_password_grant = { required = true, type = "boolean", default = false },
     hide_credentials = { type = "boolean", default = false },
-    accept_http_if_already_terminated = { required = false, type = "boolean", default = false }
+    accept_http_if_already_terminated = { required = false, type = "boolean", default = false },
+    include_paths = { required = false, type = "array", default = {} },
+    exclude_paths = { required = false, type = "array", default = {} }
   }
 }

--- a/spec/unit/dao/entities_schemas_spec.lua
+++ b/spec/unit/dao/entities_schemas_spec.lua
@@ -336,7 +336,7 @@ describe("Entities Schemas", function()
       -- Insert key-auth, whose config has some default values that should be set
       local plugin = {name = "key-auth", api_id = "stub"}
       local valid = validate_entity(plugin, plugins_schema, {dao = dao_stub})
-      assert.same({key_names = {"apikey"}, hide_credentials = false}, plugin.config)
+      assert.same({key_names = {"apikey"}, hide_credentials = false, include_paths = {}, exclude_paths = {}}, plugin.config)
       assert.True(valid)
     end)
     it("should be valid if no value is specified for a subfield and if the config schema has default as empty array", function()


### PR DESCRIPTION
I believe this may satisfy #853.

We have a use case where we want some endpoints within our api to be able to be accessible anonymously. Each of our api's hosts its own swagger ui with api-docs which we want to be accessible anonymously while securing the other endpoints with oauth2. The most flexible solution I thought of was having `include_paths` and `exclude_paths` arrays in the plugin config. Using these you can get pretty good control over which endpoints require authentication and which do not. This also opens the possibility of having multiple auth plugins on a single api for different endpoints (example basic-auth on the swagger ui and oauth2 on all else).

Each element in the include/exclude path arrays is a regex that is applied to the request url (after stripping out the path prefix). 

Also if you do hit an endpoint which is excluded and you do have the necessary auth header(s), it will still try authentication. It will only skip the auth stuff if the auth headers are not present.

Note: I can't seem to figure out the deal with the travis ci build :( It looks like it fails sending the coveralls report? I was hoping if I created a coveralls account and added my fork that it would work, but it didn't seem to help.

Just getting the following error (even if i build the latest `next` branch):
```
Upload error: Couldn't find a repository matching this job.
Upload error: Couldn't find a repository matching this job.
Upload error: Couldn't find a repository matching this job.
```