### PR TITLE
Feature/global plugins

### DIFF
--- a/kong/dao/schemas/plugins.lua
+++ b/kong/dao/schemas/plugins.lua
@@ -29,7 +29,6 @@ return {
     },
     api_id = {
       type = "id",
-      required = true,
       foreign = "apis:id"
     },
     consumer_id = {

--- a/kong/tools/database_cache.lua
+++ b/kong/tools/database_cache.lua
@@ -76,7 +76,7 @@ function _M.consumer_key(id)
 end
 
 function _M.plugin_key(name, api_id, consumer_id)
-  return CACHE_KEYS.PLUGINS..":"..name..":"..api_id..(consumer_id and ":"..consumer_id or "")
+  return CACHE_KEYS.PLUGINS..":"..name..(api_id and ":"..api_id or "")..(consumer_id and ":"..consumer_id or "")
 end
 
 function _M.basicauth_credential_key(username)

--- a/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -4,31 +4,71 @@ describe("Plugins triggering", function()
   local client
   setup(function()
     helpers.kill_all()
-    helpers.prepare_prefix()
-    helpers.dao:truncate_tables()
 
-    local consumer = assert(helpers.dao.consumers:insert {
-      username = "bob"
+    local consumer1 = assert(helpers.dao.consumers:insert {
+      username = "consumer1"
     })
-    local api = assert(helpers.dao.apis:insert {
-      name = "mockbin",
-      request_path = "/mockbin",
-      strip_request_path = true,
+    assert(helpers.dao.keyauth_credentials:insert {
+      key = "secret1",
+      consumer_id = consumer1.id
+    })
+    local consumer2 = assert(helpers.dao.consumers:insert {
+      username = "consumer2"
+    })
+    assert(helpers.dao.keyauth_credentials:insert {
+      key = "secret2",
+      consumer_id = consumer2.id
+    })
+
+    -- Global configuration
+    assert(helpers.dao.apis:insert {
+      request_host = "global1.com",
       upstream_url = "http://mockbin.com"
     })
     assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      config = { }
+    })
+    assert(helpers.dao.plugins:insert {
       name = "rate-limiting",
-      api_id = api.id,
       config = {
         hour = 1,
       }
     })
+
+    -- API Specific Configuration
+    local api1 = assert(helpers.dao.apis:insert {
+      request_host = "api1.com",
+      upstream_url = "http://mockbin.com"
+    })
     assert(helpers.dao.plugins:insert {
       name = "rate-limiting",
-      api_id = api.id,
-      consumer_id = consumer.id,
+      api_id = api1.id,
       config = {
-        hour = 1,
+        hour = 2,
+      }
+    })
+
+    -- Consumer Specific Configuration
+    assert(helpers.dao.plugins:insert {
+      name = "rate-limiting",
+      consumer_id = consumer2.id,
+      config = {
+        hour = 3,
+      }
+    })
+
+    -- API and Consumer Configuration
+    local api2 = assert(helpers.dao.apis:insert {
+      request_host = "api2.com",
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "rate-limiting",
+      api_id = api2.id,
+      consumer_id = consumer2.id,
+      config = {
+        hour = 4,
       }
     })
 
@@ -42,23 +82,48 @@ describe("Plugins triggering", function()
     helpers.clean_prefix()
   end)
 
-  -- here have 2 rows in our plugins table, one with a
-  -- consumer_id column, the other without.
-  -- With Cassandra, it is not possible to have a WHERE clause
-  -- targetting specifically the null consumer_id row. Hence,
-  -- depending on Cassandra storage internals, the plugin iterator could
-  -- return the row that applies to a consumer, or the one that does
-  -- not, making this behavior non-deterministic.
-  -- the previous **hack** was to have a "nullified" uuid (0000s),
-  -- but since Postgres support, this hack has been removed. Instead,
-  -- the plugin iterator now manually filters the rows returned :(
-  -- this hack will only be used when Cassandra is our backend.
-  it("applies the correct plugin for a consumer", function()
+  it("checks global configuration without credentials", function()
     local res = assert(client:send {
       method = "GET",
-      path = "/mockbin/status/200"
+      path = "/status/200",
+      headers = { Host = "global1.com" }
+    })
+    assert.res_status(401, res)
+  end)
+  it("checks global api configuration", function()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/status/200?apikey=secret1",
+      headers = { Host = "global1.com" }
     })
     assert.res_status(200, res)
     assert.equal("1", res.headers["x-ratelimit-limit-hour"])
+  end)
+  it("checks api specific configuration", function()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/status/200?apikey=secret1",
+      headers = { Host = "api1.com" }
+    })
+    assert.res_status(200, res)
+    assert.equal("2", res.headers["x-ratelimit-limit-hour"])
+  end)
+  it("checks global consumer configuration", function()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/status/200?apikey=secret2",
+      headers = { Host = "global1.com" }
+    })
+    assert.res_status(200, res)
+    assert.equal("3", res.headers["x-ratelimit-limit-hour"])
+  end)
+  it("checks consumer specific configuration", function()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/status/200?apikey=secret2",
+      headers = { Host = "api2.com" }
+    })
+    assert.res_status(200, res)
+    assert.equal("4", res.headers["x-ratelimit-limit-hour"])
   end)
 end)

--- a/spec/helpers_spec.lua
+++ b/spec/helpers_spec.lua
@@ -18,7 +18,6 @@ describe("helpers: assertions and modifiers;", function()
       upstream_url = "http://httpbin.org"
     })
 
-    helpers.create_prefix()
     assert(helpers.start_kong())
   end)
   teardown(function()


### PR DESCRIPTION
* Allows to apply plugins globally to every API (by not specifying an `api_id` and not `consumer_id`). 
* Allows to apply plugins globally for a consumer (by not specifying and `api_id`, but by specifying a `consumer_id`).

Implements #295 and the first two points of #505. 