### PR TITLE
Reverting back Postgres auto-creation of database

### DIFF
--- a/kong/core/reports.lua
+++ b/kong/core/reports.lua
@@ -1,6 +1,7 @@
 local syslog = require "kong.tools.syslog"
 local cache = require "kong.tools.database_cache"
 local utils = require "kong.tools.utils"
+local singletons = require "kong.singletons"
 local unique_str = utils.random_string()
 local enabled = false
 
@@ -29,7 +30,7 @@ local function send_ping(premature)
   if elapsed and elapsed == 0 then
     local reqs = cache.get(cache.requests_key())
     if not reqs then reqs = 0 end
-    syslog.log({signal = "ping", requests = reqs, unique_id = unique_str})
+    syslog.log({signal = "ping", requests = reqs, unique_id = unique_str, database = singletons.configuration.database})
     cache.incr(cache.requests_key(), -reqs) -- Reset counter
   end
   create_timer(INTERVAL, send_ping)

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -2,24 +2,6 @@ return {
   {
     name = "2015-01-12-175310_skeleton",
     up = function(db, properties)
-      local database_name = properties.database
-      local user = properties.user
-
-      -- Format final database creation query
-      local database_str = string.format([[
-        DO $$
-        BEGIN
-          CREATE EXTENSION IF NOT EXISTS dblink;
-          IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = '%s') THEN
-             PERFORM dblink_exec('dbname=' || current_database(), 'CREATE DATABASE %s%s');
-          END IF;
-        END$$;
-      ]], database_name, database_name, user and " OWNER "..user or "")
-      local err = db:queries(database_str, true)
-      if err then
-        return err
-      end
-
       return db:queries [[
         CREATE TABLE IF NOT EXISTS schema_migrations(
           id text PRIMARY KEY,

--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -121,14 +121,10 @@ end
 
 -- Querying
 
-function PostgresDB:query(query, no_database)
+function PostgresDB:query(query)
   PostgresDB.super.query(self, query)
 
   local conn_opts = self:_get_conn_options()
-  if no_database then
-    conn_opts.database = "postgres"
-    conn_opts.user = "postgres"
-  end
   local pg = pgmoon.new(conn_opts)
   local ok, err = pg:connect()
   if not ok then
@@ -432,9 +428,9 @@ end
 
 -- Migrations
 
-function PostgresDB:queries(queries, no_database)
+function PostgresDB:queries(queries)
   if utils.strip(queries) ~= "" then
-    local err = select(2, self:query(queries, no_database))
+    local err = select(2, self:query(queries))
     if err then
       return err
     end
@@ -450,16 +446,6 @@ function PostgresDB:truncate_table(table_name)
 end
 
 function PostgresDB:current_migrations()
-  -- Check if database exists
-  local rows, err = self:query(string.format([[
-    SELECT 1 FROM pg_database WHERE datname = '%s'
-  ]], self.options.database), true)
-  if err then
-    return nil, err
-  elseif #rows == 0 then
-    return {}
-  end
-
   -- Check if schema_migrations table exists
   local rows, err = self:query "SELECT to_regclass('public.schema_migrations')"
   if err then

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -42,7 +42,7 @@ return {
       ["port"] = {type = "number", default = 5432},
       ["user"] = {type = "string", default = "kong"},
       ["database"] = {type = "string", default = "kong"},
-      ["password"] = {type = "string", default = "kong"}
+      ["password"] = {type = "string", nullable = true}
     }
   },
   ["cassandra"] = {

--- a/spec/integration/dao/02-migrations_spec.lua
+++ b/spec/integration/dao/02-migrations_spec.lua
@@ -31,8 +31,14 @@ helpers.for_each_dao(function(db_type, default_opts, TYPES)
         local xfactory = Factory(db_type, invalid_opts)
 
         local cur_migrations, err = xfactory:current_migrations()
-        assert.same({}, cur_migrations)
-        assert.falsy(err)
+        if db_type == TYPES.CASSANDRA then
+          assert.same({}, cur_migrations)
+        elseif db_type == TYPES.POSTGRES then
+          assert.truthy(err)
+          assert.falsy(cur_migrations)
+          assert.True(err.db)
+          assert.equal('FATAL: database "_inexistent_" does not exist', tostring(err))
+        end
       end)
     end)
 


### PR DESCRIPTION
Reverts #1105, because effectively is becoming more complicated to implement this right rather than move the complexity to the final user.

One thing that this PR changes is having a `nullable` password instead of a default `kong` password.

Also closes #1136 (does not apply anymore). We will collect feedback and usage data from our users and see how big of an issue this is, and eventually I will go back at it if it's required.