### PR TITLE
fix(req/res-transformer) allow ":" character in transformer plugins payloads

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -63,7 +63,10 @@ local function iter(config_array)
     if current_pair == nil then -- n + 1
       return nil
     end
-    local current_name, current_value = unpack(stringy.split(current_pair, ":"))
+
+    local current_name, current_value = current_pair:match("^([^:]+):*(.-)$")
+    if current_value == "" then current_value = nil end
+
     return i, current_name, current_value
   end, config_array, 0
 end

--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -38,7 +38,10 @@ local function iter(config_array)
     if current_pair == nil then -- n + 1
       return nil
     end
-    local current_name, current_value = unpack(stringy.split(current_pair, ":"))
+
+    local current_name, current_value = current_pair:match("^([^:]+):*(.-)$")
+    if current_value == "" then current_value = nil end
+
     return i, current_name, current_value  
   end, config_array, 0
 end

--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -14,7 +14,10 @@ local function iter(config_array)
     if header_to_test == nil then -- n + 1
       return nil
     end
-    local header_to_test_name, header_to_test_value = unpack(stringy.split(header_to_test, ":"))
+
+    local header_to_test_name, header_to_test_value = header_to_test:match("^([^:]+):*(.-)$")
+    if header_to_test_value == "" then header_to_test_value = nil end
+
     return i, header_to_test_name, header_to_test_value  
   end, config_array, 0
 end

--- a/spec/plugins/request-transformer/access_spec.lua
+++ b/spec/plugins/request-transformer/access_spec.lua
@@ -22,7 +22,7 @@ describe("Request Transformer", function()
           name = "request-transformer",
           config = {
             add = {
-              headers = {"h1:v1", "h2:v2"},
+              headers = {"h1:v1", "h2:value:2"}, -- payload containing a colon
               querystring = {"q1:v1"},
               body = {"p1:v1"}
             }
@@ -43,7 +43,7 @@ describe("Request Transformer", function()
           config = {
             add = {
               headers = {"x-added:a1", "x-added2:b1", "x-added3:c2"},
-              querystring = {"query-added:newvalue", "p1:a1"},
+              querystring = {"query-added:newvalue", "p1:anything:1"},   -- payload containing a colon
               body = {"newformparam:newvalue"}
             },
             remove = {
@@ -89,7 +89,7 @@ describe("Request Transformer", function()
             append = {
               headers = {"h1:v1", "h1:v2", "h2:v1",},
               querystring = {"q1:v1", "q1:v2", "q2:v1"},
-              body = {"p1:v1", "p1:v2", "p2:v1"}
+              body = {"p1:v1", "p1:v2", "p2:value:1"}     -- payload containing a colon
             }
           },
           __api = 6
@@ -247,14 +247,14 @@ describe("Request Transformer", function()
       local body = cjson.decode(response)
       assert.equal(200, status)
       assert.equal("v1", body.headers["h1"])
-      assert.equal("v2", body.headers["h2"])
+      assert.equal("value:2", body.headers["h2"])
     end)
     it("should not change or append value if header already exists", function()
       local response, status = http_client.get(STUB_GET_URL, {}, {host = "test1.com", h1 = "v3"})
       local body = cjson.decode(response)
       assert.equal(200, status)
       assert.equal("v3", body.headers["h1"])
-      assert.equal("v2", body.headers["h2"])
+      assert.equal("value:2", body.headers["h2"])
     end)
     it("should add new parameter in url encoded body on POST", function()
       local response, status = http_client.post(STUB_POST_URL, {hello = "world"}, {host = "test1.com"})
@@ -353,14 +353,14 @@ describe("Request Transformer", function()
       local body = cjson.decode(response)
       assert.equal(200, status)
       assert.same({"v1", "v2"}, body.postData.params["p1"])
-      assert.equal("v1", body.postData.params["p2"])
+      assert.equal("value:1", body.postData.params["p2"])
     end)
     it("should append values to existing parameter in url encoded body if parameter already exist on POST", function()
       local response, status = http_client.post(STUB_POST_URL, {p1 = "v0"}, {host = "test6.com"})
       local body = cjson.decode(response)
       assert.equal(200, status)
       assert.same({"v0", "v1", "v2"}, body.postData.params["p1"])
-      assert.equal("v1", body.postData.params["p2"])
+      assert.equal("value:1", body.postData.params["p2"])
     end)
     it("should not fail if JSON body is malformed in POST", function()
       local response, status = http_client.post(STUB_POST_URL, "malformed json body", {host = "test6.com", ["content-type"] = "application/json"})
@@ -454,7 +454,7 @@ describe("Request Transformer", function()
       local response, status = http_client.post(STUB_POST_URL.."/?q1=20", {hello = "world"}, {host = "test3.com"})
       local body = cjson.decode(response)
       assert.equal(200, status)
-      assert.equal("a1", body.queryString["p1"][1])
+      assert.equal("anything:1", body.queryString["p1"][1])
       assert.equal("a2", body.queryString["p1"][2])
       assert.equal("20", body.queryString["q1"])
     end)

--- a/spec/plugins/response-transformer/body_transformer_spec.lua
+++ b/spec/plugins/response-transformer/body_transformer_spec.lua
@@ -12,7 +12,7 @@ describe("response-transformer body_transformer", function()
           json = {}
         },
         add = {
-          json = {"p1:v1", "p3:v3", "p4:\"v1\""}
+          json = {"p1:v1", "p3:value:3", "p4:\"v1\""}
         },
         append = {
           json = {}
@@ -22,13 +22,13 @@ describe("response-transformer body_transformer", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "v3", p4 = '"v1"'}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"'}, body_json)
       end)
       it("should add value in double quotes", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "v3", p4 = '"v1"'}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"'}, body_json)
       end)
     end)
     

--- a/spec/plugins/response-transformer/header_transformer_spec.lua
+++ b/spec/plugins/response-transformer/header_transformer_spec.lua
@@ -36,7 +36,7 @@ describe("response-transformer header_transformer", function()
           headers = {}
         },
         replace = {
-          headers = {"h1:v1", "h2:v2"}
+          headers = {"h1:v1", "h2:value:2"}  -- payload with colon to verify parsing
         },
         add = {
           json = {"p1:v1"},
@@ -49,12 +49,12 @@ describe("response-transformer header_transformer", function()
       it("should replace a header if the header only exists", function()
         local req_ngx_headers = {h1 = "value1", h2 = {"value2a", "value2b"}}
         header_transformer.transform_headers(conf, req_ngx_headers)
-        assert.same({h1 = "v1", h2 = "v2"}, req_ngx_headers)
+        assert.same({h1 = "v1", h2 = "value:2"}, req_ngx_headers)
       end)
       it("should not add a new header if the header does not already exist", function()
         local req_ngx_headers = {h2 = {"value2a", "value2b"}}
         header_transformer.transform_headers(conf, req_ngx_headers)
-        assert.same({h2 = "v2"}, req_ngx_headers)
+        assert.same({h2 = "value:2"}, req_ngx_headers)
       end)
       it("should set content-length nil", function()
         local ngx_headers = {h1 = "value1", h2 = {"value2a", "value2b"}, [CONTENT_LENGTH] = "100", ["content-type"] = "application/json"}


### PR DESCRIPTION
this fixes #1287 

