### PR TITLE
Auto-create Postgres database and fix make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ dev: install
       echo $$rock already installed, skipping ; \
     fi \
 	done;
-	bin/kong config -c kong.yml -e TEST
-	bin/kong config -c kong.yml -e DEVELOPMENT
+	bin/kong config -c kong.yml -e TEST -s TEST
+	bin/kong config -c kong.yml -e DEVELOPMENT -s DEVELOPMENT
 	bin/kong migrations -c $(DEVELOPMENT_CONF) up
 
 clean:

--- a/kong.yml
+++ b/kong.yml
@@ -94,10 +94,17 @@
 ######
 ## PostgreSQL configuration
 # postgres:
-#    host: "127.0.0.1"
-#    port: 5432
-#    user: kong
-#    database: kong
+  # host: "127.0.0.1"
+  # port: 5432
+
+  ######
+  ## Name of the database used by Kong. Will be created if it does not exist.
+  # database: kong
+
+  #####
+  ## User authentication settings
+  # user: ""
+  # password: ""
 
 ######
 ## Cassandra configuration (keyspace, authentication, client-to-node encryption)

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -1,12 +1,32 @@
 return {
   {
     name = "2015-01-12-175310_skeleton",
-    up = [[
-      CREATE TABLE IF NOT EXISTS schema_migrations(
-        id text PRIMARY KEY,
-        migrations varchar(100)[]
-      );
-    ]],
+    up = function(db, properties)
+      local database_name = properties.database
+      local user = properties.user
+
+      -- Format final database creation query
+      local database_str = string.format([[
+        DO $$
+        BEGIN
+          CREATE EXTENSION IF NOT EXISTS dblink;
+          IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = '%s') THEN
+             PERFORM dblink_exec('dbname=' || current_database(), 'CREATE DATABASE %s%s');
+          END IF;
+        END$$;
+      ]], database_name, database_name, user and " OWNER "..user or "")
+      local err = db:queries(database_str, true)
+      if err then
+        return err
+      end
+
+      return db:queries [[
+        CREATE TABLE IF NOT EXISTS schema_migrations(
+          id text PRIMARY KEY,
+          migrations varchar(100)[]
+        );
+      ]]
+    end,
     down = [[
       DROP TABLE schema_migrations;
     ]]

--- a/spec/integration/dao/02-migrations_spec.lua
+++ b/spec/integration/dao/02-migrations_spec.lua
@@ -31,14 +31,8 @@ helpers.for_each_dao(function(db_type, default_opts, TYPES)
         local xfactory = Factory(db_type, invalid_opts)
 
         local cur_migrations, err = xfactory:current_migrations()
-        if db_type == TYPES.CASSANDRA then
-          assert.same({}, cur_migrations)
-        elseif db_type == TYPES.POSTGRES then
-          assert.truthy(err)
-          assert.falsy(cur_migrations)
-          assert.True(err.db)
-          assert.equal('FATAL: database "_inexistent_" does not exist', tostring(err))
-        end
+        assert.same({}, cur_migrations)
+        assert.falsy(err)
       end)
     end)
 


### PR DESCRIPTION
This PR does two things:
* Auto-creates the PostgreSQL database if it's not existing, with an implementation similar to how the Cassandra DAO does it. The behavior is now 1:1 to how Cassandra works.
* Fixes `make dev` which caused an issue where the `kong_TEST.yml` file would't be created.

It also adds more comments in `kong.yml` in the `postgres` section.