### PR TITLE
feat(rate-limiting) per-consumer rate-limiting option

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -8,6 +8,7 @@ return {
     day = { type = "number" },
     month = { type = "number" },
     year = { type = "number" },
+    combined = { type = "boolean", default = false },
     async = { type = "boolean", default = false },
     continue_on_error = { type = "boolean", default = false }
   },


### PR DESCRIPTION
Currently Kong only allows to track individual usage for each credential (or auth record).
This is somewhat confusing, as rate limits are configured on consumer level, and the documentation suggests per-consumer accounting.
On Kong's Gitter this was called a bug in the plugin implementation, but I'm not sure if it's a good idea to change the default behavior (i.e. if others rely on it, or even maybe prefer per-credential limiting).

It's definitely an issue for us, as in Comtech we're using Kong as part of management layer for our APIs, with our customers and their apps being mapped to Kong's consumers and credentials, respectively. Depending on the subscription level, we configure the rate each customer can hit our systems at. We don't want to limit our users in their ability to provision individual API keys for different apps / purposes, but we also need to account system usage for all their keys combined (as otherwise it would enable unlimited usage of our services).

This patch resolves the issue by implementing the missing per-consumer limiting through new configuration option. By default, i.e. unless the option enabled, plugin's behavior remain backward compatible -- each API key is accounted individually.

Technical details:
- Adds "config.combined" parameter for Rate Limiting plugin.
 - Set to "false" by default for backward compatibility.
 - When set to "true", the plugin tracks API usage per Consumer, and not per individual credential.

