### PR TITLE
feat(conf) add 'lua_ssl_verify_depth' property

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -241,7 +241,7 @@
                                  # Only valid when `dnsmasq` is disabled.
 
 #------------------------------------------------------------------------------
-# DEVELOPMENT
+# DEVELOPMENT & MISCELLANEOUS
 #------------------------------------------------------------------------------
 
 # Additional settings inherited from lua-nginx-module allowing for more
@@ -249,6 +249,12 @@
 #
 # See the lua-nginx-module documentation for more informations:
 # https://github.com/openresty/lua-nginx-module
+
+#lua_ssl_verify_depth = 1        # Sets the verification depth in the server
+                                 # certificates chain used by Lua cosockets.
+                                 # This includes the certificates configured
+                                 # for database connections, like
+                                 # `cassandra_ssl_trusted_cert`.
 
 #lua_code_cache = on             # When disabled, every request will run in a
                                  # separate Lua VM instance: all Lua modules

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -85,7 +85,8 @@ local CONF_INFERENCES = {
   nginx_daemon = {typ = "ngx_boolean"},
   nginx_optimizations = {typ = "boolean"},
 
-  lua_code_cache = {typ = "ngx_boolean"}
+  lua_code_cache = {typ = "ngx_boolean"},
+  lua_ssl_verify_depth = {typ = "number"}
 }
 
 -- List of settings whose values must not be printed when

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -47,6 +47,7 @@ dnsmasq_port = 8053
 dns_resolver = NONE
 
 lua_code_cache = on
+lua_ssl_verify_depth = 1
 lua_package_path = ?/init.lua;./kong/?.lua
 lua_package_cpath = NONE
 ]]

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -43,6 +43,7 @@ lua_shared_dict cassandra_prepared 5m;
 lua_socket_log_errors off;
 > if lua_ssl_trusted_certificate then
 lua_ssl_trusted_certificate '${{lua_ssl_trusted_certificate}}';
+lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 
 init_by_lua_block {

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -76,6 +76,17 @@ describe("NGINX conf compiler", function()
       }))
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
       assert.matches("lua_ssl_trusted_certificate '/path/to/ca.cert';", kong_nginx_conf, nil, true)
+      assert.matches("lua_ssl_verify_depth 1;", kong_nginx_conf, nil, true)
+    end)
+    it("sets lua_ssl_verify_depth", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        cassandra_ssl = true,
+        cassandra_ssl_trusted_cert = "/path/to/ca.cert",
+        lua_ssl_verify_depth = "2"
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("lua_ssl_trusted_certificate '/path/to/ca.cert';", kong_nginx_conf, nil, true)
+      assert.matches("lua_ssl_verify_depth 2;", kong_nginx_conf, nil, true)
     end)
     it("compiles without anonymous reports", function()
       local conf = assert(conf_loader(nil, {


### PR DESCRIPTION
When specifying a certificate for datastore connections, it can be
required to adjust the verification depth in the certificates chain.

This adds the `lua_ssl_verify_depth` directive when *and only when* a
certificate is configured for Cassandra connections.

Once PostgreSQL SSL connections will be supported, we will handle better
the `lua_ssl_trusted_certificate` directive as well as the verify depth.

* New property: new default + added and documented it in
  `kong.conf.default`
* new test

Implements #1395