### PR TITLE
Replace globals with `kong.singletons` module variables.

### DIFF
--- a/kong-0.6.1-0.rockspec
+++ b/kong-0.6.1-0.rockspec
@@ -45,6 +45,7 @@ build = {
     ["resty_http"] = "kong/vendor/resty_http.lua",
 
     ["kong.constants"] = "kong/constants.lua",
+    ["kong.singletons"] = "kong/singletons.lua",
 
     ["kong.cli.utils.logger"] = "kong/cli/utils/logger.lua",
     ["kong.cli.utils.luarocks"] = "kong/cli/utils/luarocks.lua",

--- a/kong/api/app.lua
+++ b/kong/api/app.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local lapis = require "lapis"
 local utils = require "kong.tools.utils"
 local stringy = require "stringy"
@@ -130,7 +131,7 @@ local function attach_routes(routes)
 
     for k, v in pairs(methods) do
       local method = function(self)
-        return v(self, dao, handler_helpers)
+        return v(self, singletons.dao, handler_helpers)
       end
       methods[k] = parse_params(method)
     end
@@ -146,8 +147,8 @@ for _, v in ipairs({"kong", "apis", "consumers", "plugins", "cache", "cluster" }
 end
 
 -- Loading plugins routes
-if configuration and configuration.plugins then
-  for _, v in ipairs(configuration.plugins) do
+if singletons.configuration and singletons.configuration.plugins then
+  for _, v in ipairs(singletons.configuration.plugins) do
     local loaded, mod = utils.load_module_if_exists("kong.plugins."..v..".api")
     if loaded then
       ngx.log(ngx.DEBUG, "Loading API endpoints for plugin: "..v)

--- a/kong/api/routes/apis.lua
+++ b/kong/api/routes/apis.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local crud = require "kong.api.crud_helpers"
 local syslog = require "kong.tools.syslog"
 local constants = require "kong.constants"
@@ -52,7 +53,7 @@ return {
 
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.plugins, function(data)
-        if configuration.send_anonymous_reports then
+        if singletons.configuration.send_anonymous_reports then
           data.signal = constants.SYSLOG.API
           syslog.log(syslog.format_entity(data))
         end

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local constants = require "kong.constants"
 local route_helpers = require "kong.api.route_helpers"
 local utils = require "kong.tools.utils"
@@ -15,11 +16,11 @@ return {
         version = constants.VERSION,
         hostname = utils.get_hostname(),
         plugins = {
-          available_on_server = configuration.plugins,
+          available_on_server = singletons.configuration.plugins,
           enabled_in_cluster = db_plugins
         },
         lua_version = jit and jit.version or _VERSION,
-        configuration = configuration
+        configuration = singletons.configuration
       })
     end
   },

--- a/kong/core/certificate.lua
+++ b/kong/core/certificate.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local cache = require "kong.tools.database_cache"
 local stringy = require "stringy"
 
@@ -9,7 +10,7 @@ local function find_api(hosts)
     local sanitized_host = stringy.split(host, ":")[1]
 
     retrieved_api, err = cache.get_or_set(cache.api_key(sanitized_host), function()
-      local apis, err = dao.apis:find_by_keys {request_host = sanitized_host}
+      local apis, err = singletons.dao.apis:find_by_keys {request_host = sanitized_host}
       if err then
         return nil, err
       elseif apis and #apis == 1 then

--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local cache = require "kong.tools.database_cache"
 local constants = require "kong.constants"
 local responses = require "kong.tools.responses"
@@ -17,7 +18,7 @@ local function load_plugin_configuration(api_id, consumer_id, plugin_name)
   local cache_key = cache.plugin_key(plugin_name, api_id, consumer_id)
 
   local plugin = cache.get_or_set(cache_key, function()
-    local rows, err = dao.plugins:find_by_keys {
+    local rows, err = singletons.dao.plugins:find_by_keys {
       api_id = api_id,
       consumer_id = consumer_id ~= nil and consumer_id or constants.DATABASE_NULL_ID,
       name = plugin_name

--- a/kong/core/resolver.lua
+++ b/kong/core/resolver.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local url = require "socket.url"
 local cache = require "kong.tools.database_cache"
 local stringy = require "stringy"
@@ -63,7 +64,7 @@ end
 -- Load all APIs in memory.
 -- Sort the data for faster lookup: dictionary per request_host and an array of wildcard request_host.
 function _M.load_apis_in_memory()
-  local apis, err = dao.apis:find_all()
+  local apis, err = singletons.dao.apis:find_all()
   if err then
     return nil, err
   end

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -25,6 +25,7 @@
 -- ==========
 
 local core = require "kong.core.handler"
+local singletons = require "kong.singletons"
 local utils = require "kong.tools.utils"
 local dao_loader = require "kong.tools.dao_loader"
 local config_loader = require "kong.tools.config_loader"
@@ -34,11 +35,6 @@ local Events = require "kong.core.events"
 local ipairs = ipairs
 local table_insert = table.insert
 local table_sort = table.sort
-
-local loaded_plugins = {}
--- @TODO make those locals too
--- local configuration
--- local dao_factory
 
 --- Attach a hooks table to the event bus
 local function attach_hooks(events, hooks)
@@ -54,7 +50,7 @@ end
 -- @treturn table Array of plugins to execute in context handlers.
 local function load_node_plugins(configuration)
   ngx.log(ngx.DEBUG, "Discovering used plugins")
-  local db_plugins, err = dao.plugins:find_distinct()
+  local db_plugins, err = singletons.dao.plugins:find_distinct()
   if err then
     error(err)
   end
@@ -83,7 +79,7 @@ local function load_node_plugins(configuration)
     -- Attaching hooks
     local loaded, plugin_hooks = utils.load_module_if_exists("kong.plugins."..v..".hooks")
     if loaded then
-      attach_hooks(events, plugin_hooks)
+      attach_hooks(singletons.events, plugin_hooks)
     end
   end
 
@@ -127,9 +123,9 @@ function Kong.init()
       loaded_plugins = load_node_plugins(configuration)
 
       -- Attach core hooks
-      attach_hooks(events, require("kong.core.hooks"))
+      attach_hooks(singletons.events, require("kong.core.hooks"))
 
-      if configuration.send_anonymous_reports then
+      if singletons.configuration.send_anonymous_reports then
         -- Generate the unique_str inside the module
         local reports = require "kong.core.reports"
         reports.enable()
@@ -146,7 +142,7 @@ end
 function Kong.init_worker()
   core.init_worker.before()
 
-  for _, plugin in ipairs(loaded_plugins) do
+  for _, plugin in ipairs(singletons.loaded_plugins) do
     plugin.handler:init_worker()
   end
 end
@@ -154,7 +150,7 @@ end
 function Kong.ssl_certificate()
   core.certificate.before()
 
-  for plugin, plugin_conf in plugins_iterator(loaded_plugins, "certificate") do
+  for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, "certificate") do
     plugin.handler:certificate(plugin_conf)
   end
 end
@@ -162,7 +158,7 @@ end
 function Kong.access()
   core.access.before()
 
-  for plugin, plugin_conf in plugins_iterator(loaded_plugins, "access") do
+  for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, "access") do
     plugin.handler:access(plugin_conf)
   end
 
@@ -172,7 +168,7 @@ end
 function Kong.header_filter()
   core.header_filter.before()
 
-  for plugin, plugin_conf in plugins_iterator(loaded_plugins, "header_filter") do
+  for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, "header_filter") do
     plugin.handler:header_filter(plugin_conf)
   end
 
@@ -180,7 +176,7 @@ function Kong.header_filter()
 end
 
 function Kong.body_filter()
-  for plugin, plugin_conf in plugins_iterator(loaded_plugins, "body_filter") do
+  for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, "body_filter") do
     plugin.handler:body_filter(plugin_conf)
   end
 
@@ -188,7 +184,7 @@ function Kong.body_filter()
 end
 
 function Kong.log()
-  for plugin, plugin_conf in plugins_iterator(loaded_plugins, "log") do
+  for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, "log") do
     plugin.handler:log(plugin_conf)
   end
 

--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -1,9 +1,10 @@
+local singletons = require "kong.singletons"
 local BaseDao = require "kong.dao.cassandra.base_dao"
 
 local function check_unique(group, acl)
   -- If dao required to make this work in integration tests when adding fixtures
-  if dao and acl.consumer_id and group then
-    local res, err = dao.acls:find_by_keys({consumer_id=acl.consumer_id, group=group})
+  if singletons.dao and acl.consumer_id and group then
+    local res, err = singletons.dao.acls:find_by_keys({consumer_id=acl.consumer_id, group=group})
     if not err and #res > 0 then
       return false, "ACL group already exist for this consumer"
     elseif not err then

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local BasePlugin = require "kong.plugins.base_plugin"
 local cache = require "kong.tools.database_cache"
 local responses = require "kong.tools.responses"
@@ -23,7 +24,7 @@ function ACLHandler:access(conf)
 
   -- Retrieve ACL
   local acls = cache.get_or_set(cache.acls_key(consumer_id), function()
-    local results, err = dao.acls:find_by_keys({consumer_id = consumer_id})
+    local results, err = singletons.dao.acls:find_by_keys({consumer_id = consumer_id})
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local cache = require "kong.tools.database_cache"
 local stringy = require "stringy"
 local responses = require "kong.tools.responses"
@@ -67,7 +68,7 @@ local function load_credential_from_db(username)
   local credential
   if username then
     credential = cache.get_or_set(cache.basicauth_credential_key(username), function()
-      local credentials, err = dao.basicauth_credentials:find_by_keys {username = username}
+      local credentials, err = singletons.dao.basicauth_credentials:find_by_keys {username = username}
       local result
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -106,7 +107,7 @@ function _M.execute(conf)
 
   -- Retrieve consumer
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id), function()
-    local result, err = dao.consumers:find_by_primary_key({ id = credential.consumer_id })
+    local result, err = singletons.dao.consumers:find_by_primary_key({ id = credential.consumer_id })
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local BaseDao = require "kong.dao.cassandra.base_dao"
 local crypto = require "kong.plugins.basic-auth.crypto"
 
@@ -6,8 +7,8 @@ local function encrypt_password(password, credential)
   -- This causes a bug when a new password is effectively equal the to previous digest
   -- TODO: Better handle this scenario
   if credential.id then
-    if dao then -- Check to make this work with tests
-      local result = dao.basicauth_credentials:find_by_primary_key({id=credential.id})
+    if singletons.dao then -- Check to make this work with tests
+      local result = singletons.dao.basicauth_credentials:find_by_primary_key({id=credential.id})
       if result and result.password == credential.password then
         return true
       end

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local cache = require "kong.tools.database_cache"
 local stringy = require "stringy"
 local responses = require "kong.tools.responses"
@@ -106,7 +107,7 @@ local function load_credential(username)
   local credential
   if username then
       credential = cache.get_or_set(cache.hmacauth_credential_key(username), function()
-      local keys, err = dao.hmacauth_credentials:find_by_keys { username = username }
+      local keys, err = singletons.dao.hmacauth_credentials:find_by_keys { username = username }
       local result
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -171,7 +172,7 @@ function _M.execute(conf)
 
   -- Retrieve consumer
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id), function()
-    local result, err = dao.consumers:find_by_primary_key({ id = credential.consumer_id })
+    local result, err = singletons.dao.consumers:find_by_primary_key({ id = credential.consumer_id })
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local BasePlugin = require "kong.plugins.base_plugin"
 local cache = require "kong.tools.database_cache"
 local responses = require "kong.tools.responses"
@@ -75,7 +76,7 @@ function JwtHandler:access(conf)
 
   -- Retrieve the secret
   local jwt_secret = cache.get_or_set(cache.jwtauth_credential_key(jwt_secret_key), function()
-    local rows, err = dao.jwt_secrets:find_by_keys {key = jwt_secret_key}
+    local rows, err = singletons.dao.jwt_secrets:find_by_keys {key = jwt_secret_key}
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR()
     elseif #rows > 0 then
@@ -105,7 +106,7 @@ function JwtHandler:access(conf)
 
   -- Retrieve the consumer
   local consumer = cache.get_or_set(cache.consumer_key(jwt_secret_key), function()
-    local consumer, err = dao.consumers:find_by_primary_key {id = jwt_secret.consumer_id}
+    local consumer, err = singletons.dao.consumers:find_by_primary_key {id = jwt_secret.consumer_id}
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local cache = require "kong.tools.database_cache"
 local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
@@ -64,7 +65,7 @@ function KeyAuthHandler:access(conf)
     if key then
       key_found = true
       credential = cache.get_or_set(cache.keyauth_credential_key(key), function()
-        local credentials, err = dao.keyauth_credentials:find_by_keys {key = key}
+        local credentials, err = singletons.dao.keyauth_credentials:find_by_keys {key = key}
         local result
         if err then
           return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -90,7 +91,7 @@ function KeyAuthHandler:access(conf)
 
   -- Retrieve consumer
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id), function()
-    local result, err = dao.consumers:find_by_primary_key({id = credential.consumer_id})
+    local result, err = singletons.dao.consumers:find_by_primary_key({id = credential.consumer_id})
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local stringy = require "stringy"
 local utils = require "kong.tools.utils"
 local cache = require "kong.tools.database_cache"
@@ -34,7 +35,7 @@ local TOKEN_URL = "^%s/oauth2/token(/?(\\?[^\\s]*)?)$"
 local function generate_token(conf, credential, authenticated_userid, scope, state, expiration, disable_refresh)
   local token_expiration = expiration or conf.token_expiration
 
-  local token, err = dao.oauth2_tokens:insert({
+  local token, err = singletons.dao.oauth2_tokens:insert({
     credential_id = credential.id,
     authenticated_userid = authenticated_userid,
     expires_in = token_expiration,
@@ -63,7 +64,7 @@ local function get_redirect_uri(client_id)
   local client
   if client_id then
     client = cache.get_or_set(cache.oauth2_credential_key(client_id), function()
-      local credentials, err = dao.oauth2_credentials:find_by_keys { client_id = client_id }
+      local credentials, err = singletons.dao.oauth2_credentials:find_by_keys { client_id = client_id }
       local result
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -149,7 +150,7 @@ local function authorize(conf)
       -- If there are no errors, keep processing the request
       if not response_params[ERROR] then
         if response_type == CODE then
-          local authorization_code, err = dao.oauth2_authorization_codes:insert({
+          local authorization_code, err = singletons.dao.oauth2_authorization_codes:insert({
             authenticated_userid = parameters[AUTHENTICATED_USERID],
             scope = table.concat(scopes, " ")
           })
@@ -247,7 +248,7 @@ local function issue_token(conf)
     if not response_params[ERROR] then
       if grant_type == GRANT_AUTHORIZATION_CODE then
         local code = parameters[CODE]
-        local authorization_code = code and dao.oauth2_authorization_codes:find_by_keys({code = code})[1] or nil
+        local authorization_code = code and singletons.dao.oauth2_authorization_codes:find_by_keys({code = code})[1] or nil
         if not authorization_code then
           response_params = {[ERROR] = "invalid_request", error_description = "Invalid "..CODE}
         else
@@ -283,12 +284,12 @@ local function issue_token(conf)
         end
       elseif grant_type == GRANT_REFRESH_TOKEN then
         local refresh_token = parameters[REFRESH_TOKEN]
-        local token = refresh_token and dao.oauth2_tokens:find_by_keys({refresh_token = refresh_token})[1] or nil
+        local token = refresh_token and singletons.dao.oauth2_tokens:find_by_keys({refresh_token = refresh_token})[1] or nil
         if not token then
           response_params = {[ERROR] = "invalid_request", error_description = "Invalid "..REFRESH_TOKEN}
         else
           response_params = generate_token(conf, client, token.authenticated_userid, token.scope, state)
-          dao.oauth2_tokens:delete({id=token.id}) -- Delete old token
+          singletons.dao.oauth2_tokens:delete({id=token.id}) -- Delete old token
         end
       end
     end
@@ -308,7 +309,7 @@ local function retrieve_token(access_token)
   local token
   if access_token then
     token = cache.get_or_set(cache.oauth2_token_key(access_token), function()
-      local credentials, err = dao.oauth2_tokens:find_by_keys { access_token = access_token }
+      local credentials, err = singletons.dao.oauth2_tokens:find_by_keys { access_token = access_token }
       local result
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -396,7 +397,7 @@ function _M.execute(conf)
 
   -- Retrive the credential from the token
   local credential = cache.get_or_set(cache.oauth2_credential_key(token.credential_id), function()
-    local result, err = dao.oauth2_credentials:find_by_primary_key({id = token.credential_id})
+    local result, err = singletons.dao.oauth2_credentials:find_by_primary_key({id = token.credential_id})
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end
@@ -405,7 +406,7 @@ function _M.execute(conf)
 
   -- Retrive the consumer from the credential
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id), function()
-    local result, err = dao.consumers:find_by_primary_key({id = credential.consumer_id})
+    local result, err = singletons.dao.consumers:find_by_primary_key({id = credential.consumer_id})
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -1,5 +1,6 @@
 -- Copyright (C) Mashape, Inc.
 
+local singletons = require "kong.singletons"
 local BasePlugin = require "kong.plugins.base_plugin"
 local constants = require "kong.constants"
 local timestamp = require "kong.tools.timestamp"
@@ -25,7 +26,7 @@ end
 
 local function increment(api_id, identifier, current_timestamp, value)
   -- Increment metrics for all periods if the request goes through
-  local _, stmt_err = dao.ratelimiting_metrics:increment(api_id, identifier, current_timestamp, value)
+  local _, stmt_err = singletons.dao.ratelimiting_metrics:increment(api_id, identifier, current_timestamp, value)
   if stmt_err then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(stmt_err)
   end
@@ -36,7 +37,7 @@ local function get_usage(api_id, identifier, current_timestamp, limits)
   local stop
 
   for name, limit in pairs(limits) do
-    local current_metric, err = dao.ratelimiting_metrics:find_one(api_id, identifier, current_timestamp, name)
+    local current_metric, err = singletons.dao.ratelimiting_metrics:find_one(api_id, identifier, current_timestamp, name)
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -1,3 +1,4 @@
+local singletons = require "kong.singletons"
 local timestamp = require "kong.tools.timestamp"
 local responses = require "kong.tools.responses"
 local utils = require "kong.tools.utils"
@@ -22,7 +23,7 @@ local function get_current_usage(api_id, identifier, current_timestamp, limits)
 
   for k, v in pairs(limits) do -- Iterate over limit names
     for lk, lv in pairs(v) do -- Iterare over periods
-      local current_metric, err = dao.response_ratelimiting_metrics:find_one(api_id, identifier, current_timestamp, lk, k)
+      local current_metric, err = singletons.dao.response_ratelimiting_metrics:find_one(api_id, identifier, current_timestamp, lk, k)
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
       end

--- a/kong/plugins/response-ratelimiting/log.lua
+++ b/kong/plugins/response-ratelimiting/log.lua
@@ -1,8 +1,10 @@
+local singletons = require "kong.singletons"
+
 local _M = {}
 
 local function increment(api_id, identifier, current_timestamp, value, name)
   -- Increment metrics for all periods if the request goes through
-  local _, stmt_err = dao.response_ratelimiting_metrics:increment(api_id, identifier, current_timestamp, value, name)
+  local _, stmt_err = singletons.dao.response_ratelimiting_metrics:increment(api_id, identifier, current_timestamp, value, name)
   if stmt_err then
     ngx.log(ngx.ERR, tostring(stmt_err))
   end

--- a/kong/singletons.lua
+++ b/kong/singletons.lua
@@ -1,0 +1,8 @@
+local _M = {
+  configuration = nil,
+  events = nil,
+  dao = nil,
+  loaded_plugins = nil
+}
+
+return _M

--- a/spec/unit/core/resolver_spec.lua
+++ b/spec/unit/core/resolver_spec.lua
@@ -1,6 +1,7 @@
 -- Stubs
 require "kong.tools.ngx_stub"
 
+local singletons = require "kong.singletons"
 local resolver = require "kong.core.resolver"
 
 local APIS_FIXTURES = {
@@ -19,7 +20,7 @@ local APIS_FIXTURES = {
   {name = "preserve-host", request_path = "/preserve-host", request_host = "preserve-host.com", upstream_url = "http://mockbin.com", preserve_host = true}
 }
 
-_G.dao = {
+singletons.dao = {
   apis = {
     find_all = function()
       return APIS_FIXTURES


### PR DESCRIPTION
Follow-through from https://github.com/mars/kong/commit/f59c849960930dd2e709197df10d14ef93bfd06c

Replacing globals will not change any functional behavior. It will:

* avoid slow global lookups
* make it easier for devs to see where values come from

The module name `singletons` was chosen to make it easy to find these anywhere in the project; names like `env`, `environment`, `config`, etc. would lead to confusion.
