### PR TITLE
Fixing the plugins loader

### DIFF
--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -3,8 +3,6 @@ local constants = require "kong.constants"
 local responses = require "kong.tools.responses"
 
 local table_remove = table.remove
-local table_insert = table.insert
-local ipairs = ipairs
 
 --- Load the configuration for a plugin entry in the DB.
 -- Given an API, a Consumer and a plugin name, retrieve the plugin's configuration if it exists.
@@ -15,7 +13,6 @@ local ipairs = ipairs
 -- @treturn table Plugin retrieved from the cache or database.
 local function load_plugin_configuration(api_id, consumer_id, plugin_name)
   local cache_key = cache.plugin_key(plugin_name, api_id, consumer_id)
-
   local plugin = cache.get_or_set(cache_key, function()
     local rows, err = dao.plugins:find_by_keys {
       api_id = api_id,
@@ -30,7 +27,6 @@ local function load_plugin_configuration(api_id, consumer_id, plugin_name)
       return table_remove(rows, 1)
     else
       -- insert a cached value to not trigger too many DB queries.
-      -- for now, this will lock the cache for the expiraiton duration.
       return {null = true}
     end
   end)
@@ -40,78 +36,47 @@ local function load_plugin_configuration(api_id, consumer_id, plugin_name)
   end
 end
 
-local function load_plugins_for_req(loaded_plugins)
-  if ngx.ctx.plugins_for_request == nil then
-    local t = {}
-    -- Build an array of plugins that must be executed for this particular request.
-    -- A plugin is considered to be executed if there is a row in the DB which contains:
-    -- 1. the API id (contained in ngx.ctx.api.id, retrived by the core resolver)
-    -- 2. a Consumer id, in which case it overrides any previous plugin found in 1.
-    --    this use case will be treated once the authentication plugins have run (access phase).
-    -- Such a row will contain a `config` value, which is a table.
-    if ngx.ctx.api ~= nil then
-      for _, plugin in ipairs(loaded_plugins) do
-        local plugin_configuration = load_plugin_configuration(ngx.ctx.api.id, nil, plugin.name)
-        if plugin_configuration ~= nil then
-          table_insert(t, {plugin, plugin_configuration})
-        end
-      end
-    end
-
-    ngx.ctx.plugins_for_request = t
-  end
-end
-
 --- Plugins for request iterator.
 -- Iterate over the plugin loaded for a request, stored in `ngx.ctx.plugins_for_request`.
--- @param[type=string] context_name Name of the current nginx context. We don't use `ngx.get_phase()` simply because we can avoid it.
+-- @param[type=boolean] is_access_or_certificate_context Tells if the context is access_by_lua_block. We don't use `ngx.get_phase()` simply because we can avoid it.
 -- @treturn function iterator
-local function iter_plugins_for_req(loaded_plugins, context_name)
-  -- In case previous contexts did not run, we need to handle
-  -- the case when plugins have not been fetched for a given request.
-  -- This will simply make it so the look gets skipped if no API is set in the context
-  load_plugins_for_req(loaded_plugins)
+local function iter_plugins_for_req(loaded_plugins, is_access_or_certificate_context)
+  if not ngx.ctx.plugins_for_request then 
+    ngx.ctx.plugins_for_request = {} 
+  end
 
   local i = 0
-
-  -- Iterate on plugins to execute for this request until
-  -- a plugin with a handler for the given context is found.
-  local function get_next()
+  local function get_next_plugin()
     i = i + 1
-    local p = ngx.ctx.plugins_for_request[i]
-    if p == nil then
-      return
-    end
+    return loaded_plugins[i]
+  end
 
-    local plugin, plugin_configuration = p[1], p[2]
-    if plugin.handler[context_name] == nil then
-      ngx.log(ngx.DEBUG, "No handler for "..context_name.." phase on "..plugin.name.." plugin")
-      return get_next()
-    end
+  local function get_next()
+    local plugin = get_next_plugin()
+    if plugin and ngx.ctx.api then
+      if is_access_or_certificate_context then
+        ngx.ctx.plugins_for_request[plugin.name] = load_plugin_configuration(ngx.ctx.api.id, nil, plugin.name)
 
-    return plugin, plugin_configuration
+        local consumer_id = ngx.ctx.authenticated_credential and ngx.ctx.authenticated_credential.consumer_id or nil
+        if consumer_id and not plugin.schema.no_consumer then
+          local consumer_plugin_configuration = load_plugin_configuration(ngx.ctx.api.id, consumer_id, plugin.name)
+          if consumer_plugin_configuration then
+            ngx.ctx.plugins_for_request[plugin.name] = consumer_plugin_configuration
+          end
+        end
+      end
+
+      -- Return the configuration
+      if ngx.ctx.plugins_for_request[plugin.name] then
+        return plugin, ngx.ctx.plugins_for_request[plugin.name]
+      end
+
+      return get_next() -- Load next plugin
+    end
   end
 
   return function()
-    local plugin, plugin_configuration = get_next()
-
-    -- Check if any Consumer was authenticated during the access phase.
-    -- If so, retrieve the configuration for this Consumer which overrides
-    -- the API-wide configuration.
-    if plugin ~= nil and context_name == "access" then
-      local consumer_id = ngx.ctx.authenticated_credential and ngx.ctx.authenticated_credential.consumer_id or nil
-      if consumer_id ~= nil then
-        local consumer_plugin_configuration = load_plugin_configuration(ngx.ctx.api.id, consumer_id, plugin.name)
-        if consumer_plugin_configuration ~= nil then
-          -- This Consumer has a special configuration when this plugin gets executed.
-          -- Override this plugin's configuration for this request.
-          plugin_configuration = consumer_plugin_configuration
-          ngx.ctx.plugins_for_request[i][2] = consumer_plugin_configuration
-        end
-      end
-    end
-
-    return plugin, plugin_configuration
+    return get_next()
   end
 end
 


### PR DESCRIPTION
Closes #978. 

Also loads the consumer-specific configuration only for those plugins that have `no_consumer = false` in the schema.