### PR TITLE
feat(plugin) Adds upstream_latency as an option to Statsd plugin

### DIFF
--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -44,7 +44,11 @@ local gauges = {
       local stat = api_name.."."..string_gsub(message.authenticated_entity.consumer_id, "-", "_")..".request.count"
       logger:counter(stat, 1, 1)    
     end
-  end
+  end,
+  upstream_latency = function (api_name, message, logger)
+    local stat = api_name..".upstream_latency"
+    logger:gauge(stat, message.latencies.proxy, 1)
+  end,
 }
 
 local function log(premature, conf, message)

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -5,7 +5,8 @@ local metrics = {
   "status_count",
   "response_size",
   "unique_users",
-  "request_per_user"
+  "request_per_user",
+  "upstream_latency"
 }
 
 return {


### PR DESCRIPTION
### Summary

This PR adds upstream_latency as an option for the statsd logging plugin. 

### Full changelog

*adds upstream_stream latency as an option for statsd, reading the value from message.latencies.proxy
*adds test for the new value

