### PR TITLE
fix(core) relax uuid checking to fix failing migrations

### DIFF
--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -2,7 +2,7 @@ local timestamp = require "kong.tools.timestamp"
 local Errors = require "kong.dao.errors"
 local BaseDB = require "kong.dao.base_db"
 local utils = require "kong.tools.utils"
-local uuid = require "resty.jit-uuid"
+local uuid = utils.uuid
 
 local ngx_stub = _G.ngx
 _G.ngx = nil

--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -1,7 +1,7 @@
 local BaseDB = require "kong.dao.base_db"
 local Errors = require "kong.dao.errors"
-local uuid = require "resty.jit-uuid"
 local utils = require "kong.tools.utils"
+local uuid = utils.uuid
 
 local TTL_CLEANUP_INTERVAL = 60 -- 1 minute
 

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -33,7 +33,6 @@ _G._KONG = {
 
 local core = require "kong.core.handler"
 local Serf = require "kong.serf"
-local uuid = require 'resty.jit-uuid'
 local utils = require "kong.tools.utils"
 local Events = require "kong.core.events"
 local singletons = require "kong.singletons"
@@ -145,7 +144,7 @@ function Kong.init_worker()
   -- uses LuaJIT's math.random().
   -- jit-uuid handles unique seeds for multiple workers thanks to
   -- ngx.worker.pid().
-  uuid.seed()
+  utils.uuid_seed()
 
   core.init_worker.before()
 

--- a/kong/plugins/correlation-id/handler.lua
+++ b/kong/plugins/correlation-id/handler.lua
@@ -1,10 +1,9 @@
 -- Copyright (C) Mashape, Inc.
 
 local BasePlugin = require "kong.plugins.base_plugin"
-local uuid = require "resty.jit-uuid"
 local req_set_header = ngx.req.set_header
 local req_get_headers = ngx.req.get_headers
-local uuid_v4 = uuid.generate_v4
+local uuid = require("kong.tools.utils").uuid
 
 local CorrelationIdHandler = BasePlugin:extend()
 
@@ -17,7 +16,7 @@ local worker_pid = ngx.worker.pid()
 
 local generators = setmetatable({
   ["uuid"] = function()
-    return uuid_v4()
+    return uuid()
   end,
   ["uuid#counter"] = function()
     worker_counter = worker_counter + 1
@@ -45,7 +44,7 @@ end
 
 function CorrelationIdHandler:init_worker()
   CorrelationIdHandler.super.init_worker(self)
-  worker_uuid = uuid_v4()
+  worker_uuid = uuid()
   worker_counter = 0
 end
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -55,15 +55,15 @@ end
 local v4_uuid = uuid.generate_v4
 
 --- Generates a v4 uuid.
+-- @function uuid
 -- @return string with uuid
-function _M.uuid() end -- just to trick Ldoc for documentation purposes
 _M.uuid = uuid.generate_v4
 
 --- Seeds the random generator, use with care.
 -- Kong already seeds this once per worker process. It's 
 -- dangerous to ever call it again. So ask yourself
 -- "Do I feel lucky?" Well, do ya, punk?
-function _M.uuid_seed() end -- just to trick Ldoc for documentation purposes
+-- @function uuid_seed
 _M.uuid_seed = uuid.seed
 
 --- Generates a random unique string

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -17,6 +17,7 @@ local fmt = string.format
 local type = type
 local pairs = pairs
 local ipairs = ipairs
+local re_find = ngx.re.find
 local tostring = tostring
 local table_sort = table.sort
 local table_concat = table.concat
@@ -72,16 +73,16 @@ function _M.random_string()
   return v4_uuid():gsub("-", "")
 end
 
-local digit = "[0-9a-f]"
-local uuid_pattern = "^"..table.concat({ digit:rep(8), digit:rep(4), digit:rep(4), digit:rep(4), digit:rep(12) }, '%-').."$"
-function _M.is_valid_uuid(uuid)
-  return uuid and uuid:match(uuid_pattern) ~= nil
+local uuid_regex = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+function _M.is_valid_uuid(str)
+  if type(str) ~= 'string' or #str ~= 36 then return false end
+  return re_find(str, uuid_regex, 'ioj') ~= nil
 end
 
 -- function below is more acurate, but invalidates previously accepted uuids and hence causes 
 -- trouble with existing data during migrations.
 -- see: https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
---function _M.is_valid_uuid(str)
+-- function _M.is_valid_uuid(str)
 --  return str == "00000000-0000-0000-0000-000000000000" or uuid.is_valid(str)
 --end
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -54,15 +54,36 @@ end
 
 local v4_uuid = uuid.generate_v4
 
+--- Generates a v4 uuid.
+-- @return string with uuid
+function _M.uuid() end -- just to trick Ldoc for documentation purposes
+_M.uuid = uuid.generate_v4
+
+--- Seeds the random generator, use with care.
+-- Kong already seeds this once per worker process. It's 
+-- dangerous to ever call it again. So ask yourself
+-- "Do I feel lucky?" Well, do ya, punk?
+function _M.uuid_seed() end -- just to trick Ldoc for documentation purposes
+_M.uuid_seed = uuid.seed
+
 --- Generates a random unique string
 -- @return string  The random string (a uuid without hyphens)
 function _M.random_string()
   return v4_uuid():gsub("-", "")
 end
 
-function _M.is_valid_uuid(str)
-  return str == "00000000-0000-0000-0000-000000000000" or uuid.is_valid(str)
+local digit = "[0-9a-f]"
+local uuid_pattern = "^"..table.concat({ digit:rep(8), digit:rep(4), digit:rep(4), digit:rep(4), digit:rep(12) }, '%-').."$"
+function _M.is_valid_uuid(uuid)
+  return uuid and uuid:match(uuid_pattern) ~= nil
 end
+
+-- function below is more acurate, but invalidates previously accepted uuids and hence causes 
+-- trouble with existing data during migrations.
+-- see: https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
+--function _M.is_valid_uuid(str)
+--  return str == "00000000-0000-0000-0000-000000000000" or uuid.is_valid(str)
+--end
 
 _M.split = pl_stringx.split
 _M.strip = pl_stringx.strip

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -8,9 +8,13 @@ describe("Utils", function()
 
   describe("is_valid_uuid()", function()
     it("validates UUIDs from jit-uuid", function()
-      assert.True(utils.is_valid_uuid("cbb297c0-a956-486d-ad1d-f9b42df9465a"))
-      assert.False(utils.is_valid_uuid("cbb297c0-a956-486d-dd1d-f9b42df9465a")) -- invalid variant
+      assert.True (utils.is_valid_uuid("cbb297c0-a956-486d-ad1d-f9b42df9465a"))
       assert.False(utils.is_valid_uuid("cbb297c0-a956486d-ad1d-f9b42df9465a"))
+    end)
+    pending("invalidates UUIDs with invalid variants", function()
+      -- this is disabled because existing uuids in the database fail the check upon migrations
+      -- see https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
+      assert.False(utils.is_valid_uuid("cbb297c0-a956-486d-dd1d-f9b42df9465a")) -- invalid variant
     end)
     it("considers the null UUID a valid one", function()
       -- we use the null UUID for plugins' consumer_id when none is set

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -16,6 +16,11 @@ describe("Utils", function()
       -- see https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
       assert.False(utils.is_valid_uuid("cbb297c0-a956-486d-dd1d-f9b42df9465a")) -- invalid variant
     end)
+    it("validates UUIDs with invalid variants for backwards-compatibility reasons", function()
+      -- See pending test just above  ^^
+      -- see https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
+      assert.True(utils.is_valid_uuid("cbb297c0-a956-486d-dd1d-f9b42df9465a"))
+    end)
     it("considers the null UUID a valid one", function()
       -- we use the null UUID for plugins' consumer_id when none is set
       assert.True(utils.is_valid_uuid("00000000-0000-0000-0000-000000000000"))

--- a/spec/02-integration/02-dao/04-constraints_spec.lua
+++ b/spec/02-integration/02-dao/04-constraints_spec.lua
@@ -100,10 +100,9 @@ helpers.for_each_dao(function(kong_config)
     end)
 
     describe("FOREIGN constraints", function()
-      local uuid = require "resty.jit-uuid"
 
       it("not insert plugin if invalid API foreign key", function()
-        plugin_fixture.api_id = uuid()
+        plugin_fixture.api_id = utils.uuid()
 
         local plugin, err = plugins:insert(plugin_fixture)
         assert.falsy(plugin)
@@ -115,7 +114,7 @@ helpers.for_each_dao(function(kong_config)
         local plugin_tbl = {
           name = "rate-limiting",
           api_id = api_fixture.id,
-          consumer_id = uuid(),
+          consumer_id = utils.uuid(),
           config = {minute = 1}
         }
 
@@ -132,7 +131,7 @@ helpers.for_each_dao(function(kong_config)
         assert.falsy(err)
         assert.truthy(plugin)
 
-        local fake_api_id = uuid()
+        local fake_api_id = utils.uuid()
         plugin.api_id = fake_api_id
         plugin, err = plugins:update(plugin, {id = plugin.id})
         assert.falsy(plugin)

--- a/spec/03-plugins/98-rate-limiting/02-daos_spec.lua
+++ b/spec/03-plugins/98-rate-limiting/02-daos_spec.lua
@@ -1,4 +1,4 @@
-local uuid = require "resty.jit-uuid"
+local uuid = require("kong.tools.utils").uuid
 local helpers = require "spec.helpers"
 local timestamp = require "kong.tools.timestamp"
 

--- a/spec/03-plugins/98-response-rate-limiting/02-daos_spec.lua
+++ b/spec/03-plugins/98-response-rate-limiting/02-daos_spec.lua
@@ -1,4 +1,4 @@
-local uuid = require "resty.jit-uuid"
+local uuid = require("kong.tools.utils").uuid
 local helpers = require "spec.helpers"
 local timestamp = require "kong.tools.timestamp"
 


### PR DESCRIPTION
### Summary

relax uuid checking to fix failing migrations

### Full changelog

- directs all uuid related calls through `tools.utils`
- replaces the tighter uuid validation with the older more permissive one

### Issues resolved

Fix uuid migration issues for release 0.9, see https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8

