### PR TITLE
Test service versions properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This release includes some fixes and minor updates:
 - Properly enforcing required fields in PUT requests. [#1177](https://github.com/Mashape/kong/pull/1177)
 - Fixed a bug that prevented to retrieve the hostname of the local machine on certain systems. [#1178](https://github.com/Mashape/kong/pull/1178)
 
-## [0.8.0] - 2016/04/13
+## [0.8.0] - 2016/04/18
 
 This release includes support for PostgreSQL as Kong's primary datastore!
 

--- a/kong-0.8.1-0.rockspec
+++ b/kong-0.8.1-0.rockspec
@@ -29,6 +29,7 @@ dependencies = {
   "lbase64 ~> 20120820-1",
   "lua-resty-iputils ~> 0.2.0-1",
   "mediator_lua ~> 1.1.2-0",
+  "version == 0.2",
 
   "luasocket ~> 2.0.2-6",
   "lrexlib-pcre ~> 2.7.2-1",

--- a/kong/cli/services/nginx.lua
+++ b/kong/cli/services/nginx.lua
@@ -5,6 +5,7 @@ local ssl = require "kong.cli.utils.ssl"
 local constants = require "kong.constants"
 local syslog = require "kong.tools.syslog"
 local socket = require "socket"
+local version = require "version"
 
 local Nginx = BaseService:extend()
 
@@ -13,6 +14,11 @@ local START = "start"
 local RELOAD = "reload"
 local STOP = "stop"
 local QUIT = "quit"
+
+-- compatible Nginx/OpenResty version
+local version_command = " -v"                           -- commandline param to get version
+local version_pattern = "^nginx.-openresty.-([%d%.]+)"  -- pattern to grab version from output
+local compatible = version.set("1.9.3.2","1.9.7.4")     -- compatible from-to versions
 
 local function prepare_folders(configuration)
   -- Create nginx folder if needed
@@ -191,12 +197,12 @@ function Nginx:_get_cmd()
     "/usr/local/bin/",
     "/usr/sbin/"
   }, function(path)
-    local res, code = IO.os_execute(path.." -v")
+    local res, code = IO.os_execute(path..version_command)
     if code == 0 then
-      local version_match = res:match("^nginx version: ngx_openresty/") or
-                              res:match("^nginx version: openresty/")
-      if not version_match then
-        logger:error("Incompatible nginx found. Kong requires OpenResty.")
+      local version_match = res:match(version_pattern)
+      if (not version_match) or (not compatible:matches(version_match)) then
+        logger:error("Incompatible nginx found. Kong requires OpenResty, version "..tostring(compatible) ..
+          (version_match and ", got "..version_match or ""))
         os.exit(1)
       end
       return version_match

--- a/kong/cli/services/serf.lua
+++ b/kong/cli/services/serf.lua
@@ -5,12 +5,18 @@ local stringy = require "stringy"
 local logger = require "kong.cli.utils.logger"
 local cjson = require "cjson"
 local IO = require "kong.tools.io"
+local version = require "version"
 
 local Serf = BaseService:extend()
 
 local SERVICE_NAME = "serf"
 local START_TIMEOUT = 10
 local EVENT_NAME = "kong"
+
+-- compatible Serf version
+local version_command = " version"                -- commandline param to get version
+local version_pattern = "^Serf v([%d%.]+)"        -- pattern to grab version from output
+local compatible = version.set("0.7.0", "0.7.0")  -- compatible from-to versions
 
 function Serf:new(configuration)
   local nginx_working_dir = configuration.nginx_working_dir
@@ -26,11 +32,12 @@ end
 
 function Serf:_get_cmd()
   local cmd, err = Serf.super._get_cmd(self, {}, function(path)
-    local res, code = IO.os_execute(path.." version")
+    local res, code = IO.os_execute(path..version_command)
     if code == 0 then
-      local version_match = res:match("^Serf v0.7.0")
-      if not version_match then
-        logger:error("Incompatible Serf version. Kong requires v0.7.0.")
+      local version_match = res:match(version_pattern)
+      if (not version_match) or (not compatible:matches(version_match)) then
+        logger:error("Incompatible Serf version. Kong requires version "..tostring(compatible)..
+          (version_match and ", got "..tostring(version_match) or ""))
         os.exit(1)
       end
       return version_match


### PR DESCRIPTION
closes #946 and #947 

replaces #947 as fix for #946. Explicitly tests versions for Dnsmasq, Serf and OpenResty, exits with a clear error message if not ok.


NOTE: all tests pass locally