### PR TITLE
header.typ is not required

### DIFF
--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -99,7 +99,7 @@ local function decode_token(token)
     return nil, "Invalid JSON"
   end
 
-  if not header.typ or header.typ ~= "JWT" then
+  if header.typ and header.typ ~= "JWT" then
     return nil, "Invalid typ"
   end
 


### PR DESCRIPTION
Per issue:  https://github.com/Mashape/kong/issues/1191
Per RFC 7519:  https://tools.ietf.org/html/rfc7519#section-5
Use of this Header Parameter is OPTIONAL.

Therefore, header.typ should only be validated if provided.  In addition, the spec does not require the parameter to be all upper case "JWT", but that change was not made.