### PR TITLE
feat(plugins) extended plugins API to query by specific relevant field

### DIFF
--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -1,4 +1,5 @@
 local crud = require "kong.api.crud_helpers"
+local utils = require "kong.tools.utils"
 
 return{
   ["/consumers/:username_or_id/hmac-auth/"] = {
@@ -20,18 +21,26 @@ return{
     end
   },
 
-  ["/consumers/:username_or_id/hmac-auth/:id"]  = {
+  ["/consumers/:username_or_id/hmac-auth/:credential_username_or_id"]  = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
 
-      local err
-      self.hmacauth_credential, err = dao_factory.hmacauth_credentials:find(self.params)
+
+      local filter_keys = {
+        [utils.is_valid_uuid(self.params.credential_username_or_id) and "id" or "username"] = self.params.credential_username_or_id,
+        consumer_id = self.params.consumer_id,
+      }
+      self.params.credential_username_or_id = nil
+
+      local credentials, err = dao_factory.hmacauth_credentials:find_all(filter_keys)
       if err then
         return helpers.yield_error(err)
-      elseif self.hmacauth_credential == nil then
+      elseif next(credentials) == nil then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
+
+      self.hmacauth_credential = credentials[1]
     end,
 
     GET = function(self, dao_factory, helpers)

--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -1,4 +1,5 @@
 local crud = require "kong.api.crud_helpers"
+local utils = require "kong.tools.utils"
 
 return {
   ["/consumers/:username_or_id/jwt/"] = {
@@ -20,18 +21,25 @@ return {
     end
   },
 
-  ["/consumers/:username_or_id/jwt/:id"] = {
+  ["/consumers/:username_or_id/jwt/:credential_key_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
 
-      local err
-      self.jwt_secret, err = dao_factory.jwt_secrets:find(self.params)
+      local filter_keys = {
+        [utils.is_valid_uuid(self.params.credential_key_or_id) and "id" or "key"] = self.params.credential_key_or_id,
+        consumer_id = self.params.consumer_id,
+      }
+      self.params.credential_key_or_id = nil
+
+      local credentials, err = dao_factory.jwt_secrets:find_all(filter_keys)
       if err then
         return helpers.yield_error(err)
-      elseif self.jwt_secret == nil then
+      elseif next(credentials) == nil then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
+
+      self.jwt_secret = credentials[1]
     end,
 
     GET = function(self, dao_factory, helpers)

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -1,4 +1,5 @@
 local crud = require "kong.api.crud_helpers"
+local utils = require "kong.tools.utils"
 
 return {
   ["/consumers/:username_or_id/key-auth/"] = {
@@ -19,15 +20,18 @@ return {
       crud.post(self.params, dao_factory.keyauth_credentials)
     end
   },
-  ["/consumers/:username_or_id/key-auth/:id"] = {
+  ["/consumers/:username_or_id/key-auth/:credential_key_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
 
-      local credentials, err = dao_factory.keyauth_credentials:find_all {
+      local filter_keys = {
+        [utils.is_valid_uuid(self.params.credential_key_or_id) and "id" or "key"] = self.params.credential_key_or_id,
         consumer_id = self.params.consumer_id,
-        id = self.params.id
       }
+      self.params.credential_key_or_id = nil
+
+      local credentials, err = dao_factory.keyauth_credentials:find_all(filter_keys)
       if err then
         return helpers.yield_error(err)
       elseif next(credentials) == nil then

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -1,4 +1,5 @@
 local crud = require "kong.api.crud_helpers"
+local utils = require "kong.tools.utils"
 
 return {
   ["/oauth2_tokens/"] = {
@@ -15,21 +16,34 @@ return {
     end
   },
 
-  ["/oauth2_tokens/:id"] = {
-    GET = function(self, dao_factory)
-      crud.get(self.params, dao_factory.oauth2_tokens)
+  ["/oauth2_tokens/:token_or_id"] = {
+    before = function(self, dao_factory, helpers)
+      local filter_keys = {
+        [utils.is_valid_uuid(self.params.token_or_id) and "id" or "access_token"] = self.params.token_or_id,
+        consumer_id = self.params.consumer_id,
+      }
+      self.params.token_or_id = nil
+
+      local credentials, err = dao_factory.oauth2_tokens:find_all(filter_keys)
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.oauth2_token = credentials[1]
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.oauth2_token)
     end,
 
     PATCH = function(self, dao_factory)
-      crud.patch(self.params, dao_factory.oauth2_tokens, self.params)
-    end,
-
-    PUT = function(self, dao_factory)
-      crud.put(self.params, dao_factory.oauth2_tokens)
+      crud.patch(self.params, dao_factory.oauth2_tokens, self.oauth2_token)
     end,
 
     DELETE = function(self, dao_factory)
-      crud.delete(self.params, dao_factory.oauth2_tokens)
+      crud.delete(self.oauth2_token, dao_factory.oauth2_tokens)
     end
   },
 
@@ -58,15 +72,18 @@ return {
     end
   },
 
-  ["/consumers/:username_or_id/oauth2/:id"] = {
+  ["/consumers/:username_or_id/oauth2/:clientid_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
 
-      local credentials, err = dao_factory.oauth2_credentials:find_all {
+      local filter_keys = {
+        [utils.is_valid_uuid(self.params.clientid_or_id) and "id" or "client_id"] = self.params.clientid_or_id,
         consumer_id = self.params.consumer_id,
-        id = self.params.id
       }
+      self.params.clientid_or_id = nil
+
+      local credentials, err = dao_factory.oauth2_credentials:find_all(filter_keys)
       if err then
         return helpers.yield_error(err)
       elseif next(credentials) == nil then
@@ -76,16 +93,16 @@ return {
       self.oauth2_credential = credentials[1]
     end,
 
-    GET = function(self, dao_factory)
-      crud.get(self.params, dao_factory.oauth2_credentials)
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.oauth2_credential)
     end,
 
     PATCH = function(self, dao_factory)
-      crud.patch(self.params, dao_factory.oauth2_credentials, self.params)
+      crud.patch(self.params, dao_factory.oauth2_credentials, self.oauth2_credential)
     end,
 
     DELETE = function(self, dao_factory)
-      crud.delete(self.params, dao_factory.oauth2_credentials)
+      crud.delete(self.oauth2_credential, dao_factory.oauth2_credentials)
     end
   }
 }

--- a/spec/03-plugins/02-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/02-key-auth/01-api_spec.lua
@@ -151,6 +151,15 @@ describe("Plugin: key-auth (API)", function()
         local json = cjson.decode(body)
         assert.equal(credential.id, json.id)
       end)
+      it("retrieves key-auth credential by key", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/consumers/bob/key-auth/"..credential.key
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(credential.id, json.id)
+      end)
       it("retrieves credential by id only if the credential belongs to the specified consumer", function()
         assert(helpers.dao.consumers:insert {
           username = "alice"
@@ -171,7 +180,7 @@ describe("Plugin: key-auth (API)", function()
     end)
 
     describe("PATCH", function()
-      it("updates a credential", function()
+      it("updates a credential by id", function()
         local res = assert(admin_client:send {
           method = "PATCH",
           path = "/consumers/bob/key-auth/"..credential.id,
@@ -185,6 +194,21 @@ describe("Plugin: key-auth (API)", function()
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.equal("4321", json.key)
+      end)
+      it("updates a credential by key", function()
+        local res = assert(admin_client:send {
+          method = "PATCH",
+          path = "/consumers/bob/key-auth/"..credential.key,
+          body = {
+            key = "4321UPD"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("4321UPD", json.key)
       end)
       describe("errors", function()
         it("handles invalid input", function()
@@ -218,7 +242,7 @@ describe("Plugin: key-auth (API)", function()
             method = "DELETE",
             path = "/consumers/bob/key-auth/blah"
           })
-          assert.res_status(400, res)
+          assert.res_status(404, res)
         end)
         it("returns 404 if not found", function()
           local res = assert(admin_client:send {

--- a/spec/03-plugins/06-jwt/02-api_spec.lua
+++ b/spec/03-plugins/06-jwt/02-api_spec.lua
@@ -194,10 +194,17 @@ describe("Plugin: jwt (API)", function()
         })
         assert.res_status(200, res)
       end)
+      it("retrieves by key", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/consumers/bob/jwt/"..jwt_secret.key,
+        })
+        assert.res_status(200, res)
+      end)
     end)
 
     describe("PATCH", function()
-      it("updates a credential", function()
+      it("updates a credential by id", function()
         local res = assert(admin_client:send {
           method = "PATCH",
           path = "/consumers/bob/jwt/"..jwt_secret.id,
@@ -212,6 +219,22 @@ describe("Plugin: jwt (API)", function()
         local body = assert.res_status(200, res)
         jwt_secret = cjson.decode(body)
         assert.equal("newsecret", jwt_secret.secret)
+      end)
+      it("updates a credential by key", function()
+        local res = assert(admin_client:send {
+          method = "PATCH",
+          path = "/consumers/bob/jwt/"..jwt_secret.key,
+          body = {
+            key = "alice",
+            secret = "newsecret2"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = assert.res_status(200, res)
+        jwt_secret = cjson.decode(body)
+        assert.equal("newsecret2", jwt_secret.secret)
       end)
     end)
 
@@ -236,7 +259,7 @@ describe("Plugin: jwt (API)", function()
             ["Content-Type"] = "application/json"
           }
         })
-        assert.res_status(400, res)
+        assert.res_status(404, res)
 
        local res = assert(admin_client:send {
           method = "DELETE",

--- a/spec/03-plugins/06-jwt/03-access_spec.lua
+++ b/spec/03-plugins/06-jwt/03-access_spec.lua
@@ -165,9 +165,9 @@ describe("Plugin: jwt (access)", function()
       PAYLOAD.iss = base64_jwt_secret.key
       local original_secret = base64_jwt_secret.secret
       local base64_secret = ngx.encode_base64(base64_jwt_secret.secret)
-      assert(admin_client:send {
+      local res = assert(admin_client:send {
         method = "PATCH",
-        path = "/consumers/jwt_tests_consumer/jwt/"..base64_jwt_secret.id,
+        path = "/consumers/jwt_tests_base64_consumer/jwt/"..base64_jwt_secret.id,
         body = {
           key = base64_jwt_secret.key,
           secret = base64_secret},
@@ -175,6 +175,7 @@ describe("Plugin: jwt (access)", function()
           ["Content-Type"] = "application/json"
         }
       })
+      assert.res_status(200, res)
 
       local jwt = jwt_encoder.encode(PAYLOAD, original_secret)
       local authorization = "Bearer "..jwt
@@ -188,7 +189,7 @@ describe("Plugin: jwt (access)", function()
       })
       local body = cjson.decode(assert.res_status(200, res))
       assert.equal(authorization, body.headers.authorization)
-      assert.equal("jwt_tests_consumer", body.headers["x-consumer-username"])
+      assert.equal("jwt_tests_base64_consumer", body.headers["x-consumer-username"])
     end)
     it("finds the JWT if given in URL parameters", function()
       PAYLOAD.iss = jwt_secret.key

--- a/spec/03-plugins/09-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/09-hmac-auth/02-api_spec.lua
@@ -106,10 +106,21 @@ describe("Plugin: hmac-auth (API)", function()
         local body = cjson.decode(body_json)
         assert.equals(credential.id, body.id)
       end)
+      it("should retrieve by username", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/consumers/bob/hmac-auth/"..credential.username,
+          body = {},
+          headers = {["Content-Type"] = "application/json"}
+        })
+        local body_json = assert.res_status(200, res)
+        local body = cjson.decode(body_json)
+        assert.equals(credential.id, body.id)
+      end)
     end)
 
     describe("PATCH", function()
-      it("[SUCCESS] should update a credential", function()
+      it("[SUCCESS] should update a credential by id", function()
         local res = assert(client:send {
           method = "PATCH",
           path = "/consumers/bob/hmac-auth/"..credential.id,
@@ -119,6 +130,17 @@ describe("Plugin: hmac-auth (API)", function()
         local body_json = assert.res_status(200, res)
         credential = cjson.decode(body_json)
         assert.equals("alice", credential.username)
+      end)
+      it("[SUCCESS] should update a credential by username", function()
+        local res = assert(client:send {
+          method = "PATCH",
+          path = "/consumers/bob/hmac-auth/"..credential.username,
+          body = {username = "aliceUPD"},
+          headers = {["Content-Type"] = "application/json"}
+        })
+        local body_json = assert.res_status(200, res)
+        credential = cjson.decode(body_json)
+        assert.equals("aliceUPD", credential.username)
       end)
       it("[FAILURE] should return proper errors", function()
         local res = assert(client:send {
@@ -136,11 +158,11 @@ describe("Plugin: hmac-auth (API)", function()
       it("[FAILURE] should return proper errors", function()
         local res = assert(client:send {
           method = "DELETE",
-          path = "/consumers/bob/hmac-auth/alice",
+          path = "/consumers/bob/hmac-auth/aliceasd",
           body = {},
           headers = {["Content-Type"] = "application/json"}
         })
-        assert.res_status(400, res)
+        assert.res_status(404, res)
 
         local res = assert(client:send {
           method = "DELETE",


### PR DESCRIPTION
### Summary

Extends the plugins API to make queries easier. The ACL plugin has been already extended with #1544.

### Full changelog

* Extended Basic-Auth API to query credentials by `username`.
* Extended HMAC-Auth API to query credentials by `username`.
* Extended JWT API to query credentials by `key`.
* Extended Key-Auth API to query credentials by `key`.
* Extended OAuth2 API to query credentials by `client_id` and tokens by `access_token`.
