### PR TITLE
refactor/key-auth: extends test to validate unique random keys

### DIFF
--- a/spec/03-plugins/key-auth/01-api_spec.lua
+++ b/spec/03-plugins/key-auth/01-api_spec.lua
@@ -42,8 +42,8 @@ describe("Plugin: key-auth (API)", function()
         assert.equal(consumer.id, json.consumer_id)
         assert.equal("1234", json.key)
       end)
-      it("creates a key-auth auto-generating the key", function()
-          local res = assert(admin_client:send {
+      it("creates a key-auth auto-generating a unique key", function()
+        local res = assert(admin_client:send {
           method = "POST",
           path = "/consumers/bob/key-auth",
           body = {},
@@ -55,6 +55,24 @@ describe("Plugin: key-auth (API)", function()
         local json = cjson.decode(body)
         assert.equal(consumer.id, json.consumer_id)
         assert.is_string(json.key)
+        
+        local first_key = json.key
+        helpers.dao:truncate_table("keyauth_credentials")
+        
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/bob/key-auth",
+          body = {},
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = assert.res_status(201, res)
+        local json = cjson.decode(body)
+        assert.equal(consumer.id, json.consumer_id)
+        assert.is_string(json.key)
+
+        assert.not_equal(first_key, json.key)
       end)
     end)
 


### PR DESCRIPTION
closes #772. Fix was already applied, this adds only the test.