### PR TITLE
fix (startup) fix resty check and improve nginx-check messages

### DIFF
--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -1,5 +1,6 @@
 local log = require "kong.cmd.utils.log"
 local kill = require "kong.cmd.utils.kill"
+local meta = require "kong.meta"
 local pl_path = require "pl.path"
 local version = require "version"
 local pl_utils = require "pl.utils"
@@ -10,12 +11,11 @@ local nginx_search_paths = {
   "/usr/local/openresty/nginx/sbin",
   ""
 }
-local nginx_version_command = "-v"                            -- commandline param to get version
-local nginx_version_pattern = "^nginx.-openresty.-([%d%.]+)"  -- pattern to grab version from output
-local nginx_compatible = version.set("1.9.15.1")              -- compatible from-to versions
+local nginx_version_pattern = "^nginx.-openresty.-([%d%.]+)"
+local nginx_compatible = version.set(meta._DEPENDENCIES.nginx)
 
 local function is_openresty(bin_path)
-  local cmd = fmt("%s %s", bin_path, nginx_version_command)
+  local cmd = fmt("%s -v", bin_path)
   local ok, _, _, stderr = pl_utils.executeex(cmd)
   log.debug("%s: '%s'", cmd, stderr:sub(1, -2))
   if ok and stderr then

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -51,10 +51,11 @@ local function find_resty_bin()
   local found
   for _, path in ipairs(resty_search_paths) do
     local path_to_check = pl_path.join(path, resty_bin_name)
-    local cmd = fmt("%s -V", path_to_check)
-    if pl_utils.executeex(cmd) then
+    local cmd = fmt("%s -v", path_to_check)
+    local ok, _, _, stderr = pl_utils.executeex(cmd)
+    log.debug("%s: '%s'", cmd, pl_stringx.splitlines(stderr)[1])
+    if ok then
       found = path_to_check
-      log.verbose("found OpenResty 'resty' executable at %s", found)
       break
     end
     log.debug("OpenResty 'resty' executable not found at %s", path_to_check)
@@ -63,6 +64,8 @@ local function find_resty_bin()
   if not found then
     return nil, "could not find OpenResty 'resty' executable"
   end
+
+  log.verbose("found OpenResty 'resty' executable at %s", found)
 
   return found
 end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -51,18 +51,18 @@ local function find_resty_bin()
   local found
   for _, path in ipairs(resty_search_paths) do
     local path_to_check = pl_path.join(path, resty_bin_name)
-    local cmd = fmt("%s -v", path_to_check)
+    local cmd = fmt("%s -V", path_to_check)
     if pl_utils.executeex(cmd) then
       found = path_to_check
+      log.verbose("found OpenResty 'resty' executable at %s", found)
       break
     end
+    log.debug("OpenResty 'resty' executable not found at %s", path_to_check)
   end
 
   if not found then
     return nil, "could not find OpenResty 'resty' executable"
   end
-
-  log.verbose("found OpenResty 'resty' executable at %s", found)
 
   return found
 end

--- a/kong/cmd/utils/serf_signals.lua
+++ b/kong/cmd/utils/serf_signals.lua
@@ -8,12 +8,13 @@ local pl_file = require "pl.file"
 local Serf = require "kong.serf"
 local kill = require "kong.cmd.utils.kill"
 local log = require "kong.cmd.utils.log"
+local meta = require "kong.meta"
 local version = require "version"
 local fmt = string.format
 
 local serf_event_name = "kong"
-local serf_version_pattern = "^Serf v([%d%.]+)"        -- pattern to grab version from output
-local serf_compatible = version.set("0.7.0", "0.7.0")  -- compatible from-to versions
+local serf_version_pattern = "^Serf v([%d%.]+)"
+local serf_compatible = version.set(meta._DEPENDENCIES.serf)
 local start_timeout = 5
 
 local function check_serf_bin(kong_config)

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -13,5 +13,14 @@ local version = setmetatable({
 return {
   _NAME = "kong",
   _VERSION = tostring(version),
-  _VERSION_TABLE = version
+  _VERSION_TABLE = version,
+
+  -- third-party dependencies' required version, as they would be specified
+  -- to lua-version's `set()`.
+  _DEPENDENCIES = {
+    nginx = "1.9.15.1",
+    --resty = "", -- not version dependent for now
+    serf  = "0.7.0",
+    --dnsmasq = "" -- not version dependent for now
+  }
 }

--- a/spec/01-unit/01-rockspec_meta_spec.lua
+++ b/spec/01-unit/01-rockspec_meta_spec.lua
@@ -32,6 +32,11 @@ describe("rockspec/meta", function()
       assert.is_number(meta._VERSION_TABLE.patch)
       -- pre_release optional
     end)
+    it("has a _DEPENDENCIES field", function()
+      assert.is_table(meta._DEPENDENCIES)
+      assert.is_string(meta._DEPENDENCIES.nginx)
+      assert.is_string(meta._DEPENDENCIES.serf)
+    end)
   end)
 
   it("has same version as meta", function()


### PR DESCRIPTION
### Summary
Fix startup checks and error messages

### Full changelog

* change -v to -V for resty check
* updated error messages for nginx executable

### Issues resolved

Fix #XXX

Not a listed issue, but fixes the check on the resty executable. The executable is checked using `-v` which always fails, it should be `-V` (capitalized)
