### PR TITLE
feat(helpers) new busted assertions and modifiers

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -241,15 +241,21 @@ local function modifier_request(state, arguments, level)
 end
 luassert:register("modifier", "request", modifier_request)
 
---- Generic fail assertion. Always fails.
+--- Generic fail assertion. A convenience function for debugging tests, always fails. It will output the 
+-- values it was called with as a table, with an `n` field to indicate the number of arguments received.
 -- @usage
--- assert.fail()
+-- assert.fail(some, value)
 local function fail(state, args)
-  args[1] = table.concat(args, " ")
+  local out = {}
+  for k,v in pairs(args) do out[k] = v end
+  args[1] = out
   args.n = 1
   return false
 end
-say:set("assertion.fail.negative", "%s")
+say:set("assertion.fail.negative", [[
+Fail assertion was called with the following parameters (formatted as a table);
+%s
+]])
 luassert:register("assertion", "fail", fail,
                   "assertion.fail.negative",
                   "assertion.fail.negative")

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -331,6 +331,8 @@ Body:
 ]])
 luassert:register("assertion", "status", res_status,
                   "assertion.res_status.negative")
+luassert:register("assertion", "res_status", res_status,     -- TODO: remove this, for now will break too many existing tests
+                  "assertion.res_status.negative")
 
 --- Checks and returns a json body of an http response/request.
 -- @name jsonbody


### PR DESCRIPTION
I found myself repeating a lot of data structure parsing and handling responses and requests (returned from mockbin). So I wrote some assertions and modifiers.

It allows you to do this;
```lua

local res = assert(client:send {
  method = "POST",
  path = "/request",
  query = {
    hello = "world",
    hello2 = "world2",
  },
  body = {
    ["toremoveform"] = "yes",
    ["nottoremove"] = "yes"
  },
  headers = {
    ["Content-Type"] = "application/x-www-form-urlencoded",
    host = "test4.com",
    custom = "myValue"
  }
})

local body_as_text = assert.response(res).has.status(200)
local body_as_table = assert.response(res).has.jsonbody()
local value = assert.response(res).has.header("custom")
assert.equal("myValue", value)

local assert.request(res).has.no.queryparam("hello3")
local param = assert.request(res).has.queryparam("hello2")
assert.equal("world2", param)

assert.request(res).has.no.formparam("toremoveform")
local param = assert.request(res).has.formparam("nottoremove")
assert.equal("yes", param)
```

It's a bit rough, but it allows to focus on what needs to be tested instead of on how to parse the data structures over and over again.

basically its an extension of what was done in #1305 