### PR TITLE
fix(admin-api) ignore bodies on all methods except PUT/POST/PATCH

### DIFF
--- a/kong/api/app.lua
+++ b/kong/api/app.lua
@@ -5,17 +5,22 @@ local responses = require "kong.tools.responses"
 local singletons = require "kong.singletons"
 local app_helpers = require "lapis.application"
 local api_helpers = require "kong.api.api_helpers"
+local tablex = require "pl.tablex"
 
 local find = string.find
 
 local app = lapis.Application()
 
+local needs_body = tablex.readonly({ PUT = 1, POST = 2, PATCH = 3 })
+
 local function parse_params(fn)
   return app_helpers.json_params(function(self, ...)
-    local content_type = self.req.headers["content-type"]
-    if content_type and find(content_type:lower(), "application/json", nil, true) then
-      if not self.json then
-        return responses.send_HTTP_BAD_REQUEST("Cannot parse JSON body")
+    if needs_body[ngx.req.get_method()] then
+      local content_type = self.req.headers["content-type"]
+      if content_type and find(content_type:lower(), "application/json", nil, true) then
+        if not self.json then
+          return responses.send_HTTP_BAD_REQUEST("Cannot parse JSON body")
+        end
       end
     end
     self.params = api_helpers.normalize_nested_params(self.params)
@@ -66,8 +71,7 @@ app.handle_error = function(self, err, trace)
 end
 
 app:before_filter(function(self)
-  local method = ngx.req.get_method()
-  if method ~= "GET" and method ~= "DELETE" then
+  if needs_body[ngx.req.get_method()] then
     local content_type = self.req.headers["content-type"]
     if not content_type or stringy.strip(content_type) == "" then
       return responses.send_HTTP_UNSUPPORTED_MEDIA_TYPE()

--- a/kong/tools/http_client.lua
+++ b/kong/tools/http_client.lua
@@ -71,7 +71,7 @@ local function with_body(method)
 end
 
 local function without_body(method)
-  return function(url, querystring, headers)
+  return function(url, querystring, headers, body)
     if not headers then headers = {} end
 
     if querystring then
@@ -86,12 +86,41 @@ local function without_body(method)
   end
 end
 
+--- Allows creation of non-compliant requests for testing bad requests.
+-- If the content-length header is not provided, but a body is, then the header 
+-- will be added based on the `body`. If a different length is needed, set it explicitly.
+-- @param method the http method to use
+-- @param url the url to use
+-- @param querystring (optional) will be encoded and appended to the url if given
+-- @param headers table with headers (optional)
+-- @param body string containing body (optional)
+local function raw(method, url, querystring, headers, body)
+  if not headers then headers = {} end
+
+  if querystring then
+    url = string.format("%s?%s", url, ngx.encode_args(querystring, true))
+  end
+  
+  if body and (not headers["content-length"]) then
+    headers["content-length"] = string.len(body)
+  end
+
+  return http_call {
+    method = method:upper(),
+    url = url,
+    headers = headers,
+    source = body and ltn12.source.string(body)
+  }
+end
+
+
 _M.put = with_body("PUT")
 _M.post = with_body("POST")
 _M.patch = with_body("PATCH")
 _M.get = without_body("GET")
 _M.delete = without_body("DELETE")
 _M.options = without_body("OPTIONS")
+_M.raw = raw
 
 function _M.post_multipart(url, form, headers)
   if not headers then headers = {} end

--- a/kong/tools/http_client.lua
+++ b/kong/tools/http_client.lua
@@ -71,7 +71,7 @@ local function with_body(method)
 end
 
 local function without_body(method)
-  return function(url, querystring, headers, body)
+  return function(url, querystring, headers)
     if not headers then headers = {} end
 
     if querystring then

--- a/spec/integration/04-admin_api/apis_routes_spec.lua
+++ b/spec/integration/04-admin_api/apis_routes_spec.lua
@@ -195,6 +195,16 @@ describe("Admin API", function()
         assert.equal(400, status)
         assert.equal([[{"foo":"unknown field"}]], stringy.strip(response))
       end)
+      it("should ignore the body", function()
+        local response, status = http_client.raw(
+              "get", 
+              BASE_URL, 
+              nil, 
+              {["content-type"] = "application/json"}, 
+              'this does not even look like json'
+            )
+        assert.equal(200, status)
+      end)
     end)
 
     describe("/apis/:api", function()


### PR DESCRIPTION
No longer returning json error on a GET with a body. Fixes #1272.