### PR TITLE
Reducing avg Serf UDP packet sizes

### DIFF
--- a/kong/dao/cassandra/base_dao.lua
+++ b/kong/dao/cassandra/base_dao.lua
@@ -655,6 +655,8 @@ function BaseDao:event(type, data_t)
   if self.events_handler then
     if self._schema.marshall_event then
       data_t = self._schema.marshall_event(self._schema, data_t)
+    else
+      data_t = {}
     end
 
     local payload = {

--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -159,5 +159,8 @@ return {
     strip_request_path = {type = "boolean"},
     upstream_url = {type = "url", required = true, func = validate_upstream_url_protocol},
     preserve_host = {type = "boolean"}
-  }
+  },
+  marshall_event = function(self, t)
+    return { id = t.id }
+  end
 }

--- a/kong/dao/schemas/consumers.lua
+++ b/kong/dao/schemas/consumers.lua
@@ -19,5 +19,8 @@ return {
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true },
     custom_id = { type = "string", unique = true, queryable = true, func = check_custom_id_and_username },
     username = { type = "string", unique = true, queryable = true, func = check_custom_id_and_username }
-  }
+  },
+  marshall_event = function(self, t)
+    return { id = t.id }
+  end
 }

--- a/kong/dao/schemas/plugins.lua
+++ b/kong/dao/schemas/plugins.lua
@@ -56,6 +56,7 @@ return {
     }
   },
   marshall_event = function(self, plugin_t)
+    local result = utils.deep_copy(plugin_t)
     if plugin_t and plugin_t.config then
       local config_schema, err = self.fields.config.schema(plugin_t)
       if err then
@@ -63,11 +64,13 @@ return {
       end
 
       if config_schema.marshall_event and type(config_schema.marshall_event) == "function" then
-        plugin_t.config = config_schema.marshall_event(plugin_t.config)
+        result.config = config_schema.marshall_event(plugin_t.config)
+      else
+        result.config = {}
       end
     end
     
-    return plugin_t
+    return result
   end,
   self_check = function(self, plugin_t, dao, is_update)
     -- Load the config schema

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -36,8 +36,5 @@ return {
     end
 
     return true
-  end,
-  marshall_event = function(self, t)
-    return {} -- We don't need any value in the cache event
   end
 }

--- a/kong/plugins/ssl/schema.lua
+++ b/kong/plugins/ssl/schema.lua
@@ -28,8 +28,5 @@ return {
     -- Internal use
     _cert_der_cache = { type = "string" },
     _key_der_cache = { type = "string" }
-  },
-  marshall_event = function(self, t)
-    return {} -- We don't need any value in the cache event
-  end
+  }
 }

--- a/spec/integration/dao/cassandra/events_spec.lua
+++ b/spec/integration/dao/cassandra/events_spec.lua
@@ -28,9 +28,8 @@ describe("Events", function()
         assert.equals(event_types.ENTITY_CREATED, message_t.type)
         assert.equals("apis", message_t.collection)
         assert.truthy(message_t.entity)
-        assert.equals(5, utils.table_size(message_t.entity))
-        assert.equals("test.com", message_t.entity.request_host)
-        assert.equals("http://mockbin.org", message_t.entity.upstream_url)
+        assert.equals(1, utils.table_size(message_t.entity))
+        assert.truthy(message_t.entity.id)
         
         received = true
       end
@@ -59,9 +58,8 @@ describe("Events", function()
         assert.equals(event_types.ENTITY_UPDATED, message_t.type)
         assert.equals("apis", message_t.collection)
         assert.truthy(message_t.entity)
-        assert.equals(5, utils.table_size(message_t.entity))
-        assert.equals("test.com", message_t.entity.request_host)
-        assert.equals("http://mockbin.org", message_t.entity.upstream_url)
+        assert.equals(1, utils.table_size(message_t.entity))
+        assert.truthy(message_t.entity.id)
 
         local new_entity = dao_factory.apis:find_by_primary_key({id=message_t.entity.id})
         assert.equals("http://mockbin2.org", new_entity.upstream_url)
@@ -97,9 +95,8 @@ describe("Events", function()
         assert.equals(event_types.ENTITY_DELETED, message_t.type)
         assert.equals("apis", message_t.collection)
         assert.truthy(message_t.entity)
-        assert.equals(5, utils.table_size(message_t.entity))
-        assert.equals("test.com", message_t.entity.request_host)
-        assert.equals("http://mockbin.org", message_t.entity.upstream_url)
+        assert.equals(1, utils.table_size(message_t.entity))
+        assert.truthy(message_t.entity.id)
 
         received = true
       end

--- a/spec/plugins/logging_spec.lua
+++ b/spec/plugins/logging_spec.lua
@@ -20,7 +20,8 @@ local function create_mock_bin()
   return res:sub(2, res:len() - 1)
 end
 
-local mock_bin = create_mock_bin()
+local mock_bin_http = create_mock_bin()
+local mock_bin_https = create_mock_bin()
 
 describe("Logging Plugins #ci", function()
 
@@ -39,8 +40,8 @@ describe("Logging Plugins #ci", function()
         {name = "tcp-log", config = {host = "127.0.0.1", port = TCP_PORT}, __api = 1},
         {name = "tcp-log", config = {host = "127.0.0.1", port = TCP_PORT}, __api = 2},
         {name = "udp-log", config = {host = "127.0.0.1", port = UDP_PORT}, __api = 3},
-        {name = "http-log", config = {http_endpoint = "http://mockbin.org/bin/"..mock_bin}, __api = 4},
-        {name = "http-log", config = {http_endpoint = "https://mockbin.org/bin/"..mock_bin}, __api = 5},
+        {name = "http-log", config = {http_endpoint = "http://mockbin.org/bin/"..mock_bin_http}, __api = 4},
+        {name = "http-log", config = {http_endpoint = "https://mockbin.org/bin/"..mock_bin_https}, __api = 5},
         {name = "file-log", config = {path = FILE_LOG_PATH }, __api = 6}
       }
     }
@@ -117,7 +118,7 @@ describe("Logging Plugins #ci", function()
     local res, status, body
     repeat
       assert.truthy(total_time <= 10) -- Fail after 10 seconds
-      res, status = http_client.get("http://mockbin.org/bin/"..mock_bin.."/log", nil, { accept = "application/json" })
+      res, status = http_client.get("http://mockbin.org/bin/"..mock_bin_http.."/log", nil, { accept = "application/json" })
       assert.equal(200, status)
       body = cjson.decode(res)
       local wait = 1
@@ -141,7 +142,7 @@ describe("Logging Plugins #ci", function()
     local res, status, body
     repeat
       assert.truthy(total_time <= 10) -- Fail after 10 seconds
-      res, status = http_client.get("http://mockbin.org/bin/"..mock_bin.."/log", nil, { accept = "application/json" })
+      res, status = http_client.get("http://mockbin.org/bin/"..mock_bin_https.."/log", nil, { accept = "application/json" })
       assert.equal(200, status)
       body = cjson.decode(res)
       local wait = 1

--- a/spec/plugins/rate-limiting/access_spec.lua
+++ b/spec/plugins/rate-limiting/access_spec.lua
@@ -10,7 +10,7 @@ local function wait()
   -- fail. So we give it this test 30 seconds to execute, and if the second
   -- of the current minute is > 30, then we wait till the new minute kicks in
   local current_second = timestamp.get_timetable().sec
-  if current_second > 30 then
+  if current_second > 20 then
     os.execute("sleep "..tostring(60 - current_second))
   end
 end

--- a/spec/plugins/response-ratelimiting/access_spec.lua
+++ b/spec/plugins/response-ratelimiting/access_spec.lua
@@ -11,7 +11,7 @@ local function wait()
   -- fail. So we give it this test 30 seconds to execute, and if the second
   -- of the current minute is > 30, then we wait till the new minute kicks in
   local current_second = timestamp.get_timetable().sec
-  if current_second > 30 then
+  if current_second > 20 then
     os.execute("sleep "..tostring(60 - current_second))
   end
 end


### PR DESCRIPTION
`marshall_event` by default now returns an empty object, and the properties to propagate need to be explicitly returned.

This changed the previous behavior where by default `marshall_event` returned the entire object.