### PR TITLE
feat(plugin) Adding path prefix support in request transformer

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -303,10 +303,35 @@ local function transform_body(conf)
   end
 end
 
+local function transform_path(conf)
+  local uri = ngx.var.request_uri
+
+  -- Remove path_prefix(es)
+  if #conf.remove.path_prefix > 0 then
+    for _, name, value in iter(conf.remove.path_prefix) do
+      if (stringy.startswith(uri, value)) then
+        uri = uri:sub(value:len() + 1)
+      end
+    end
+  end
+
+  -- Add (prepend) path_prefix(es)
+  if #conf.add.path_prefix > 0 then
+    for _, name, value in iter(conf.remove.path_prefix) do
+      uri = value .. uri
+    end
+  end
+
+  -- Update the URI after our changes
+  ngx.req.set_uri(uri)
+
+end
+
 function _M.execute(conf)
   transform_body(conf)
   transform_headers(conf)
   transform_querystrings(conf)
+  transform_path(conf)
 end
 
 return _M

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -309,8 +309,8 @@ local function transform_path(conf)
   -- Remove path_prefix(es)
   if #conf.remove.path_prefix > 0 then
     for _, name, value in iter(conf.remove.path_prefix) do
-      if (uri:substr(0, value:len()) == value) then
-        uri = uri:substr(value:len() + 1)
+      if (uri:sub(0, value:len()) == value) then
+        uri = uri:sub(value:len() + 1)
       end
     end
   end

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -309,8 +309,8 @@ local function transform_path(conf)
   -- Remove path_prefix(es)
   if #conf.remove.path_prefix > 0 then
     for _, name, value in iter(conf.remove.path_prefix) do
-      if (stringy.startswith(uri, value)) then
-        uri = uri:sub(value:len() + 1)
+      if (uri:substr(0, value:len()) == value) then
+        uri = uri:substr(value:len() + 1)
       end
     end
   end

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -18,7 +18,8 @@ return {
         fields = {
           body = {type = "array", default = {}}, -- does not need colons
           headers = {type = "array", default = {}}, -- does not need colons
-          querystring = {type = "array", default = {}} -- does not need colons
+          querystring = {type = "array", default = {}}, -- does not need colons
+          path_prefix = {type = "array", default = {}} -- does not need colons
         }
       }
     },
@@ -38,7 +39,8 @@ return {
         fields = {
           body = {type = "array", default = {}, func = check_for_value},
           headers = {type = "array", default = {}, func = check_for_value},
-          querystring = {type = "array", default = {}, func = check_for_value}
+          querystring = {type = "array", default = {}, func = check_for_value},
+          path_prefix = {type = "array", default = {}, func = check_for_value}
         }
       }
     },

--- a/spec/03-plugins/request-transformer/01-access_spec.lua
+++ b/spec/03-plugins/request-transformer/01-access_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local cjson = require "cjson"
 
 describe("Plugin: request-transformer (access)", function()
   local client

--- a/spec/03-plugins/request-transformer/01-access_spec.lua
+++ b/spec/03-plugins/request-transformer/01-access_spec.lua
@@ -10,6 +10,8 @@ describe("Plugin: request-transformer (access)", function()
     local api4 = assert(helpers.dao.apis:insert {request_host = "test4.com", upstream_url = "http://mockbin.com"})
     local api5 = assert(helpers.dao.apis:insert {request_host = "test5.com", upstream_url = "http://mockbin.com"})
     local api6 = assert(helpers.dao.apis:insert {request_host = "test6.com", upstream_url = "http://mockbin.com"})
+    local api7 = assert(helpers.dao.apis:insert {request_host = "test7.com", upstream_url = "http://mockbin.com"})
+    local api8 = assert(helpers.dao.apis:insert {request_host = "test8.com", upstream_url = "http://mockbin.com"})
 
     -- plugin config 1
     assert(helpers.dao.plugins:insert {
@@ -90,6 +92,26 @@ describe("Plugin: request-transformer (access)", function()
           headers = {"h1:v1", "h1:v2", "h2:v1",},
           querystring = {"q1:v1", "q1:v2", "q2:v1"},
           body = {"p1:v1", "p1:v2", "p2:value:1"}     -- payload containing a colon
+        }
+      }
+    })
+    -- plugin config 7
+    assert(helpers.dao.plugins:insert {
+      api_id = api7.id,
+      name = "request-transformer",
+      config = {
+        remove = {
+          path_prefix = {"/example"}
+        }
+      }
+    })
+    -- plugin config 8
+    assert(helpers.dao.plugins:insert {
+      api_id = api8.id,
+      name = "request-transformer",
+      config = {
+        add = {
+          path_prefix = {"/another"}
         }
       }
     })
@@ -446,6 +468,15 @@ describe("Plugin: request-transformer (access)", function()
       local value = assert.request(r).has.queryparam("q2")
       assert.equals("v2", value)
     end)
+    it("removes a matched path prefix", function()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/example/page",
+      })
+      local body = assert.res_status(200, r)
+      local json = cjson.decode(body)
+      assert.equal("http://mockbin.com/page", json.url)
+    end)
   end)
 
   describe("add", function()
@@ -645,6 +676,15 @@ describe("Plugin: request-transformer (access)", function()
       local json = assert.response(r).has.jsonbody()
       local value = assert.has.header("host", json)
       assert.equals("httpbin.org", value)
+    end)
+    it("adds a path prefix", function()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/page",
+      })
+      local body = assert.res_status(200, r)
+      local json = cjson.decode(body)
+      assert.equal("http://mockbin.com/another/page", json.url)
     end)
   end)
 


### PR DESCRIPTION
### Summary

Allows for a path prefix to be prepended or removed.

So with the following configuration...

```
curl -X POST http://localhost:8001/apis/mockbin/plugins \
  --data "name=request-transformer" \
  --data "config.remove.path_prefix[1]=/example" \
  --data "config.add.path_prefix[1]=/another"
```

A request to `/example/page` would be transformed to `/another/page`

**NOTE: I have not set up a full dev environment, so I have not actually tested these changes.**

If someone could take a look, I think the changes are pretty straightforward.

### Full changelog

* Implemented path prefix support
* Created test

### Issues resolved

May address #724

