### PR TITLE
cluster_fault_tolerant is now fault_tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The main focus of this release is Kong's new CLI. With a simpler configuration f
 - New arguments for the CLI, such as verbose, debug and tracing flags. We also avoid requiring the configuration file as an argument to each command as per the previous CLI.
 - Customization of the Nginx configuration can now be taken care of using two different approaches: with a custom Nginx configuration template and using `kong start --template <file>`, or by using `kong compile` to generate the Kong Nginx sub-configuration, and `include` it in a custom Nginx instance.
 - Plugins:
-  - Rate Limiting: the `continue_on_error` property is now called `cluster_fault_tolerant`.
-  - Response Rate Limiting: the `continue_on_error` property is now called `cluster_fault_tolerant`.
+  - Rate Limiting: the `continue_on_error` property is now called `fault_tolerant`.
+  - Response Rate Limiting: the `continue_on_error` property is now called `fault_tolerant`.
 
 ### Added
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -74,7 +74,7 @@ function RateLimitingHandler:access(conf)
   local identifier = get_identifier(conf)
   local api_id = ngx.ctx.api.id
   local policy = conf.policy
-  local cluster_fault_tolerant = conf.cluster_fault_tolerant
+  local fault_tolerant = conf.fault_tolerant
 
   -- Load current metric for configured period
   local usage, stop, err = get_usage(conf, api_id, identifier, current_timestamp, {
@@ -86,7 +86,7 @@ function RateLimitingHandler:access(conf)
     year = conf.year
   })
   if err then
-    if cluster_fault_tolerant then
+    if fault_tolerant then
       ngx_log(ngx.ERR, "failed to get usage: ", tostring(err))
     else
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)

--- a/kong/plugins/rate-limiting/migrations/cassandra.lua
+++ b/kong/plugins/rate-limiting/migrations/cassandra.lua
@@ -42,7 +42,7 @@ return {
             year = rate_limiting.config.year,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = rate_limiting.config.continue_on_error
+            fault_tolerant = rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/kong/plugins/rate-limiting/migrations/postgres.lua
+++ b/kong/plugins/rate-limiting/migrations/postgres.lua
@@ -60,7 +60,7 @@ return {
             year = rate_limiting.config.year,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = rate_limiting.config.continue_on_error
+            fault_tolerant = rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -12,7 +12,7 @@ return {
     year = { type = "number" },
     limit_by = { type = "string", enum = {"consumer", "credential", "ip"}, default = "consumer" },
     policy = { type = "string", enum = {"local", "cluster", REDIS}, default = "cluster" },
-    cluster_fault_tolerant = { type = "boolean", default = true },
+    fault_tolerant = { type = "boolean", default = true },
     redis_host = { type = "string" },
     redis_port = { type = "number", default = 6379 },
     redis_password = { type = "string" },

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -66,7 +66,7 @@ function _M.execute(conf)
   -- Load current metric for configured period
   local usage, err = get_usage(conf, api_id, identifier, current_timestamp, conf.limits)
   if err then
-    if conf.cluster_fault_tolerant then
+    if conf.fault_tolerant then
       ngx.log(ngx.ERR, "failed to get usage: ", tostring(err))
       return
     else

--- a/kong/plugins/response-ratelimiting/migrations/cassandra.lua
+++ b/kong/plugins/response-ratelimiting/migrations/cassandra.lua
@@ -43,7 +43,7 @@ return {
             block_on_first_violation = response_rate_limiting.config.block_on_first_violation,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = response_rate_limiting.config.continue_on_error
+            fault_tolerant = response_rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/kong/plugins/response-ratelimiting/migrations/postgres.lua
+++ b/kong/plugins/response-ratelimiting/migrations/postgres.lua
@@ -61,7 +61,7 @@ return {
             block_on_first_violation = response_rate_limiting.config.block_on_first_violation,
             limit_by = "consumer",
             policy = "cluster",
-            cluster_fault_tolerant = response_rate_limiting.config.continue_on_error
+            fault_tolerant = response_rate_limiting.config.continue_on_error
           }
         }
         if err then return err end

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -40,7 +40,7 @@ return {
     header_name = { type = "string", default = "x-kong-limit" },
     limit_by = { type = "string", enum = {"consumer", "credential", "ip"}, default = "consumer" },
     policy = { type = "string", enum = {"local", "cluster", REDIS}, default = "cluster" },
-    cluster_fault_tolerant = { type = "boolean", default = true },
+    fault_tolerant = { type = "boolean", default = true },
     redis_host = { type = "string" },
     redis_port = { type = "number", default = 6379 },
     redis_password = { type = "string" },

--- a/spec/03-plugins/98-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/98-rate-limiting/04-access_spec.lua
@@ -78,7 +78,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         config = {
           policy = policy,
           minute = 6,
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
           redis_password = REDIS_PASSWORD
@@ -95,7 +95,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         config = {
           minute = 3,
           hour = 5,
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -117,7 +117,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         config = {
           minute = 6,
           limit_by = "credential",
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -130,7 +130,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         consumer_id = consumer1.id,
         config = {
           minute = 8,
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -152,7 +152,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         consumer_id = consumer1.id,
         config = {
           minute = 6,
-          cluster_fault_tolerant = true,
+          fault_tolerant = true,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -349,7 +349,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
           assert(helpers.dao.plugins:insert {
             name = "rate-limiting",
             api_id = api1.id,
-            config = { minute = 6, cluster_fault_tolerant = false }
+            config = { minute = 6, fault_tolerant = false }
           })
 
           local api2 = assert(helpers.dao.apis:insert {
@@ -359,7 +359,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
           assert(helpers.dao.plugins:insert {
             name = "rate-limiting",
             api_id = api2.id,
-            config = { minute = 6, cluster_fault_tolerant = true }
+            config = { minute = 6, fault_tolerant = true }
           })
 
           assert(helpers.start_kong())
@@ -450,7 +450,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
             redis_host = REDIS_HOST,
             redis_port = REDIS_PORT,
             redis_password = REDIS_PASSWORD,
-            cluster_fault_tolerant = false
+            fault_tolerant = false
           }
         })
       end)

--- a/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
@@ -74,7 +74,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         name = "response-ratelimiting",
         api_id = api.id,
         config = {
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -91,7 +91,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         name = "response-ratelimiting",
         api_id = api.id,
         config = {
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -118,7 +118,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         api_id = api.id,
         consumer_id = consumer1.id,
         config = {
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -135,7 +135,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         name = "response-ratelimiting",
         api_id = api.id,
         config = {
-          cluster_fault_tolerant = true,
+          fault_tolerant = true,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -152,7 +152,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         name = "response-ratelimiting",
         api_id = api.id,
         config = {
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -178,7 +178,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         name = "response-ratelimiting",
         api_id = api.id,
         config = {
-          cluster_fault_tolerant = false,
+          fault_tolerant = false,
           policy = policy,
           redis_host = REDIS_HOST,
           redis_port = REDIS_PORT,
@@ -433,7 +433,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
             name = "response-ratelimiting",
             api_id = api1.id,
             config = {
-              cluster_fault_tolerant = false,
+              fault_tolerant = false,
               policy = policy,
               redis_host = REDIS_HOST,
               redis_port = REDIS_PORT,
@@ -450,7 +450,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
             name = "response-ratelimiting",
             api_id = api2.id,
             config = {
-              cluster_fault_tolerant = true,
+              fault_tolerant = true,
               policy = policy,
               redis_host = REDIS_HOST,
               redis_port = REDIS_PORT,
@@ -547,7 +547,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
             redis_host = REDIS_HOST,
             redis_port = REDIS_PORT,
             redis_password = REDIS_PASSWORD,
-            cluster_fault_tolerant = false,
+            fault_tolerant = false,
             limits = {video = {minute = 6}}
           }
         })


### PR DESCRIPTION
### Summary

Renamed configuration property for the Rate-Limiting and Response Rate-Limiting plugins.

### Full changelog

* Renamed `cluster_fault_tolerant` to `fault_tolerant`
