### PR TITLE
Showing ngx timers stats in the API

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -14,6 +14,10 @@ return {
         tagline = "Welcome to Kong",
         version = constants.VERSION,
         hostname = utils.get_hostname(),
+        timers = {
+          running = ngx.timer.running_count(),
+          pending = ngx.timer.pending_count()
+        },
         plugins = {
           available_on_server = configuration.plugins,
           enabled_in_cluster = db_plugins


### PR DESCRIPTION
Shows the following stats in the index endpoint `/` of the Kong API, for example:

```json
{
  "timers": {
    "running": 2,
    "pending": 5
  }

  ...
}
```