### PR TITLE
refactor(key-auth) perf improvements + handle duplicate key in querystring

### DIFF
--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -7,7 +7,7 @@ end
 return {
   no_consumer = true,
   fields = {
-    key_names = { required = true, type = "array", default = default_key_names },
-    hide_credentials = { type = "boolean", default = false }
+    key_names = {required = true, type = "array", default = default_key_names},
+    hide_credentials = {type = "boolean", default = false}
   }
 }

--- a/spec/03-plugins/02-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/02-key-auth/02-access_spec.lua
@@ -52,7 +52,7 @@ describe("Plugin: key-auth (access)", function()
         }
       })
       local body = assert.res_status(401, res)
-      assert.equal([[{"message":"No API Key found in headers, body or querystring"}]], body)
+      assert.equal([[{"message":"No API key found in headers or querystring"}]], body)
     end)
     it("returns WWW-Authenticate header on missing credentials", function()
       local res = assert(client:send {
@@ -88,6 +88,17 @@ describe("Plugin: key-auth (access)", function()
       })
       local body = assert.res_status(403, res)
       assert.equal([[{"message":"Invalid authentication credentials"}]], body)
+    end)
+    it("handles duplicated key in querystring", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200?apikey=kong&apikey=kong",
+        headers = {
+          ["Host"] = "key-auth1.com"
+        }
+      })
+      local body = assert.res_status(401, res)
+      assert.equal([[{"message":"Duplicate API key found"}]], body)
     end)
   end)
 


### PR DESCRIPTION
The old implementation was too cumberstone with little added benefit
(since an API key will never be searched in some other place than
querystring or headers anyways). This new one is simpler but also more
efficient because it involves fewer loops and table lookups.

* refactor key-auth access handler (perf + simpler)
* handle duplicated API keys in querystring (HTTP 401)
* add duplicate key in qs test

Fix #1462