### PR TITLE
warn user when Serf versions are out of date

### DIFF
--- a/kong/cli/services/nginx.lua
+++ b/kong/cli/services/nginx.lua
@@ -181,8 +181,13 @@ function Nginx:_get_cmd()
   }, function(path)
     local res, code = IO.os_execute(path.." -v")
     if code == 0 then
-      return res:match("^nginx version: ngx_openresty/") or
-             res:match("^nginx version: openresty/")
+      local version_match = res:match("^nginx version: ngx_openresty/") or
+                              res:match("^nginx version: openresty/")
+      if not version_match then
+        logger:error("Incompatible nginx found. Kong requires OpenResty.")
+        os.exit(1)
+      end
+      return version_match
     end
 
     return false

--- a/kong/cli/services/serf.lua
+++ b/kong/cli/services/serf.lua
@@ -30,7 +30,8 @@ function Serf:_get_cmd()
     if code == 0 then
       local version_match = res:match("^Serf v0.7.0")
       if not version_match then
-        logger:warn("Incompatible Serf version. Kong requires v0.7.0.")
+        logger:error("Incompatible Serf version. Kong requires v0.7.0.")
+        os.exit(1)
       end
       return version_match
     end
@@ -53,7 +54,7 @@ function Serf:prepare()
   if not luajit_path then
     return nil, "Can't find luajit"
   end
-  
+
   local script = [[
 #!/bin/sh
 PAYLOAD=`cat` # Read from stdin
@@ -214,7 +215,7 @@ function Serf:event(t_payload)
   if string.len(encoded_payload) > 512 then
     -- Serf can't send a payload greater than 512 bytes
     return false, "Encoded payload is "..string.len(encoded_payload).." and it exceeds the limit of 512 bytes!"
-  end 
+  end
 
   return self:invoke_signal("event "..tostring(args).." kong", {"'"..encoded_payload.."'"}, true)
 end

--- a/kong/cli/services/serf.lua
+++ b/kong/cli/services/serf.lua
@@ -28,7 +28,11 @@ function Serf:_get_cmd()
   local cmd, err = Serf.super._get_cmd(self, {}, function(path)
     local res, code = IO.os_execute(path.." version")
     if code == 0 then
-      return res:match("^Serf v0.7.0")
+      local version_match = res:match("^Serf v0.7.0")
+      if not version_match then
+        logger:warn("Incompatible Serf version. Kong requires v0.7.0.")
+      end
+      return version_match
     end
 
     return false


### PR DESCRIPTION
The current behavior is to exit with an error message of "Could not find
Serf". It should be more friendly to warn if incompatible serf versions are
found in the path.