### PR TITLE
Fixes starting Kong in foreground mode

### DIFF
--- a/kong-0.7.0rc1-0.rockspec
+++ b/kong-0.7.0rc1-0.rockspec
@@ -27,6 +27,7 @@ dependencies = {
   "lbase64 ~> 20120820-1",
   "lua-resty-iputils ~> 0.2.0-1",
   "mediator_lua ~> 1.1.2-0",
+  "luaposix ~> 33.3.1-1",
 
   "luasocket ~> 2.0.2-6",
   "lrexlib-pcre ~> 2.7.2-1",

--- a/kong.yml
+++ b/kong.yml
@@ -7,6 +7,10 @@
 ## Beware of YAML formatting for nested properties.
 
 ######
+## Instructs Kong to run in background or in foreground
+# daemon: true
+
+######
 ## Additional plugins that this node needs to load.
 ## If you want to load custom plugins that are not supported by Kong, uncomment and update
 ## this property with the names of the plugins to load.

--- a/kong/cli/cmds/start.lua
+++ b/kong/cli/cmds/start.lua
@@ -27,6 +27,17 @@ elseif status == services.STATUSES.ALL_RUNNING then
   os.exit(1)
 end
 
+if not configuration.daemon then
+  local terminate_daemon = function()
+    services.stop_all(configuration, configuration_path)
+    logger:success("Stopped")
+    os.exit(0)
+  end
+  local signal = require "posix.signal"
+  signal.signal(signal.SIGTERM, function() terminate_daemon() end)
+  signal.signal(signal.SIGINT, function() terminate_daemon() end)
+end
+
 local ok, err = services.start_all(configuration, configuration_path)
 if not ok then
   services.stop_all(configuration, configuration_path)
@@ -35,4 +46,11 @@ if not ok then
   os.exit(1)
 end
 
-logger:success("Started")
+logger:success("Started"..((configuration.daemon) and "" or " in foreground mode"))
+
+if not configuration.daemon then
+  while(true) do
+    io.read()
+  end
+end
+

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -1,4 +1,5 @@
 return {
+  ["daemon"] = {type = "boolean", default = true},
   ["custom_plugins"] = {type = "array", default = {}},
   ["nginx_working_dir"] = {type = "string", default = "/usr/local/kong"},
   ["proxy_listen"] = {type = "string", default = "0.0.0.0:8000"},


### PR DESCRIPTION
This PR allows Kong to run in foreground mode again.

Introduces a `daemon` property in the `kong.yml` configuration, that can be used to specify if Kong should start in background (`daemon=true`) or foreground (`daemon=false`) mode.

**Note**: The user will never have to change the `daemon` property of Nginx, which is supposed to be set to `daemon on;` **always**.