### PR TITLE
add ldap-acl plugin to integrate acl and ldap-auth

### DIFF
--- a/kong-0.9.1-0.rockspec
+++ b/kong-0.9.1-0.rockspec
@@ -261,5 +261,9 @@ build = {
     ["kong.plugins.bot-detection.rules"] = "kong/plugins/bot-detection/rules.lua",
     ["kong.plugins.bot-detection.cache"] = "kong/plugins/bot-detection/cache.lua",
     ["kong.plugins.bot-detection.hooks"] = "kong/plugins/bot-detection/hooks.lua",
+
+    ["kong.plugins.ldap-acl.bind_consumer"] = "kong/plugins/ldap-acl/bind_consumer.lua",
+    ["kong.plugins.ldap-acl.handler"] = "kong/plugins/ldap-acl/handler.lua",
+    ["kong.plugins.ldap-acl.schema"] = "kong/plugins/ldap-acl/schema.lua",
   }
 }

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -3,7 +3,7 @@ local plugins = {
   "file-log", "http-log", "key-auth", "hmac-auth", "basic-auth", "ip-restriction",
   "galileo", "request-transformer", "response-transformer",
   "request-size-limiting", "rate-limiting", "response-ratelimiting", "syslog",
-  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection"
+  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection", "ldap-acl"
 }
 
 local plugin_map = {}

--- a/kong/plugins/ldap-acl/bind_consumer.lua
+++ b/kong/plugins/ldap-acl/bind_consumer.lua
@@ -1,0 +1,17 @@
+local BindConsumer = { dao = nil }
+
+function BindConsumer:new(o)
+  o = o or {} -- create object if user does not provide one
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function BindConsumer.bind(self, username)
+  local consumers = self.dao:find_all { username = username }
+  if consumers then
+    return consumers[1]
+  end
+end
+
+return BindConsumer

--- a/kong/plugins/ldap-acl/handler.lua
+++ b/kong/plugins/ldap-acl/handler.lua
@@ -1,0 +1,41 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local BindConsumer = require "kong.plugins.ldap-acl.bind_consumer"
+local cache = require "kong.tools.database_cache"
+local responses = require "kong.tools.responses"
+local singletons = require "kong.singletons"
+
+local LdapAclHandler = BasePlugin:extend()
+
+function LdapAclHandler:new()
+  LdapAclHandler.super.new(self, "ldap-acl")
+end
+
+function LdapAclHandler:access(conf)
+  LdapAclHandler.super.access(self)
+
+  local ldap_authorization = ngx.ctx.authenticated_credential
+
+  if not ldap_authorization then
+    return responses.send_HTTP_UNAUTHORIZED()
+  end
+
+  if not ldap_authorization.username then
+    return responses.send_HTTP_UNAUTHORIZED()
+  end
+
+  local bind_consumer = BindConsumer:new { dao = singletons.dao.consumers, cache = cache }
+
+  ngx.log(ngx.DEBUG, "[ldap-acl] bind username between ldap and consumer: ", ldap_authorization.username)
+  local consumer = BindConsumer.bind(bind_consumer, ldap_authorization.username)
+
+  if not consumer then
+    ngx.log(ngx.ERR, "[ldap-acl] consumer was not found by ldap user: ", ldap_authorization.username)
+    return responses.send_HTTP_UNAUTHORIZED()
+  end
+
+  ldap_authorization.consumer_id = consumer.id
+end
+
+LdapAclHandler.PRIORITY = 999
+
+return LdapAclHandler

--- a/kong/plugins/ldap-acl/schema.lua
+++ b/kong/plugins/ldap-acl/schema.lua
@@ -1,0 +1,5 @@
+return {
+  fields = {
+    cache_ttl = {required = true, type = "number", default = 60},
+  }
+}

--- a/kong/tools/database_cache.lua
+++ b/kong/tools/database_cache.lua
@@ -20,6 +20,7 @@ local CACHE_KEYS = {
   TIMERS = "timers",
   ALL_APIS_BY_DIC = "ALL_APIS_BY_DIC",
   LDAP_CREDENTIAL = "ldap_credentials",
+  LDAP_BIND_CONSUMER = "ldap_bind_consumers",
   BOT_DETECTION = "bot_detection"
 }
 
@@ -108,6 +109,10 @@ end
 
 function _M.ldap_credential_key(username)
   return CACHE_KEYS.LDAP_CREDENTIAL.."/"..username
+end
+
+function _M.ldap_bind_consumer(username)
+  return CACHE_KEYS.LDAP_BIND_CONSUMER..":"..username
 end
 
 function _M.acls_key(consumer_id)

--- a/spec/01-unit/11-database_cache_spec.lua
+++ b/spec/01-unit/11-database_cache_spec.lua
@@ -31,4 +31,8 @@ describe("Database cache", function()
     assert.are.equal("requests", cache.requests_key())
   end)
 
+  it("returns a valid LdapBindConsumer cache key", function()
+    assert.are.equal("ldap_bind_consumers:username", cache.ldap_bind_consumer("username"))
+  end)
+
 end)

--- a/spec/03-plugins/17-ldap-acl/01-bind_consumer_spec.lua
+++ b/spec/03-plugins/17-ldap-acl/01-bind_consumer_spec.lua
@@ -1,0 +1,41 @@
+local helpers = require "spec.helpers"
+
+describe('Plugin: ldap-acl consumer unit tests', function()
+  local consumer1 = { username = 'consumer1' }
+  local consumers
+  setup(function()
+    consumers = {
+      [1] = consumer1
+    }
+  end)
+  teardown(function()
+    helpers.dao:truncate_tables()
+  end)
+  describe('should be find consumer from ldap user', function()
+    it('retrieve a consumer by username', function()
+
+      local dao = helpers.dao.consumers
+      stub(dao, 'find_all').returns(consumers)
+
+      local BindConsumer = require('kong.plugins.ldap-acl.bind_consumer')
+      local bind_consumer = BindConsumer:new { dao = dao }
+
+      local consumer = bind_consumer.bind(bind_consumer, 'consumer1')
+
+      assert.is_not_nil(consumer)
+      assert.are.equals(consumer1.username, consumer.username)
+    end)
+    it('failed on retrieve a consumer by username', function()
+
+      local dao = helpers.dao.consumers
+      stub(dao, 'find_all').returns({})
+
+      local BindConsumer = require('kong.plugins.ldap-acl.bind_consumer')
+      local bind_consumer = BindConsumer:new { dao = dao }
+
+      local consumer = bind_consumer.bind(bind_consumer, 'no_bind')
+
+      assert.is_nil(consumer)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

This `ldap-acl` plugin is a glue between `ldap-auth` and `acl` plugins.
It will find `consumer_id` by ldap username and append it on `ngx.ctx.authenticated_credential`, because `ldap-auth` plugin doesn't have a link with kong consumers.
#### Requirements
- sync all ldap users into kong consumers
- enable and configure `ldap-auth` and `acl` plugins
### Full changelog
- add `ldap-acl` makes `ldap-auth` and `acl` working togheter
### Issues resolved

Fix #1439 
