### PR TITLE
tests(cli) add /etc/hosts resolving test cases for CLI

### DIFF
--- a/spec/02-integration/01-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/01-cmd/02-start_stop_spec.lua
@@ -101,6 +101,24 @@ describe("kong start/stop", function()
     end)
   end)
 
+  describe("/etc/hosts resolving in CLI", function()
+    -- dnsmasq is not yet started at this point and resty-cli does not include
+    -- it in its resolver directive. As such and until supported by resty-cli,
+    -- we must force the use of LuaSocket in our CLI to resolve localhost.
+    it("resolves cassandra hostname", function()
+      assert(helpers.kong_exec("start --conf "..helpers.test_conf_path, {
+        cassandra_contact_points = "localhost",
+        database = "cassandra"
+      }))
+    end)
+    it("resolves postgres hostname", function()
+      assert(helpers.kong_exec("start --conf "..helpers.test_conf_path, {
+        pg_host = "localhost",
+        database = "postgres"
+      }))
+    end)
+  end)
+
   describe("Serf", function()
     it("starts Serf agent daemon", function()
       assert(helpers.kong_exec("start --conf "..helpers.test_conf_path))


### PR DESCRIPTION
Adding test to check that both IPs and hostnames are properly supported in the DB settings when starting Kong.