### PR TITLE
fix: no-op math.randomseed() once called by Kong

### DIFF
--- a/kong-0.9.0-0.rockspec
+++ b/kong-0.9.0-0.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "penlight == 1.3.2",
   "mediator_lua == 1.1.2",
   "lua-resty-http == 0.08",
-  "lua-resty-jit-uuid == 0.0.4",
+  "lua-resty-jit-uuid == 0.0.5",
   "multipart == 0.3",
   "version == 0.2",
   "lapis == 1.5.1",
@@ -90,6 +90,7 @@ build = {
     ["kong.core.cluster"] = "kong/core/cluster.lua",
     ["kong.core.events"] = "kong/core/events.lua",
     ["kong.core.error_handlers"] = "kong/core/error_handlers.lua",
+    ["kong.core.globalpatches"] = "kong/core/globalpatches.lua",
 
     ["kong.dao.errors"] = "kong/dao/errors.lua",
     ["kong.dao.schemas_validation"] = "kong/dao/schemas_validation.lua",

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -1,0 +1,34 @@
+local meta = require "kong.meta"
+local randomseed = math.randomseed
+
+_G._KONG = {
+  _NAME = meta._NAME,
+  _VERSION = meta._VERSION
+}
+
+local seed
+
+--- Seeds the random generator, use with care.
+-- The uuid.seed() method will create a unique seed per worker
+-- process, using a combination of both time and the worker's pid.
+-- We only allow it to be called once to prevent third-party modules
+-- from overriding our correct seed (many modules make a wrong usage
+-- of `math.randomseed()` by calling it multiple times or do not use
+-- unique seed for Nginx workers).
+-- luacheck: globals math
+_G.math.randomseed = function()
+  if ngx.get_phase() ~= "init_worker" then
+    ngx.log(ngx.ERR, "math.randomseed() must be called in init_worker")
+  elseif not seed then
+    seed = ngx.time() + ngx.worker.pid()
+    ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker n", ngx.worker.id(),
+                       " (pid: ", ngx.worker.pid(), ")")
+    randomseed(seed)
+  else
+    ngx.log(ngx.DEBUG, "attempt to seed random number generator, but ",
+                       "already seeded")
+  end
+
+  return seed
+end
+

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -24,12 +24,7 @@
 -- |[[    ]]|
 -- ==========
 
-local meta = require "kong.meta"
-
-_G._KONG = {
-  _NAME = meta._NAME,
-  _VERSION = meta._VERSION
-}
+require "kong.core.globalpatches"
 
 local core = require "kong.core.handler"
 local Serf = require "kong.serf"
@@ -139,12 +134,11 @@ function Kong.init()
 end
 
 function Kong.init_worker()
-  -- it is very important to seed this module in the init_worker phase
-  -- to avoid duplicated UUID sequences accross workers since jit-uuid
-  -- uses LuaJIT's math.random().
-  -- jit-uuid handles unique seeds for multiple workers thanks to
-  -- ngx.worker.pid().
-  utils.uuid_seed()
+  -- special math.randomseed from kong.core.globalpatches
+  -- not taking any argument. Must be called only once
+  -- and in the init_worker phase, to avoid duplicated
+  -- seeds.
+  math.randomseed()
 
   core.init_worker.before()
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -9,20 +9,22 @@
 -- @module kong.tools.utils
 
 local url = require "socket.url"
+local ffi = require "ffi"
 local uuid = require "resty.jit-uuid"
 local pl_stringx = require "pl.stringx"
-local ffi = require "ffi"
 
-local fmt = string.format
-local type = type
-local pairs = pairs
-local ipairs = ipairs
-local re_find = ngx.re.find
-local tostring = tostring
-local table_sort = table.sort
-local table_concat = table.concat
-local table_insert = table.insert
-local string_find = string.find
+local C          = ffi.C
+local fmt        = string.format
+local type       = type
+local pairs      = pairs
+local ipairs     = ipairs
+local re_find    = ngx.re.find
+local tostring   = tostring
+local sort       = table.sort
+local concat     = table.concat
+local insert     = table.insert
+local find       = string.find
+local gsub       = string.gsub
 
 ffi.cdef[[
 int gethostname(char *name, size_t len);
@@ -34,7 +36,6 @@ local _M = {}
 -- @return string  The hostname
 function _M.get_hostname()
   local result
-  local C = ffi.C
   local SIZE = 128
 
   local buf = ffi.new("unsigned char[?]", SIZE)
@@ -42,12 +43,12 @@ function _M.get_hostname()
 
   if res == 0 then
     local hostname = ffi.string(buf, SIZE)
-    result = string.gsub(hostname, "%z+$", "")
+    result = gsub(hostname, "%z+$", "")
   else
-    local f = io.popen ("/bin/hostname")
+    local f = io.popen("/bin/hostname")
     local hostname = f:read("*a") or ""
     f:close()
-    result = string.gsub(hostname, "\n$", "")
+    result = gsub(hostname, "\n$", "")
   end
 
   return result
@@ -59,13 +60,6 @@ local v4_uuid = uuid.generate_v4
 -- @function uuid
 -- @return string with uuid
 _M.uuid = uuid.generate_v4
-
---- Seeds the random generator, use with care.
--- Kong already seeds this once per worker process. It's 
--- dangerous to ever call it again. So ask yourself
--- "Do I feel lucky?" Well, do ya, punk?
--- @function uuid_seed
-_M.uuid_seed = uuid.seed
 
 --- Generates a random unique string
 -- @return string  The random string (a uuid without hyphens)
@@ -79,7 +73,7 @@ function _M.is_valid_uuid(str)
   return re_find(str, uuid_regex, 'ioj') ~= nil
 end
 
--- function below is more acurate, but invalidates previously accepted uuids and hence causes 
+-- function below is more acurate, but invalidates previously accepted uuids and hence causes
 -- trouble with existing data during migrations.
 -- see: https://github.com/thibaultcha/lua-resty-jit-uuid/issues/8
 -- function _M.is_valid_uuid(str)
@@ -125,7 +119,7 @@ function _M.encode_args(args, raw)
     keys[#keys+1] = k
   end
 
-  table_sort(keys)
+  sort(keys)
 
   for _, key in ipairs(keys) do
     local value = args[key]
@@ -145,7 +139,7 @@ function _M.encode_args(args, raw)
     end
   end
 
-  return table_concat(query, "&")
+  return concat(query, "&")
 end
 
 --- Checks whether a request is https or was originally https (but already terminated).
@@ -278,7 +272,7 @@ function _M.add_error(errors, k, v)
       errors[k] = setmetatable({errors[k]}, err_list_mt)
     end
 
-    table_insert(errors[k], v)
+    insert(errors[k], v)
   else
     errors[k] = v
   end
@@ -297,7 +291,7 @@ function _M.load_module_if_exists(module_name)
   if status then
     return true, res
   -- Here we match any character because if a module has a dash '-' in its name, we would need to escape it.
-  elseif type(res) == "string" and string_find(res, "module '"..module_name.."' not found", nil, true) then
+  elseif type(res) == "string" and find(res, "module '"..module_name.."' not found", nil, true) then
     return false, res
   else
     error(res)


### PR DESCRIPTION
### Summary

This replaces #1554, since the improved seeding technique was not an
appropriate fix. To this point, I do not think it is worth investing in such a
complex seeding technique as the root of the issue really was the 
continuous use of `math.randomseed()` by one of Lapis' utilities.
 
### Changes

* Disable (or rather, no-op) `math.randomseed()` to prevent
third-party modules from overriding our correct seed (many modules
make a wrong usage of `math.randomseed()` by calling it multiple times
or do not use unique seed for Nginx workers.
* Bump lua-resty-jit-uuid version to include `uuid.seed()` changes
* Shorten the name of some of our cached variables

---

Update:

fix: patch math.randomseed() to prevent invalid calls  …
Patch `math.random` to prevent it from being called by another context
than init_worker, and especially to prevent it from being called
multiple times. It is being patched very early in Kong's runtime so
we're sure no other module has time to cache the original `math.random`
function.

* implement a `globalpatches.lua` module for modifying `_G`.
* seed in init_worker with `math.randomseed`