### PR TITLE
fix(core) returning appropriate headers in error pages

### DIFF
--- a/kong/core/error_handlers.lua
+++ b/kong/core/error_handlers.lua
@@ -12,6 +12,13 @@ local xml_template = '<?xml version="1.0" encoding="UTF-8"?>\n<error><message>%s
 local html_template = '<html><head><title>Kong Error</title></head><body><h1>Kong Error</h1><p>%s.</p></body></html>'
 
 local BODIES = {
+  s404 = "Not found",
+  s408 = "Request timeout",
+  s411 = "Length required",
+  s412 = "Precondition failed",
+  s413 = "Payload too large",
+  s414 = "URI too long",
+  s417 = "Expectation failed",
   s500 = "An unexpected error occurred",
   s502 = "An invalid response was received from the upstream server",
   s503 = "The upstream server is currently unavailable",

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -60,7 +60,8 @@ init_worker_by_lua_block {
 server {
     server_name kong;
     listen ${{PROXY_LISTEN}};
-    error_page 500 502 503 504 /50x;
+    error_page 404 408 411 412 413 414 417 /kong_error_handler;
+    error_page 500 502 503 504 /kong_error_handler;
 
 > if ssl then
     listen ${{PROXY_LISTEN_SSL}} ssl;
@@ -100,7 +101,7 @@ server {
         }
     }
 
-    location = /50x {
+    location = /kong_error_handler {
         internal;
         content_by_lua_block {
             require('kong.core.error_handlers')(ngx)

--- a/spec/02-integration/05-proxy/01-resolver_spec.lua
+++ b/spec/02-integration/05-proxy/01-resolver_spec.lua
@@ -358,5 +358,6 @@ describe("Resolver", function()
       }
     })
     assert.res_status(414, res)
+    assert.match(meta._NAME.."/"..meta._VERSION, res.headers["server"])
   end)
 end)


### PR DESCRIPTION
### Full changelog

* Properly return the correct Kong headers on 40x and 50x errors.

### Issues resolved

Fix #1552 and #1553.
