### PR TITLE
Fixes a bug in the invalidation event of the IP Restriction plugin

### DIFF
--- a/kong/cli/services/serf.lua
+++ b/kong/cli/services/serf.lua
@@ -60,7 +60,7 @@ fi
 
 echo $PAYLOAD > /tmp/payload
 
-COMMAND='require("kong.tools.http_client").post("http://]]..self._configuration.admin_api_listen..[[/cluster/events/", ]].."[['${PAYLOAD}']]"..[[, {["content-type"] = "application/json"})'
+COMMAND='require("kong.tools.http_client").post("http://]]..self._configuration.admin_api_listen..[[/cluster/events/", ]].."[=['${PAYLOAD}']=]"..[[, {["content-type"] = "application/json"})'
 
 echo $COMMAND | ]]..luajit_path..[[
 ]]

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -23,6 +23,10 @@ function IpRestrictionHandler:access(conf)
   local block = false
   local remote_addr = ngx.var.remote_addr
 
+  if not remote_addr then
+    return responses.send_HTTP_FORBIDDEN("Cannot identify the client IP address, unix domain sockets are not supported.")
+  end
+
   if conf._blacklist_cache and #conf._blacklist_cache > 0 then
     block = iputils.ip_in_cidrs(remote_addr, conf._blacklist_cache)
   end

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -36,5 +36,8 @@ return {
     end
 
     return true
+  end,
+  marshall_event = function(self, t)
+    return {} -- We don't need any value in the cache event
   end
 }


### PR DESCRIPTION
Fixes the restart bug mentioned in #782, and adds an additional check if the request comes from a unix domain socket.