### PR TITLE
feat(plugin) Method Restriction

### DIFF
--- a/kong-0.9.0-0.rockspec
+++ b/kong-0.9.0-0.rockspec
@@ -260,5 +260,8 @@ build = {
     ["kong.plugins.bot-detection.rules"] = "kong/plugins/bot-detection/rules.lua",
     ["kong.plugins.bot-detection.cache"] = "kong/plugins/bot-detection/cache.lua",
     ["kong.plugins.bot-detection.hooks"] = "kong/plugins/bot-detection/hooks.lua",
+
+    ["kong.plugins.method-restriction.handler"] = "kong/plugins/method-restriction/handler.lua",
+    ["kong.plugins.method-restriction.schema"] = "kong/plugins/method-restriction/schema.lua",
   }
 }

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -3,7 +3,8 @@ local plugins = {
   "file-log", "http-log", "key-auth", "hmac-auth", "basic-auth", "ip-restriction",
   "galileo", "request-transformer", "response-transformer",
   "request-size-limiting", "rate-limiting", "response-ratelimiting", "syslog",
-  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection"
+  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection",
+  "method-restriction"
 }
 
 local plugin_map = {}

--- a/kong/plugins/method-restriction/handler.lua
+++ b/kong/plugins/method-restriction/handler.lua
@@ -1,0 +1,42 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local responses = require "kong.tools.responses"
+local get_method = ngx.req.get_method
+
+local function reverse(tbl)
+  local reversed = {}
+
+  for k, v in ipairs(tbl) do
+    reversed[string.upper(v)] = k
+  end
+
+  return reversed
+end
+
+local MethodRestrictionHandler = BasePlugin:extend()
+
+MethodRestrictionHandler.PRIORITY = 940
+
+function MethodRestrictionHandler:new()
+  MethodRestrictionHandler.super.new(self, "method-restriction")
+end
+
+function MethodRestrictionHandler:access(conf)
+  MethodRestrictionHandler.super.access(self)
+
+  local block = false
+  local method = get_method()
+
+  if conf.blacklist then
+    block = reverse(conf.blacklist)[method]
+  end
+
+  if conf.whitelist then
+    block = not reverse(conf.whitelist)[method]
+  end
+
+  if block then
+    return responses.send_HTTP_METHOD_NOT_ALLOWED()
+  end
+end
+
+return MethodRestrictionHandler

--- a/kong/plugins/method-restriction/schema.lua
+++ b/kong/plugins/method-restriction/schema.lua
@@ -1,0 +1,17 @@
+local Errors = require "kong.dao.errors"
+
+return {
+  fields = {
+    whitelist = { type = "array" },
+    blacklist = { type = "array" }
+  },
+  self_check = function(schema, plugin_t, dao, is_update)
+    if next(plugin_t.whitelist or {}) and next(plugin_t.blacklist or {}) then
+      return false, Errors.schema "You cannot set both a whitelist and a blacklist"
+    end
+    if not (next(plugin_t.whitelist or {}) or next(plugin_t.blacklist or {})) then
+      return false, Errors.schema "You must set at least a whitelist or blacklist"
+    end
+    return true
+  end
+}

--- a/spec/03-plugins/17-method-restriction/01-schema_spec.lua
+++ b/spec/03-plugins/17-method-restriction/01-schema_spec.lua
@@ -1,0 +1,41 @@
+local schemas_validation = require "kong.dao.schemas_validation"
+local schema = require "kong.plugins.method-restriction.schema"
+
+local v = schemas_validation.validate_entity
+
+describe("Plugin: method-restriction (schema)", function()
+  it("should accept a valid whitelist", function()
+    assert(v({whitelist = {"GET", "POST"}}, schema))
+  end)
+  it("should accept a valid blacklist", function()
+    assert(v({blacklist = {"GET", "POST"}}, schema))
+  end)
+
+  describe("errors", function()
+    it("whitelist should not accept invalid types", function()
+      local ok, err = v({whitelist = 12}, schema)
+      assert.False(ok)
+      assert.same({whitelist = "whitelist is not an array"}, err)
+    end)
+    it("blacklist should not accept invalid types", function()
+      local ok, err = v({blacklist = 12}, schema)
+      assert.False(ok)
+      assert.same({blacklist = "blacklist is not an array"}, err)
+    end)
+    it("should not accept both a whitelist and a blacklist", function()
+      local t = {blacklist = {"GET"}, whitelist = {"POST"}}
+      local ok, err, self_err = v(t, schema)
+      assert.False(ok)
+      assert.is_nil(err)
+      assert.equal("You cannot set both a whitelist and a blacklist", self_err.message)
+    end)
+    it("should not accept both empty whitelist and blacklist", function()
+      local t = {blacklist = {}, whitelist = {}}
+      local ok, err, self_err = v(t, schema)
+      assert.False(ok)
+      assert.is_nil(err)
+      assert.equal("You must set at least a whitelist or blacklist", self_err.message)
+    end)
+  end)
+
+end)

--- a/spec/03-plugins/17-method-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-method-restriction/02-access_spec.lua
@@ -1,0 +1,133 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+describe("Plugin: method-restriction (access)", function()
+  local client
+  setup(function()
+    assert(helpers.start_kong())
+    client = helpers.proxy_client()
+
+    local api1 = assert(helpers.dao.apis:insert {
+      request_host = "mr1.com",
+      upstream_url = "http://mockbin.com"
+    })
+    local api2 = assert(helpers.dao.apis:insert {
+      request_host = "mr2.com",
+      upstream_url = "http://mockbin.com"
+    })
+    local api3 = assert(helpers.dao.apis:insert {
+      request_host = "mr3.com",
+      upstream_url = "http://mockbin.com"
+    })
+    local api4 = assert(helpers.dao.apis:insert {
+      request_host = "mr4.com",
+      upstream_url = "http://mockbin.com"
+    })
+    local api5 = assert(helpers.dao.apis:insert {
+      request_host = "mr5.com",
+      upstream_url = "http://mockbin.com"
+    })
+
+    assert(helpers.dao.plugins:insert {
+      name = "method-restriction",
+      api_id = api1.id,
+      config = {
+        blacklist = {"GET"}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "method-restriction",
+      api_id = api2.id,
+      config = {
+        blacklist = {"POST"}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "method-restriction",
+      api_id = api3.id,
+      config = {
+        whitelist = {"GET"}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "method-restriction",
+      api_id = api4.id,
+      config = {
+        whitelist = {"POST"}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "method-restriction",
+      api_id = api5.id,
+      config = {
+        whitelist = {"Get"}
+      }
+    })
+  end)
+
+  teardown(function()
+    if client then client:close() end
+    helpers.stop_kong()
+  end)
+
+  describe("blacklist", function()
+    it("blocks a request when the method is blacklisted", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "mr1.com"
+        }
+      })
+      local body = assert.res_status(405, res)
+      assert.equal([[{"message":"Method not allowed"}]], body)
+    end)
+    it("allows a request when the method is not blacklisted", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "mr2.com"
+        }
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("GET", json.method)
+    end)
+  end)
+
+  describe("whitelist", function()
+    it("blocks a request when the method is not whitelisted", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "mr3.com"
+        }
+      })
+      local body = assert.res_status(405, res)
+      assert.equal([[{"message":"Method not allowed"}]], body)
+    end)
+    it("allows a request when the method is whitelisted", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "mr4.com"
+        }
+      })
+      assert.res_status(200, res)
+    end)
+    it("allows a request when method is registered with camelcase", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "mr5.com"
+        }
+      })
+      assert.res_status(200, res)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
The intention of this plugin is make api restrictions using http methods, with this, we will have more flexibility to "close" or "open" some api resources.

Please, look: #1411 
