### PR TITLE
docs(changelog) 0.7.x changelog and upgrade path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## [Unreleased][unreleased]
 
+### Breaking changes
+
+Due to the NGINX security fixes (CVE-2016-0742, CVE-2016-0746, CVE-2016-0747), OpenResty was bumped to `1.9.7.3` which is not backwards compatible, and thus requires changes to be made to the `nginx` property of Kong's configuration file. See the [0.7 upgrade path](https://github.com/Mashape/kong/blob/master/UPGRADE.md#upgrade-to-07x) for instructions.
+
+However by upgrading the underlying OpenResty version, source installations do not have to patch the NGINX core and use the old `ssl-cert-by-lua` branch of ngx_lua anymore. This will make source installations much easier.
+
+### Added
+
+- Support for OpenResty `1.9.7.*`. This includes NGINX security fixes (CVE-2016-0742, CVE-2016-0746, CVE-2016-0747). [#906](https://github.com/Mashape/kong/pull/906)
+- Plugins
+  - **New Datadog plugin**: Send metrics to Datadog statsd server. [#758](https://github.com/Mashape/kong/pull/758)
+  - **New Runscope plugin**: Monitor your APIs from Kong with Runscope. Courtesy of [@mansilladev](https://github.com/mansilladev). [#924](https://github.com/Mashape/kong/pull/924)
+  - Support for asynchronous incrementation of rate-limiting (request and response) counters. [#912](https://github.com/Mashape/kong/pull/912) [#953](https://github.com/Mashape/kong/pull/953)
+  - New option in rate-limiting (request and response) plugins to authorize requests when Cassandra appears to be down. [#912](https://github.com/Mashape/kong/pull/912)
+- Send 500 errors in the appropriate format. [#927](https://github.com/Mashape/kong/pull/927) [#970](https://github.com/Mashape/kong/pull/970)
+- CLI
+  - Perform a simple permission check on the NGINX working directory when starting, to prevent errors during execution. [#939](https://github.com/Mashape/kong/pull/939)
+
+### Fixed
+
+- Plugins
+  - OAuth2
+    - Better handling of `redirect_uri` (prevent the use of fragments and correctly handle querystrings). Courtesy of [@PGBI](https://github.com/PGBI). [#930](https://github.com/Mashape/kong/pull/930)
+    - Add `PUT` support to the `/auth2_tokens` route. [#897](https://github.com/Mashape/kong/pull/897)
+  - IP restriction: Fix an issue that could arise when restarting Kong. Now Kong does not need to be restarted for the ip-restriction configuration to take effect. [#782](https://github.com/Mashape/kong/pull/782) [#960](https://github.com/Mashape/kong/pull/960)
+  - SSL: Replace shelled out openssl calls with native `ngx.ssl` conversion utilities, which preserve the certificate chain. [#968](https://github.com/Mashape/kong/pull/968)
+- Avoid user warning on start when the user is not root. [#964](https://github.com/Mashape/kong/pull/964)
+- Store Serf logs in NGINX working directory to prevent eventual permission issues. [#975](https://github.com/Mashape/kong/pull/975)
+- Allow plugins configured on a Consumer *without* being configured on an API to run. [#978](https://github.com/Mashape/kong/issues/978) [#980](https://github.com/Mashape/kong/pull/980)
+
 ## [0.6.1] - 2016/02/03
 
 This release contains tiny bug fixes that were especially annoying for complex Cassandra setups and power users of the Admin API!

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,22 @@ $ kong reload [-c configuration_file]
 
 **Reminder**: `kong reload` leverages the Nginx `reload` signal and seamlessly starts new workers taking over the old ones until they all have been terminated. This will guarantee you no drop in your current incoming traffic.
 
+## Upgrade to `0.7.x`
+
+If you are running a source installation, you will need to upgrade OpenResty to its `1.9.7.*` version. The good news is that this family of releases does not need to patch the NGINX core anymore to enable SSL support. If you install Kong from one of the distribution packages, they already include the appropriate OpenResty, simply download and install the appropriate package for your platform.
+
+As described in the Changelog, this upgrade has benefits, such as the SSL support and fixes for critical NGINX vulnerabilities, but also requires that you upgrade the `nginx` property of your Kong config, because it is not backwards compatible.
+
+- We advise that you retrieve the `nginx` property from the `0.7.x` configuration file, and use it in yours with the changes you feel are appropriate.
+
+- Finally, you can reload Kong as usual:
+
+```shell
+$ kong reload [-c configuration_file]
+```
+
+**Note**: We expose the underlying NGINX configuration as a way for Kong to be as flexible as possible and allow you to bend your NGINX instance to your needs. We are aware that many of you do not need to customize it and such changes should not affect you. Plans are to embed the NGINX configuration in Kong, while still allowing customization for the most demanding users. [#217](https://github.com/Mashape/kong/pull/217) is the place to discuss this and share thoughts/needs.
+
 ## Upgrade to `0.6.x`
 
 **Note**: if you are using Kong 0.4.x or earlier, you must first upgrade to Kong 0.5.x.


### PR DESCRIPTION
- 0.7.x changelog (still as "unreleased")
- 0.7.x upgrade path

Note in upgrade path that I feel is appropriate:

> **Note**: We expose the underlying NGINX configuration as a way for Kong
to be as flexible as possible and allow you to bend your NGINX instance
to your needs. We are aware that many of you do not need to customize it
and such changes should not affect you. Plans are to embed the NGINX
configuration in Kong, while still allowing customization for the most
demanding users. [#217](https://github.com/Mashape/kong/pull/217) is the
place to discuss this and share thoughts/needs.