### PR TITLE
fix(rockspec) rename runscope.buffer to runscope.log

### DIFF
--- a/kong-0.7.0-0.rockspec
+++ b/kong-0.7.0-0.rockspec
@@ -163,7 +163,7 @@ build = {
 
     ["kong.plugins.runscope.handler"] = "kong/plugins/runscope/handler.lua",
     ["kong.plugins.runscope.schema"] = "kong/plugins/runscope/schema.lua",
-    ["kong.plugins.runscope.buffer"] = "kong/plugins/runscope/log.lua",
+    ["kong.plugins.runscope.log"] = "kong/plugins/runscope/log.lua",
 
     ["kong.plugins.mashape-analytics.schema.migrations"] = "kong/plugins/mashape-analytics/schema/migrations.lua",
     ["kong.plugins.mashape-analytics.handler"] = "kong/plugins/mashape-analytics/handler.lua",

--- a/spec/unit/rockspec_spec.lua
+++ b/spec/unit/rockspec_spec.lua
@@ -2,21 +2,6 @@ local stringy = require "stringy"
 local IO = require "kong.tools.io"
 local fs = require "luarocks.fs"
 
--- Function that checks if the path has been imported as a module
-local is_in_rockspec = function(path)
-  if stringy.startswith(path, "./") then
-    path = string.sub(path, 3)
-  end
-  local found = false
-  for _, v in pairs(build.modules) do
-    if v == path then
-      found = true
-      break
-    end
-  end
-  return found
-end
-
 describe("Rockspec", function()
   local rockspec_path, files
 
@@ -28,7 +13,7 @@ describe("Rockspec", function()
       end
     end
     if not rockspec_path then
-      error("Can't find the rockspec file")
+      error("can't find rockspec")
     end
 
     loadfile(rockspec_path)()
@@ -46,9 +31,29 @@ describe("Rockspec", function()
       it("should include "..v, function()
         local path = stringy.strip(v)
         if path ~= "" and stringy.startswith(path, "./kong") then
-          assert.True(is_in_rockspec(path))
+          path = string.sub(path, 3)
+
+          local found = false
+          for mod_name, mod_path in pairs(build.modules) do
+            if mod_path == path then
+              found = true
+              break
+            end
+          end
+
+          assert.True(found)
         end
       end)
+    end
+
+    for mod_name, mod_path in pairs(build.modules) do
+      if mod_name ~= "kong" and mod_name ~= "resty_http" and
+         mod_name ~= "classic" and mod_name ~= "lapp" then
+        it(mod_path.." has correct name", function()
+          mod_path = mod_path:gsub("%.lua", ""):gsub("/", '.')
+          assert.equal(mod_name, mod_path)
+        end)
+      end
     end
   end)
 end)


### PR DESCRIPTION
+ test to ensure most of our Lua modules bear the same name when
installed via Luarocks as when required from './kong'

fix #1079