### PR TITLE
fix(cassandra) add a 'port' option for clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release includes support for PostgreSQL as Kong's primary datastore!
 
 ### Fixed
 
+- Introduce a new `port` option when connecting to your Cassandra cluster instead of using the CQL default (9042). [#1139](https://github.com/Mashape/kong/issues/1139)
 - Plugins
   - Request/Response Transformer: add missing migrations for upgrades from ` <= 0.5.x`. [#1064](https://github.com/Mashape/kong/issues/1064)
   - OAuth2

--- a/kong-0.8.0rc2-0.rockspec
+++ b/kong-0.8.0rc2-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "yaml ~> 1.1.2-1",
   "lapis ~> 1.3.1-1",
   "stringy ~> 0.4-1",
-  "lua-cassandra ~> 0.5.0",
+  "lua-cassandra ~> 0.5.1",
   "pgmoon ~> 1.4.0",
   "multipart ~> 0.3-2",
   "lua-path ~> 0.2.3-1",
@@ -264,7 +264,7 @@ build = {
     ["kong.plugins.datadog.handler"] = "kong/plugins/datadog/handler.lua",
     ["kong.plugins.datadog.schema"] = "kong/plugins/datadog/schema.lua",
     ["kong.plugins.datadog.statsd_logger"] = "kong/plugins/datadog/statsd_logger.lua",
-    
+
     ["kong.plugins.statsd.handler"] = "kong/plugins/statsd/handler.lua",
     ["kong.plugins.statsd.schema"] = "kong/plugins/statsd/schema.lua",
     ["kong.plugins.statsd.statsd_logger"] = "kong/plugins/statsd/statsd_logger.lua"

--- a/kong.yml
+++ b/kong.yml
@@ -88,8 +88,8 @@
   # encrypt: "foo"
 
   ######
-  ## The TTL (time to live), in seconds, of a node in the cluster when it stops sending healthcheck pings, maybe 
-  ## because of a failure. If the node is not able to send a new healthcheck before the expiration, then new nodes 
+  ## The TTL (time to live), in seconds, of a node in the cluster when it stops sending healthcheck pings, maybe
+  ## because of a failure. If the node is not able to send a new healthcheck before the expiration, then new nodes
   ## in the cluster will stop attempting to connect to it on startup.
   # ttl_on_failure: 3600
 
@@ -119,6 +119,10 @@
   ## Contact points to your Cassandra cluster.
   # contact_points:
   #   - "127.0.0.1:9042"
+
+  ## Port on which your cluster's peers (other than your contact_points)
+  ## are listening on.
+  # port: 9042
 
   ######
   ## Name of the keyspace used by Kong. Will be created if it does not exist.

--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -26,6 +26,9 @@ function CassandraDB:new(options)
     prepared_shm = "cassandra_prepared",
     contact_points = options.contact_points,
     keyspace = options.keyspace,
+    protocol_options = {
+      default_port = options.port
+    },
     query_options = {
       prepare = true
     },

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -49,6 +49,7 @@ return {
     type = "table",
     content = {
       ["contact_points"] = {type = "array", default = {"127.0.0.1:9042"}},
+      ["port"] = {type = "number", default = 9042},
       ["keyspace"] = {type = "string", default = "kong"},
       ["timeout"] = {type = "number", default = 5000},
       ["replication_strategy"] = {type = "string", default = "SimpleStrategy", enum = {"SimpleStrategy", "NetworkTopologyStrategy"}},
@@ -56,7 +57,7 @@ return {
       ["data_centers"] = {type = "table", default = {}},
       ["username"] = {type = "string", nullable = true},
       ["password"] = {type = "string", nullable = true},
-      ["consistency"] = {type = "string", default = "ONE", enum = {"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL", "LOCAL_QUORUM", 
+      ["consistency"] = {type = "string", default = "ONE", enum = {"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL", "LOCAL_QUORUM",
                                                                    "EACH_QUORUM", "SERIAL", "LOCAL_SERIAL", "LOCAL_ONE"}},
       ["ssl"] = {
         type = "table",


### PR DESCRIPTION
Clusters with nodes not running on the default `9042` port couldn't be
properly reached by Kong. This bumps the driver (including the fix), and
adds a `port` options to the configuration. Thanks @allisthere2love for
the investigation.

This issue was never encountered before and my guess is because such
clusters added their contact_points including the port (`x.x.x.x:9043`),
and the driver could connect to it, but not to the other nodes, since it
was trying `9042` on those. So it simply considered the other nodes as
DOWN, and thus still worked from an outsider's POV (if one doesn't check the logs and those lags
are not displaying warnings, it seems like nothing is going wrong).
However @allisthere2love had nodes from another C* cluster listening on
`9042`, leading to inconsistencies and thus, actual errors that allowed
us to track it down.

As per other datastax drivers, all nodes of a cluster must listen on the
same port.

Fix Mashape/kong#1139
See thibaultCha/lua-cassandra#47