### PR TITLE
fix(migrations) + release(0.9.0rc1)

### DIFF
--- a/kong-0.9.0rc1-0.rockspec
+++ b/kong-0.9.0rc1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "0.8.3-0"
+version = "0.9.0rc1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Mashape/kong",
-  tag = "0.8.3"
+  tag = "0.9.0rc1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -12,7 +12,7 @@ local nginx_search_paths = {
 }
 local nginx_version_command = "-v"                            -- commandline param to get version
 local nginx_version_pattern = "^nginx.-openresty.-([%d%.]+)"  -- pattern to grab version from output
-local nginx_compatible = version.set("1.9.3.2","1.9.7.5")     -- compatible from-to versions
+local nginx_compatible = version.set("1.9.15.1")              -- compatible from-to versions
 
 local function is_openresty(bin_path)
   local cmd = fmt("%s %s", bin_path, nginx_version_command)

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,12 +1,12 @@
 local version = setmetatable({
   major = 0,
-  minor = 8,
-  patch = 3,
-  --pre_release = "alpha"
+  minor = 9,
+  patch = 0,
+  pre_release = "rc1"
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,
-                         t.pre_release and "-"..t.pre_release or "")
+                         t.pre_release and t.pre_release or "")
   end
 })
 

--- a/kong/plugins/rate-limiting/migrations/cassandra.lua
+++ b/kong/plugins/rate-limiting/migrations/cassandra.lua
@@ -30,15 +30,15 @@ return {
           consumer_id = rate_limiting.consumer_id,
           enabled = rate_limiting.enabled,
           config = {
-            second = rate_limiting.second,
-            minute = rate_limiting.minute,
-            hour = rate_limiting.hour,
-            day = rate_limiting.day,
-            month = rate_limiting.month,
-            year = rate_limiting.year,
+            second = rate_limiting.config.second,
+            minute = rate_limiting.config.minute,
+            hour = rate_limiting.config.hour,
+            day = rate_limiting.config.day,
+            month = rate_limiting.config.month,
+            year = rate_limiting.config.year,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = rate_limiting.continue_on_error
+            cluster_fault_tolerant = rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/kong/plugins/rate-limiting/migrations/postgres.lua
+++ b/kong/plugins/rate-limiting/migrations/postgres.lua
@@ -48,15 +48,15 @@ return {
           consumer_id = rate_limiting.consumer_id,
           enabled = rate_limiting.enabled,
           config = {
-            second = rate_limiting.second,
-            minute = rate_limiting.minute,
-            hour = rate_limiting.hour,
-            day = rate_limiting.day,
-            month = rate_limiting.month,
-            year = rate_limiting.year,
+            second = rate_limiting.config.second,
+            minute = rate_limiting.config.minute,
+            hour = rate_limiting.config.hour,
+            day = rate_limiting.config.day,
+            month = rate_limiting.config.month,
+            year = rate_limiting.config.year,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = rate_limiting.continue_on_error
+            cluster_fault_tolerant = rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/spec/01-unit/01-rockspec_spec.lua
+++ b/spec/01-unit/01-rockspec_spec.lua
@@ -18,7 +18,7 @@ describe("rockspec", function()
   end)
 
   it("has same version as meta", function()
-    assert.matches(meta._VERSION, rock.version:match("(%d.%d.%d)"))
+    assert.matches(meta._VERSION, rock.version:match("(.-)%-.*$"))
   end)
   it("has same name as meta", function()
     assert.equal(meta._NAME, rock.package)


### PR DESCRIPTION
### Summary

Release `0.9.0rc1` with some fixes along the way.

### Full changelog

* Release `0.9.0rc1`.
* OpenResty `1.9.15.1` required.
* Fixed rockspec test.
* Fixed rate-limiting migration.


