### PR TITLE
fix: use OpenSSL RAND_bytes to seed math.random

### DIFF
--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -144,7 +144,7 @@ function Kong.init_worker()
   -- uses LuaJIT's math.random().
   -- jit-uuid handles unique seeds for multiple workers thanks to
   -- ngx.worker.pid().
-  utils.uuid_seed()
+  utils.randomseed()
 
   core.init_worker.before()
 


### PR DESCRIPTION
### Summary

In order to handle multi-machines or containarized setup, we'd rather
not use uuid.seed from lua-resty-jit-uuid (considering scenarios when
the number of available pids is limited and those might be reused, hence
could result in duplicated seeds).

We now use the seeding technique from lua-resty-random, since OpenSSL
already is a Kong dependency.

### Full changelog

* Add FFI bindings to `RAND_bytes`
* new `utils.randomseed` function
* log the seed being used in debug logs
* some names shortening of the globals being used