### PR TITLE
Loading runscope by default

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -33,7 +33,7 @@ return {
     "http-log", "key-auth", "hmac-auth", "basic-auth", "ip-restriction",
     "mashape-analytics", "request-transformer", "response-transformer",
     "request-size-limiting", "rate-limiting", "response-ratelimiting", "syslog",
-    "loggly", "datadog"
+    "loggly", "datadog", "runscope"
   },
   -- Non standard headers, specific to Kong
   HEADERS = {


### PR DESCRIPTION
Enables the Runscope plugin in the default installation.