### PR TITLE
feat(postgres) implement SSL connections capability

### DIFF
--- a/kong-0.8.3-0.rockspec
+++ b/kong-0.8.3-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "lapis ~> 1.3.1-1",
   "stringy ~> 0.4-1",
   "lua-cassandra ~> 0.5.2",
-  "pgmoon ~> 1.4.0",
+  "pgmoon ~> 1.5.0",
   "multipart ~> 0.3-2",
   "lua-cjson ~> 2.1.0-1",
   "lbase64 ~> 20120820-1",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -112,6 +112,14 @@
 #pg_password = kong              # The password to authenticate if required.
 #pg_database = kong              # The database name to connect to.
 
+#pg_ssl = off                    # Toggles client-server TLS connections
+                                 # between Kong and PostgreSQL.
+
+#pg_ssl_verify = off             # Toggles server certificate verification if
+                                 # `pg_ssl` is enabled.
+                                 # See the `lua_ssl_trusted_certificate`
+                                 # setting to specify a certificate authority.
+
 #cassandra_contact_points = 127.0.0.1  # A comma-separated list of contact
                                        # points to your cluster.
 
@@ -132,12 +140,8 @@
 
 #cassandra_ssl_verify = off      # Toggles server certificate verification if
                                  # `cassandra_ssl` is enabled.
-
-#cassandra_ssl_trusted_cert =    # Absolute path to the certificate
-                                 # authority file in PEM format. This setting
-                                 # will set the `lua_ssl_trusted_certificate`
-                                 # directive when Kong compiles the Nginx
-                                 # configuration file.
+                                 # See the `lua_ssl_trusted_certificate`
+                                 # setting to specify a certificate authority.
 
 #cassandra_username = kong       # Username when using the
                                  # `PasswordAuthenticator` scheme.
@@ -250,11 +254,18 @@
 # See the lua-nginx-module documentation for more informations:
 # https://github.com/openresty/lua-nginx-module
 
+#lua_ssl_trusted_certificate =   # Absolute path to the certificate
+                                 # authority file for Lua cosockets in PEM
+                                 # format. This certificate will be the one
+                                 # used for verifying Kong's database
+                                 # connections, when `pg_ssl_verify` or
+                                 # `cassandra_ssl_verify` are enabled.
+
 #lua_ssl_verify_depth = 1        # Sets the verification depth in the server
-                                 # certificates chain used by Lua cosockets.
+                                 # certificates chain used by Lua cosockets,
+                                 # set by `lua_ssl_trusted_certificate`.
                                  # This includes the certificates configured
-                                 # for database connections, like
-                                 # `cassandra_ssl_trusted_cert`.
+                                 # for Kong's database connections.
 
 #lua_code_cache = on             # When disabled, every request will run in a
                                  # separate Lua VM instance: all Lua modules

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -100,9 +100,6 @@ local function compile_conf(kong_config, conf_template)
     tostring = tostring
   }
 
-  if kong_config.cassandra_ssl and kong_config.cassandra_ssl_trusted_cert then
-    compile_env["lua_ssl_trusted_certificate"] = kong_config.cassandra_ssl_trusted_cert
-  end
   if kong_config.dnsmasq then
     compile_env["dns_resolver"] = "127.0.0.1:"..kong_config.dnsmasq_port
   end

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -58,6 +58,8 @@ local CONF_INFERENCES = {
 
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},
+  pg_ssl = {typ = "boolean"},
+  pg_ssl_verify = {typ = "boolean"},
 
   cassandra_contact_points = {typ = "array"},
   cassandra_port = {typ = "number"},

--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -40,7 +40,7 @@ function CassandraDB:new(kong_config)
     ssl_options = {
       enabled = kong_config.cassandra_ssl,
       verify = kong_config.cassandra_ssl_verify,
-      ca = kong_config.cassandra_ssl_trusted_cert
+      ca = kong_config.lua_ssl_trusted_certificate
     }
   }
 

--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -26,7 +26,10 @@ function PostgresDB:new(kong_config)
     port = kong_config.pg_port,
     user = kong_config.pg_user,
     password = kong_config.pg_password,
-    database = kong_config.pg_database
+    database = kong_config.pg_database,
+    ssl = kong_config.pg_ssl,
+    ssl_verify = kong_config.pg_ssl_verify,
+    cafile = kong_config.lua_ssl_trusted_certificate
   }
 
   PostgresDB.super.new(self, "postgres", conn_opts)
@@ -112,7 +115,7 @@ local function parse_error(err_str)
       err = Errors.foreign {[col] = value}
     end
   end
-  
+
   return err or Errors.db(err_str)
 end
 
@@ -208,7 +211,7 @@ function PostgresDB:deserialize_rows(rows, schema)
     local json = require "cjson"
     for i, row in ipairs(rows) do
       for col, value in pairs(row) do
-        if type(value) == "string" and schema.fields[col] and 
+        if type(value) == "string" and schema.fields[col] and
           (schema.fields[col].type == "table" or schema.fields[col].type == "array") then
           rows[i][col] = json.decode(value)
         end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -21,6 +21,8 @@ pg_port = 5432
 pg_database = kong
 pg_user = kong
 pg_password = NONE
+pg_ssl = off
+pg_ssl_verify = off
 cassandra_contact_points = 127.0.0.1
 cassandra_port = 9042
 cassandra_keyspace = kong
@@ -31,7 +33,6 @@ cassandra_consistency = ONE
 cassandra_timeout = 5000
 cassandra_ssl = off
 cassandra_ssl_verify = off
-cassandra_ssl_trusted_cert = NONE
 cassandra_username = kong
 cassandra_password = NONE
 
@@ -47,6 +48,7 @@ dnsmasq_port = 8053
 dns_resolver = NONE
 
 lua_code_cache = on
+lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1
 lua_package_path = ?/init.lua;./kong/?.lua
 lua_package_cpath = NONE

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -42,7 +42,7 @@ lua_shared_dict cassandra 1m;
 lua_shared_dict cassandra_prepared 5m;
 lua_socket_log_errors off;
 > if lua_ssl_trusted_certificate then
-lua_ssl_trusted_certificate '${{lua_ssl_trusted_certificate}}';
+lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
 lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -99,21 +99,29 @@ describe("Configuration loader", function()
       assert.True(conf.anonymous_reports)
       assert.False(conf.cassandra_ssl)
       assert.False(conf.cassandra_ssl_verify)
+      assert.False(conf.pg_ssl)
+      assert.False(conf.pg_ssl_verify)
 
       conf = assert(conf_loader(nil, {
-        cassandra_ssl = true
+        cassandra_ssl = true,
+        pg_ssl = true
       }))
       assert.True(conf.cassandra_ssl)
+      assert.True(conf.pg_ssl)
 
       conf = assert(conf_loader(nil, {
-        cassandra_ssl = "on"
+        cassandra_ssl = "on",
+        pg_ssl = "on"
       }))
       assert.True(conf.cassandra_ssl)
+      assert.True(conf.pg_ssl)
 
       conf = assert(conf_loader(nil, {
-        cassandra_ssl = "true"
+        cassandra_ssl = "true",
+        pg_ssl = "true"
       }))
       assert.True(conf.cassandra_ssl)
+      assert.True(conf.pg_ssl)
     end)
     it("infer arrays (comma-separated strings)", function()
       local conf = assert(conf_loader())

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -69,19 +69,17 @@ describe("NGINX conf compiler", function()
       assert.not_matches("ssl_protocols", kong_nginx_conf)
       assert.not_matches("ssl_certificate_by_lua_block", kong_nginx_conf)
     end)
-    it("sets lua_ssl_trusted_certificate from cassandra_ssl_trusted_cert", function()
+    it("does not include lua_ssl_trusted_certificate/lua_ssl_verify_depth by default", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
-        cassandra_ssl = true,
-        cassandra_ssl_trusted_cert = "/path/to/ca.cert"
+        lua_ssl_verify_depth = "2"
       }))
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
-      assert.matches("lua_ssl_trusted_certificate '/path/to/ca.cert';", kong_nginx_conf, nil, true)
-      assert.matches("lua_ssl_verify_depth 1;", kong_nginx_conf, nil, true)
+      assert.not_matches("lua_ssl_trusted_certificate", kong_nginx_conf, nil, true)
+      assert.not_matches("lua_ssl_verify_depth", kong_nginx_conf, nil, true)
     end)
-    it("sets lua_ssl_verify_depth", function()
+    it("sets lua_ssl_trusted_certificate/lua_ssl_verify_depth", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
-        cassandra_ssl = true,
-        cassandra_ssl_trusted_cert = "/path/to/ca.cert",
+        lua_ssl_trusted_certificate = "/path/to/ca.cert",
         lua_ssl_verify_depth = "2"
       }))
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)


### PR DESCRIPTION
This bumps pgmoon to v1.5.0 and adds the necessary configuration
settings to allow for SSL connections to PostgreSQL when used as Kong's
backend.
It removes the `cassandra_ssl_trusted_cert` property in favor of
`lua_ssl_trusted_certificate` in the misc section, since this setting is
not stricly related to Cassandra/Postgres connections but any Lua
cosocket one too.

* bump pgmoon to v1.5.0
* add posdtgres and misc default settings for SSL connections
* document postgres/misc settings for SSL connections
* remove `cassandra_ssl_trusted_cert`
* update kong nginx config compilation tests

Implements #1309