### PR TITLE
fix: changelog/kong roar/serf error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ The main focus of this release is Kong's new CLI. With a simpler configuration f
 - Ability to configure the validation depth of database SSL certificates from the configuration file. [#1420](https://github.com/Mashape/kong/pull/1420)
 - `request_host`: internationalized url support; utf-8 domain names through punycode support and paths through %-encoding. [#1300](https://github.com/Mashape/kong/issues/1300)
 - Implements caching locks when fetching database configuration (APIs, Plugins...) to avoid dog pile effect on cold nodes. [#1402](https://github.com/Mashape/kong/pull/1402)
-- Internal locks when for datastore requests. Now Kong will only trigger maximum one request per node to the datastore when requesting a specific entity, which prevents the Dogpile effect. [#1402](https://github.com/Mashape/kong/pull/1402)
 - Plugins:
   - :fireworks: **New bot-detection plugin**: protect your APIs by detecting and rejecting common bots and crawlers. [#1413](https://github.com/Mashape/kong/pull/1413)
   - correlation-id: new "tracker" generator, identifying requests per worker and connection. [#1288](https://github.com/Mashape/kong/pull/1288)

--- a/kong/cmd/cluster.lua
+++ b/kong/cmd/cluster.lua
@@ -53,7 +53,6 @@ The available commands are:
  force-leave -p <node_name> Forcefully remove a node from the cluster (useful
                             if the node is in a failed state).
 
-
 Options:
  -c,--conf   (optional string) configuration file
  -p,--prefix (optional string) prefix Kong is running at

--- a/kong/cmd/roar.lua
+++ b/kong/cmd/roar.lua
@@ -1,7 +1,7 @@
 return {
   execute = function()
     print [==[
--- Kong, the biggest ape in town
+-- Kong, Monolith destroyer.
 --
 --     /\  ____
 --     <> ( oo )
@@ -25,6 +25,7 @@ return {
 --  ========
 -- ==========
 -- |[[    ]]|
--- ==========]==]
+-- ==========
+]==]
   end
 }

--- a/kong/cmd/utils/serf_signals.lua
+++ b/kong/cmd/utils/serf_signals.lua
@@ -116,7 +116,8 @@ end
 function _M.stop(kong_config, dao)
   log.verbose("leaving serf cluster")
   local serf = Serf.new(kong_config, dao)
-  serf:leave()
+  local ok, err = serf:leave()
+  if not ok then return nil, err end
   log.verbose("left serf cluster")
 
   log.verbose("stopping serf agent at %s", kong_config.serf_pid)

--- a/spec/02-integration/01-cmd/01-cmds_spec.lua
+++ b/spec/02-integration/01-cmd/01-cmds_spec.lua
@@ -7,6 +7,12 @@ describe("CLI commands", function()
       assert.matches("kong COMMAND [OPTIONS]", stderr, nil, true)
     end)
 
+    it("don't remove the cool tagline", function()
+      local ok, _, stdout = helpers.kong_exec("roar")
+      assert.True(ok)
+      assert.matches("Kong, Monolith destroyer.", stdout, nil, true)
+    end)
+
     describe("errors", function()
       it("errors on invalid command", function()
         local _, stderr = helpers.kong_exec "foobar"

--- a/spec/02-integration/01-cmd/04-reload_spec.lua
+++ b/spec/02-integration/01-cmd/04-reload_spec.lua
@@ -13,11 +13,12 @@ describe("kong reload", function()
 
   it("send a 'reload' signal to a running Nginx master process", function()
     assert(helpers.start_kong())
+    ngx.sleep(1)
+
     local nginx_pid = helpers.file.read(helpers.test_conf.nginx_pid)
 
     -- kong_exec uses test conf too, so same prefix
     assert(helpers.kong_exec("reload --prefix "..helpers.test_conf.prefix))
-
     ngx.sleep(1)
 
     -- same master PID


### PR DESCRIPTION
* re-enable serf error handling in 'leave',
  68b79bcc4c4ea6a1ed5ad8d1828719c03a2d52e4 is disabling it at the serf
  module level
* update tagline for 'kong roar'
* fix duplicated change in CHANGELOG.md