### PR TITLE
bug fix in cassandra_db.lua:find_all

### DIFF
--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -249,7 +249,7 @@ function CassandraDB:find_all(table_name, tbl, schema)
   local res_rows, err = {}, nil
 
   for rows, page_err in session:execute(query, args, {auto_paging = true}) do
-    if err then
+    if page_err then
       err = Errors.db(tostring(page_err))
       res_rows = nil
       break


### PR DESCRIPTION
I think there's a bug in cassandra_db.lua:find_all. There's a loop over pages fetched from the database. The loop body does not check the error code of the last fetched page. Instead it wrongly checks the error code of the operation that opened the database session, which was already checked before entering the loop.

The consequences of this bug are: if the session is opened successfully but reading a page results in an error, the result of find_all is incomplete but marked as a success. In the case of the apis table, the incomplete (possibly empty) result is placed in the cache and all user requests during the cache validity period report an error.