### PR TITLE
fix(tests) do not try to get migrations from non-existing Postgres DB

### DIFF
--- a/spec/02-integration/02-dao/02-migrations_spec.lua
+++ b/spec/02-integration/02-dao/02-migrations_spec.lua
@@ -20,19 +20,17 @@ helpers.for_each_dao(function(kong_config)
         assert.falsy(err)
         assert.same({}, cur_migrations)
       end)
-      it("should return empty migrations", function()
-        local invalid_conf = utils.shallow_copy(kong_config)
-        if invalid_conf.database == "cassandra" then
+      if kong_config.database == "cassandra" then
+        it("returns empty migrations on non-existing Cassandra keyspace", function()
+          local invalid_conf = utils.shallow_copy(kong_config)
           invalid_conf.cassandra_keyspace = "_inexistent_"
-        elseif invalid_conf.database == "postgres" then
-          invalid_conf.pg_database = "_inexistent_"
-        end
 
-        local xfactory = Factory(invalid_conf)
-        local cur_migrations, err = xfactory:current_migrations()
-        assert.is_nil(err)
-        assert.same({}, cur_migrations)
-      end)
+          local xfactory = Factory(invalid_conf)
+          local cur_migrations, err = xfactory:current_migrations()
+          assert.is_nil(err)
+          assert.same({}, cur_migrations)
+        end)
+      end
     end)
 
     describe("migrations_modules()", function()

--- a/spec/02-integration/03-admin_api/06-cluster_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/06-cluster_routes_spec.lua
@@ -88,7 +88,7 @@ describe("Admin API", function()
         })
         assert.res_status(200, res) -- why not 204??
 
-        ngx.sleep(1)
+        ngx.sleep(3)
 
         res = assert(client:send {
           method = "GET",


### PR DESCRIPTION
There should not be an attempt to connect to a non-existing Postgres database because that will only result in an error. This is only supported by Cassandra.