### PR TITLE
hotfix(jwt) default algorithm to 'HS256'

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -87,12 +87,14 @@ function JwtHandler:access(conf)
     return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..conf.key_claim_name.."'")
   end
 
+  local algorithm = jwt_secret.algorithm or "HS256"
+
   -- Verify "alg"
-  if jwt.header.alg ~= jwt_secret.algorithm then
+  if jwt.header.alg ~= algorithm then
     return responses.send_HTTP_FORBIDDEN("Invalid algorithm")
   end
 
-  local jwt_secret_value = jwt_secret.algorithm == "HS256" and jwt_secret.secret or jwt_secret.rsa_public_key
+  local jwt_secret_value = algorithm == "HS256" and jwt_secret.secret or jwt_secret.rsa_public_key
   if conf.secret_is_base64 then
     jwt_secret_value = jwt:b64_decode(jwt_secret_value)
   end


### PR DESCRIPTION
When migrating from an older version of Kong, the 'algorithm' field is
left empty. Better to include it in the code rather than in the
migration to resolve the issue for users who already migrated.

Fix #1233