### PR TITLE
Fixed a failed error parsing on Postgres.

### DIFF
--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -95,15 +95,17 @@ local function parse_error(err_str)
   local err
   if string.find(err_str, "Key .* already exists") then
     local col, value = string.match(err_str, "%((.+)%)=%((.+)%)")
-    err = Errors.unique {[col] = value}
+    if col then
+      err = Errors.unique {[col] = value}
+    end
   elseif string.find(err_str, "violates foreign key constraint") then
     local col, value = string.match(err_str, "%((.+)%)=%((.+)%)")
-    err = Errors.foreign {[col] = value}
-  else
-    err = Errors.db(err_str)
+    if col then
+      err = Errors.foreign {[col] = value}
+    end
   end
-
-  return err
+  
+  return err or Errors.db(err_str)
 end
 
 local function get_select_fields(schema)


### PR DESCRIPTION
Prevent it from exploding into a Lua error, obfuscating the real error. Now returns the DB error.
See issue #1239