### PR TITLE
Remove sensitive information before sending to syslog

### DIFF
--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -35,7 +35,7 @@ end
 
 local function log(premature, conf, message)
   if premature then return end
-  
+
   if message.response.status >= 500 then
     send_to_syslog(conf.log_level, conf.server_errors_severity, message)
   elseif message.response.status >= 400 then
@@ -53,6 +53,10 @@ function SysLogHandler:log(conf)
   SysLogHandler.super.log(self)
 
   local message = basic_serializer.serialize(ngx)
+  if conf.strip_auth_header and message['request'] ~= nil and message['request']['headers'] ~= nil  then
+    message['request']['headers']['authorization'] = nil
+  end
+
   local ok, err = ngx_timer_at(0, log, conf, message)
   if not ok then
     ngx_log(ngx.ERR, "failed to create timer: ", err)

--- a/kong/plugins/syslog/schema.lua
+++ b/kong/plugins/syslog/schema.lua
@@ -6,5 +6,6 @@ return {
     successful_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
     client_errors_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
     server_errors_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
+    strip_auth_header = { type = "boolean", default = false }
   }
 }


### PR DESCRIPTION
Add a configurable option for the syslog plugin that will remove the authorization header from the request.
