### PR TITLE
Fixing the response value of /plugins/enabled

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -74,8 +74,12 @@ return {
 
   ["/plugins/enabled"] = {
     GET = function(self, dao_factory, helpers)
+      local enabled_plugins = {}
+      for k, v in pairs(singletons.configuration.plugins) do
+        if v then table.insert(enabled_plugins, k) end
+      end
       return helpers.responses.send_HTTP_OK {
-        enabled_plugins = singletons.configuration.plugins
+        enabled_plugins = enabled_plugins
       }
     end
   }

--- a/spec/02-integration/03-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/04-plugins_routes_spec.lua
@@ -21,6 +21,7 @@ describe("Admin API", function()
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
       assert.is_table(json.enabled_plugins)
+      assert.True(#json.enabled_plugins > 0)
     end)
   end)
 


### PR DESCRIPTION
The response of `/plugins/enabled` now returns a proper JSON array. This was a bug introduced with v0.9.

### Full changelog

* `/plugins/enabled` returns a JSON array like it did in < 0.9 and not a JSON object.

