### PR TITLE
Closing #1255

### DIFF
--- a/kong/core/cluster.lua
+++ b/kong/core/cluster.lua
@@ -43,7 +43,7 @@ local function async_autojoin(premature)
         ngx.log(ngx.ERR, tostring(err))
       elseif #members < 2 then
         -- Trigger auto-join
-        local _, err = singletons.serf:_autojoin(cluster_utils.get_node_name(singletons.configuration))
+        local _, err = singletons.serf:_autojoin(cluster_utils.get_node_identifier(singletons.configuration))
         if err then
           ngx.log(ngx.ERR, tostring(err))
         end
@@ -73,7 +73,7 @@ local function send_keepalive(premature)
   local elapsed = lock:lock("keepalive")
   if elapsed and elapsed == 0 then
     -- Send keepalive
-    local node_name = cluster_utils.get_node_name(singletons.configuration)
+    local node_name = cluster_utils.get_node_identifier(singletons.configuration)
     local nodes, err = singletons.dao.nodes:find_all {name = node_name}
     if err then
       ngx.log(ngx.ERR, tostring(err))

--- a/kong/tools/cluster.lua
+++ b/kong/tools/cluster.lua
@@ -1,9 +1,30 @@
+local IO = require "kong.tools.io"
 local utils = require "kong.tools.utils"
+local singletons = require "kong.singletons"
 
 local _M = {}
 
-function _M.get_node_name(conf)
-  return utils.get_hostname().."_"..conf.cluster_listen
+local IDENTIFIER = "serf.id"
+
+function _M.get_node_identifier(conf)
+  local id = singletons.serf_id
+  if not id then
+    id = IO.read_file(IO.path:join(conf.nginx_working_dir, IDENTIFIER))
+    singletons.serf_id = id
+  end
+  return id
+end
+
+function _M.create_node_identifier(conf)
+  local path = IO.path:join(conf.nginx_working_dir, IDENTIFIER)
+  if not IO.file_exists(path) then
+    local id = utils.get_hostname().."_"..conf.cluster_listen.."_"..utils.random_string()
+    local _, err = IO.write_to_file(path, id)
+    if err then
+      return false, err
+    end
+  end
+  return true
 end
 
 return _M


### PR DESCRIPTION
This PR creates a `serf.id` file at startup (only the first time if the file is missing) in the Kong working directory. The value of the file is then used as a `name` in the `nodes` table when starting a Kong node.

Should close #1255 and maybe #1160.

If this is merged, it needs to be back-ported to `refactor/cli`.