### PR TITLE
Adding node on start, and not on hook

### DIFF
--- a/kong/api/routes/cluster.lua
+++ b/kong/api/routes/cluster.lua
@@ -1,5 +1,4 @@
 local responses = require "kong.tools.responses"
-local cjson = require "cjson"
 local Serf = require "kong.cli.services.serf"
 
 local pairs = pairs
@@ -9,12 +8,11 @@ local string_upper = string.upper
 return {
   ["/cluster/"] = {
     GET = function(self, dao_factory, helpers)
-      local res, err = Serf(configuration):invoke_signal("members", {["-format"] = "json"})
+      local members, err = Serf(configuration):_members()
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
       end
 
-      local members = cjson.decode(res).members
       local result = {data = {}}
       for _, v in pairs(members) do
         if not self.params.status or (self.params.status and v.status == self.params.status) then

--- a/kong/cli/utils/services.lua
+++ b/kong/cli/utils/services.lua
@@ -13,8 +13,8 @@ _M.STATUSES = {
 -- Services ordered by priority
 local services = {
   require "kong.cli.services.dnsmasq",
-  require "kong.cli.services.nginx",
-  require "kong.cli.services.serf"
+  require "kong.cli.services.serf",
+  require "kong.cli.services.nginx"
 }
 
 local function prepare_database(configuration)
@@ -116,8 +116,9 @@ function _M.check_status(configuration, configuration_path)
 end
 
 function _M.stop_all(configuration, configuration_path)
-  for _, service in ipairs(services) do
-    service(configuration, configuration_path):stop()
+  -- Backwards
+  for i=#services, 1, -1 do
+    services[i](configuration, configuration_path):stop()
   end
 end
 

--- a/kong/core/cluster.lua
+++ b/kong/core/cluster.lua
@@ -1,7 +1,6 @@
 local cluster_utils = require "kong.tools.cluster"
 local Serf = require "kong.cli.services.serf"
 local cache = require "kong.tools.database_cache"
-local cjson = require "cjson"
 
 local resty_lock
 local status, res = pcall(require, "resty.lock")
@@ -40,12 +39,11 @@ local function async_autojoin(premature)
       ngx.log(ngx.ERR, tostring(err))
     elseif count > 1 then
       local serf = Serf(configuration)
-      local res, err = serf:invoke_signal("members", {["-format"] = "json"})
+      local members, err = serf:_members()
       if err then
         ngx.log(ngx.ERR, tostring(err))
       end
 
-      local members = cjson.decode(res).members
       if #members < 2 then
         -- Trigger auto-join
         local _, err = serf:_autojoin(cluster_utils.get_node_name(configuration))


### PR DESCRIPTION
This change adds the node on start, and not on hook. It provides a better way of dealing with the `nodes` table, and also allows `nginx` to be the last service to start up.

Also tries to address issue #1004.