### PR TITLE
fix(postgres) use pgmoon-mashape 2.0.0

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -3,7 +3,7 @@
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523
-for _, namespace in ipairs({"cassandra", "pgmoon"}) do
+for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
   local socket = require(namespace .. ".socket")
   socket.force_luasocket(ngx.get_phase(), true)
 end

--- a/bin/kong
+++ b/bin/kong
@@ -3,7 +3,7 @@
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523
-for _, namespace in ipairs({"cassandra", "pgmoon"}) do
+for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
   local socket = require(namespace .. ".socket")
   socket.force_luasocket(ngx.get_phase(), true)
 end

--- a/kong-0.9.0-0.rockspec
+++ b/kong-0.9.0-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "version == 0.2",
   "lapis == 1.5.1",
   "lua-cassandra == 0.5.3",
-  "pgmoon-mashape == 1.7.0",
+  "pgmoon-mashape == 2.0.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.1",
   "lua-resty-iputils == 0.2.1",

--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -1,14 +1,10 @@
+local pgmoon = require "pgmoon-mashape"
 local BaseDB = require "kong.dao.base_db"
 local Errors = require "kong.dao.errors"
 local utils = require "kong.tools.utils"
 local uuid = utils.uuid
 
 local TTL_CLEANUP_INTERVAL = 60 -- 1 minute
-
-local ngx_stub = _G.ngx
-_G.ngx = nil
-local pgmoon = require "pgmoon"
-_G.ngx = ngx_stub
 
 local PostgresDB = BaseDB:extend()
 


### PR DESCRIPTION
This fixes a namespace issue where lapis' pgmoon dependency would
override Mashape's pgmoon fork source code and lead to issues as
`pgmoon.socket` would not be used properly.