### PR TITLE
Drop long deprecated Admin API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased][unreleased]
 
+### Breaking changes
+
+- Remove support for the long deprecated `/consumers/:consumer/keyauth/` and `/consumers/:consumer/basicauth/` routes (deprecated in `0.5.0`). The new routes (available since `0.5.0` too) use the real name of the plugin: `/consumers/:consumer/key-auth` and `/consumers/:consumer/basic-auth`.
+
 ### Added
 
 - Support for PostgreSQL as Kong's primary datastore. [#331](https://github.com/Mashape/kong/issues/331) [#1054](https://github.com/Mashape/kong/issues/1054)

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -1,59 +1,52 @@
 local crud = require "kong.api.crud_helpers"
 
-local global_route = {
-  before = function(self, dao_factory, helpers)
-    crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
-    self.params.consumer_id = self.consumer.id
-  end,
-
-  GET = function(self, dao_factory)
-    crud.paginated_set(self, dao_factory.basicauth_credentials)
-  end,
-
-  PUT = function(self, dao_factory)
-    crud.put(self.params, dao_factory.basicauth_credentials)
-  end,
-
-  POST = function(self, dao_factory)
-    crud.post(self.params, dao_factory.basicauth_credentials)
-  end
-}
-
-local single_route = {
-  before = function(self, dao_factory, helpers)
-    crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
-    self.params.consumer_id = self.consumer.id
-
-    local credentials, err = dao_factory.basicauth_credentials:find_all {
-      consumer_id = self.params.consumer_id,
-      id = self.params.id
-    }
-    if err then
-      return helpers.yield_error(err)
-    elseif next(credentials) == nil then
-      return helpers.responses.send_HTTP_NOT_FOUND()
-    end
-
-    self.basicauth_credential = credentials[1]
-  end,
-
-  GET = function(self, dao_factory, helpers)
-    return helpers.responses.send_HTTP_OK(self.basicauth_credential)
-  end,
-
-  PATCH = function(self, dao_factory)
-    crud.patch(self.params, dao_factory.basicauth_credentials, self.basicauth_credential)
-  end,
-
-  DELETE = function(self, dao_factory)
-    crud.delete(self.basicauth_credential, dao_factory.basicauth_credentials)
-  end
-}
-
 return {
-  ["/consumers/:username_or_id/basic-auth/"] = global_route,
-  ["/consumers/:username_or_id/basic-auth/:id"] = single_route,
-  -- Deprecated in 0.5.0, maintained for backwards compatibility.
-  ["/consumers/:username_or_id/basicauth/"] = global_route,
-  ["/consumers/:username_or_id/basicauth/:id"] = single_route
+  ["/consumers/:username_or_id/basic-auth/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.basicauth_credentials)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.basicauth_credentials)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.basicauth_credentials)
+    end
+  },
+  ["/consumers/:username_or_id/basic-auth/:id"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+
+      local credentials, err = dao_factory.basicauth_credentials:find_all {
+        consumer_id = self.params.consumer_id,
+        id = self.params.id
+      }
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.basicauth_credential = credentials[1]
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.basicauth_credential)
+    end,
+
+    PATCH = function(self, dao_factory)
+      crud.patch(self.params, dao_factory.basicauth_credentials, self.basicauth_credential)
+    end,
+
+    DELETE = function(self, dao_factory)
+      crud.delete(self.basicauth_credential, dao_factory.basicauth_credentials)
+    end
+  }
 }

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -1,59 +1,52 @@
 local crud = require "kong.api.crud_helpers"
 
-local global_route = {
-  before = function(self, dao_factory, helpers)
-    crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
-    self.params.consumer_id = self.consumer.id
-  end,
-
-  GET = function(self, dao_factory)
-    crud.paginated_set(self, dao_factory.keyauth_credentials)
-  end,
-
-  PUT = function(self, dao_factory)
-    crud.put(self.params, dao_factory.keyauth_credentials)
-  end,
-
-  POST = function(self, dao_factory)
-    crud.post(self.params, dao_factory.keyauth_credentials)
-  end
-}
-
-local single_route = {
-  before = function(self, dao_factory, helpers)
-    crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
-    self.params.consumer_id = self.consumer.id
-
-    local credentials, err = dao_factory.keyauth_credentials:find_all {
-      consumer_id = self.params.consumer_id,
-      id = self.params.id
-    }
-    if err then
-      return helpers.yield_error(err)
-    elseif next(credentials) == nil then
-      return helpers.responses.send_HTTP_NOT_FOUND()
-    end
-
-    self.keyauth_credential = credentials[1]
-  end,
-
-  GET = function(self, dao_factory, helpers)
-    return helpers.responses.send_HTTP_OK(self.keyauth_credential)
-  end,
-
-  PATCH = function(self, dao_factory)
-    crud.patch(self.params, dao_factory.keyauth_credentials, self.keyauth_credential)
-  end,
-
-  DELETE = function(self, dao_factory)
-    crud.delete(self.keyauth_credential, dao_factory.keyauth_credentials)
-  end
-}
-
 return {
-  ["/consumers/:username_or_id/key-auth/"] = global_route,
-  ["/consumers/:username_or_id/key-auth/:id"] = single_route,
-  -- Deprecated in 0.5.0, maintained for backwards compatibility.
-  ["/consumers/:username_or_id/keyauth/"] = global_route,
-  ["/consumers/:username_or_id/keyauth/:id"] = single_route
+  ["/consumers/:username_or_id/key-auth/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.keyauth_credentials)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.keyauth_credentials)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.keyauth_credentials)
+    end
+  },
+  ["/consumers/:username_or_id/key-auth/:id"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+
+      local credentials, err = dao_factory.keyauth_credentials:find_all {
+        consumer_id = self.params.consumer_id,
+        id = self.params.id
+      }
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.keyauth_credential = credentials[1]
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.keyauth_credential)
+    end,
+
+    PATCH = function(self, dao_factory)
+      crud.patch(self.params, dao_factory.keyauth_credentials, self.keyauth_credential)
+    end,
+
+    DELETE = function(self, dao_factory)
+      crud.delete(self.keyauth_credential, dao_factory.keyauth_credentials)
+    end
+  }
 }


### PR DESCRIPTION
- `/consumers/:consumer/keyauth` -> `/consumers/:consumer/key-auth`
- `/consumers/:consumer/basicauth` -> `/consumers/:consumer/basic-auth`