### PR TITLE
fix(cli) stop all services when Kong cannot start

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -225,6 +225,7 @@ local function tcp_server(port, ...)
     function(port)
       local socket = require "socket"
       local server = assert(socket.tcp())
+      server:settimeout(10)
       assert(server:setoption('reuseaddr', true))
       assert(server:bind("*", port))
       assert(server:listen())


### PR DESCRIPTION
### Summary

Stop services on failure to `start`/`restart`. 

### Full changelog

- use an xpcall to catch errors and stop all services from there (no
  error checking)
- new test for this behavior

Fix #1530