### PR TITLE
Closing #1150

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -26,7 +26,9 @@ return {
     CREDENTIAL_USERNAME = "X-Credential-Username",
     RATELIMIT_LIMIT = "X-RateLimit-Limit",
     RATELIMIT_REMAINING = "X-RateLimit-Remaining",
-    CONSUMER_GROUPS = "X-Consumer-Groups"
+    CONSUMER_GROUPS = "X-Consumer-Groups",
+    FORWARDED_HOST = "X-Forwarded-Host",
+    FORWARDED_PREFIX = "X-Forwarded-Prefix"
   },
   RATELIMIT = {
     PERIODS = {

--- a/kong/core/resolver.lua
+++ b/kong/core/resolver.lua
@@ -207,6 +207,7 @@ local function find_api(uri, headers)
   api, matched_host, hosts_list = _M.find_api_by_request_host(headers, apis_dics)
   -- If it was found by Host, return
   if api then
+    ngx.req.set_header(constants.HEADERS.FORWARDED_HOST, matched_host)
     return nil, api, matched_host, hosts_list
   end
 
@@ -240,6 +241,7 @@ function _M.execute(request_uri, request_headers)
   -- If API was retrieved by request_path and the request_path needs to be stripped
   if strip_request_path_pattern and api.strip_request_path then
     uri = _M.strip_request_path(uri, strip_request_path_pattern, url_has_path(upstream_url))
+    ngx.req.set_header(constants.HEADERS.FORWARDED_PREFIX, api.request_path)
   end
 
   upstream_url = upstream_url..uri


### PR DESCRIPTION
Adds `X-Forwarded-Host` and `X-Forwarded-Prefix` to the upstream request headers (depending if the API is being resolved using the `Host` header or the path).

Closes #1150.