### PR TITLE
accepts hostnames without TLD, and i18n formats (punycode).

### DIFF
--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -28,9 +28,10 @@ local function check_request_host_and_path(api_t)
   return true
 end
 
-local host_allowed_chars = "[%d%a%-%.%_]"
-local ext_allowed_chars = "[%d%a]"
-local dns_pattern = "^"..host_allowed_chars.."+%."..ext_allowed_chars..ext_allowed_chars.."+$"
+--local host_allowed_chars = "[%d%a%-%.%_]"
+--local ext_allowed_chars = "[%d%a]"
+--local dns_pattern = "^"..host_allowed_chars.."+$"
+local dns_pattern = "^[%d%a%-%.%_]+$"
 
 local function check_request_host(request_host, api_t)
   local valid, err = check_request_host_and_path(api_t)
@@ -48,8 +49,9 @@ local function check_request_host(request_host, api_t)
       end
 
       -- Reject prefix/trailing dashes and dots in each segment
+      -- note: punycode allowes prefixed dash, if the characters before the dash are escaped
       for _, segment in ipairs(stringy.split(request_host, ".")) do
-        if segment == "" or segment:match("^-") or segment:match("-$") or segment:match("^%.") or segment:match("%.$") then
+        if segment == "" or segment:match("-$") or segment:match("^%.") or segment:match("%.$") then
           return false, "Invalid value: "..request_host
         end
       end

--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -28,9 +28,6 @@ local function check_request_host_and_path(api_t)
   return true
 end
 
---local host_allowed_chars = "[%d%a%-%.%_]"
---local ext_allowed_chars = "[%d%a]"
---local dns_pattern = "^"..host_allowed_chars.."+$"
 local dns_pattern = "^[%d%a%-%.%_]+$"
 
 local function check_request_host(request_host, api_t)

--- a/spec/01-unit/08-entities_schemas_spec.lua
+++ b/spec/01-unit/08-entities_schemas_spec.lua
@@ -99,7 +99,7 @@ describe("Entities Schemas", function()
         local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
                         "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
                         "hello.abcd", "mockbin_api.com", "localhost",
-                        -- punycode exmaples from RFC3492; https://tools.ietf.org/html/rfc3492#page-14
+                        -- punycode examples from RFC3492; https://tools.ietf.org/html/rfc3492#page-14
                         -- specifically the japanese ones as they mix ascii with escaped characters
                         "3B-ww4c5e180e575a65lsy2b", "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
                         "Hello-Another-Way--fc4qua05auwb3674vfr0b", "2-u9tlzr9756bt3uc0v",

--- a/spec/01-unit/08-entities_schemas_spec.lua
+++ b/spec/01-unit/08-entities_schemas_spec.lua
@@ -82,10 +82,10 @@ describe("Entities Schemas", function()
         assert.equal("At least a 'request_host' or a 'request_path' must be specified", errors.request_path)
       end)
       it("should not accept an invalid request_host", function()
-        local invalids = {"/mockbin", ".mockbin", "mockbin.", "mockbin.f", "mock;bin",
-                          "mockbin.com-org", "mockbin.com/org", "mockbin.com_org",
-                          "-mockbin.org", "mockbin-.org", "mockbin.or-g", "mockbin.org-",
-                          "mockbin.-org", "hello.-mockbin.com", "hello..mockbin.com", "hello-.mockbin.com"}
+        local invalids = {"/mockbin", ".mockbin", "mockbin.", "mock;bin",
+                          "mockbin.com/org",
+                          "mockbin-.org", "mockbin.org-",
+                          "hello..mockbin.com", "hello-.mockbin.com"}
 
         for _, v in ipairs(invalids) do
           local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}
@@ -98,7 +98,13 @@ describe("Entities Schemas", function()
       it("should accept valid request_host", function()
         local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
                         "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
-                        "hello.abcd", "mockbin_api.com"}
+                        "hello.abcd", "mockbin_api.com", "localhost",
+                        -- punycode exmaples from RFC3492; https://tools.ietf.org/html/rfc3492#page-14
+                        -- specifically the japanese ones as they mix ascii with escaped characters
+                        "3B-ww4c5e180e575a65lsy2b", "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
+                        "Hello-Another-Way--fc4qua05auwb3674vfr0b", "2-u9tlzr9756bt3uc0v",
+                        "MajiKoi5-783gue6qz075azm5e", "de-jg4avhby1noc0d", "d9juau41awczczp",
+                        }
 
         for _, v in ipairs(valids) do
           local t = {request_host = v, upstream_url = "http://mockbin.com", name = "mockbin"}

--- a/spec/02-integration/03-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/02-apis_routes_spec.lua
@@ -84,13 +84,13 @@ describe("Admin API", function()
               method = "POST",
               path = "/apis",
               body = {
-                request_host = "my-api",
+                request_host = "my-api.com/com",
                 upstream_url = "http://my-api.con"
               },
               headers = {["Content-Type"] = content_type}
             })
             body = assert.res_status(400, res)
-            assert.equal([[{"request_host":"Invalid value: my-api"}]], body)
+            assert.equal([[{"request_host":"Invalid value: my-api.com\/com"}]], body)
           end
         end)
         it_content_types("returns 409 on conflict", function(content_type)
@@ -212,14 +212,14 @@ describe("Admin API", function()
               method = "PUT",
               path = "/apis",
               body = {
-                request_host = "my-api",
+                request_host = "my-api.com/com",
                 upstream_url = "http://my-api.com",
                 created_at = 1461276890000
               },
               headers = {["Content-Type"] = content_type}
             })
             body = assert.res_status(400, res)
-            assert.equal([[{"request_host":"Invalid value: my-api"}]], body)
+            assert.equal([[{"request_host":"Invalid value: my-api.com\/com"}]], body)
           end
         end)
         it_content_types("returns 409 on conflict", function(content_type)


### PR DESCRIPTION
fixes #1300 and i18n hostnames. See https://github.com/Mashape/kong/issues/1205#issuecomment-221386825
