### PR TITLE
Implementing missing check on ttl_on_failure

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -90,7 +90,7 @@
   ######
   ## The TTL (time to live), in seconds, of a node in the cluster when it stops sending healthcheck pings, maybe
   ## because of a failure. If the node is not able to send a new healthcheck before the expiration, then new nodes
-  ## in the cluster will stop attempting to connect to it on startup.
+  ## in the cluster will stop attempting to connect to it on startup. Should be at least 60.
   # ttl_on_failure: 3600
 
 ######

--- a/kong/tools/config_defaults.lua
+++ b/kong/tools/config_defaults.lua
@@ -31,7 +31,7 @@ return {
       ["advertise"] = {type = "string", nullable = true},
       ["encrypt"] = {type = "string", nullable = true},
       ["profile"] = {type = "string", default = "wan", enum = {"wan", "lan", "local"}},
-      ["ttl_on_failure"] = {type = "number", default = 3600}
+      ["ttl_on_failure"] = {type = "number", default = 3600, min = 60}
     }
   },
   ["database"] = {type = "string", default = "cassandra", enum = {"cassandra", "postgres"}},


### PR DESCRIPTION
`ttl_on_failure` should be at least `60`.