### PR TITLE
patch the global tcp.connect function to use the internal dns resolver

### DIFF
--- a/kong/plugins/galileo/buffer.lua
+++ b/kong/plugins/galileo/buffer.lua
@@ -21,7 +21,6 @@
 
 local alf_serializer = require "kong.plugins.galileo.alf"
 local http = require "resty.http"
-local connect = require("kong.singletons").dns.connect
 
 local setmetatable = setmetatable
 local timer_at = ngx.timer.at
@@ -112,7 +111,7 @@ _send = function(premature, self, to_send)
   local client = http.new()
   client:set_timeout(self.connection_timeout)
 
-  local ok, err = connect(client, self.host, self.port)
+  local ok, err = client:connect(self.host, self.port)
   if not ok then
     retry = true
     log(ERR, "could not connect to Galileo collector: ", err)

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -2,7 +2,6 @@ local basic_serializer = require "kong.plugins.log-serializers.basic"
 local BasePlugin = require "kong.plugins.base_plugin"
 local cjson = require "cjson"
 local url = require "socket.url"
-local connect = require("kong.singletons").dns.connect
 
 local HttpLogHandler = BasePlugin:extend()
 
@@ -55,7 +54,7 @@ local function log(premature, conf, body, name)
   local sock = ngx.socket.tcp()
   sock:settimeout(conf.timeout)
 
-  ok, err = connect(sock, host, port)
+  ok, err = sock:connect(host, port)
   if not ok then
     ngx.log(ngx.ERR, name.."failed to connect to "..host..":"..tostring(port)..": ", err)
     return

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -1,4 +1,3 @@
-local singletons = require "kong.singletons"
 local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local cache = require "kong.tools.database_cache"
@@ -12,7 +11,6 @@ local ngx_debug = ngx.DEBUG
 local decode_base64 = ngx.decode_base64
 local ngx_socket_tcp = ngx.socket.tcp
 local tostring =  tostring
-local connect = singletons.dns.connect
 
 local AUTHORIZATION = "authorization"
 local PROXY_AUTHORIZATION = "proxy-authorization"
@@ -40,7 +38,7 @@ local function ldap_authenticate(given_username, given_password, conf)
   local sock = ngx_socket_tcp()
   sock:settimeout(conf.timeout)
   
-  ok, error = connect(sock, conf.ldap_host, conf.ldap_port)
+  ok, error = sock:connect(conf.ldap_host, conf.ldap_port)
   if not ok then
     ngx_log(ngx_error, "[ldap-auth] failed to connect to "..conf.ldap_host..":"..tostring(conf.ldap_port)..": ", error)
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(error)

--- a/kong/plugins/rate-limiting/policies.lua
+++ b/kong/plugins/rate-limiting/policies.lua
@@ -65,7 +65,7 @@ return {
     increment = function(conf, api_id, identifier, current_timestamp, value)
       local red = redis:new()
       red:set_timeout(conf.redis_timeout)
-      local ok, err = connect(red, conf.redis_host, conf.redis_port)
+      local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
         return
@@ -110,7 +110,7 @@ return {
     usage = function(conf, api_id, identifier, current_timestamp, name)
       local red = redis:new()
       red:set_timeout(conf.redis_timeout)
-      local ok, err = connect(red, conf.redis_host, conf.redis_port)
+      local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
         return

--- a/kong/plugins/response-ratelimiting/policies.lua
+++ b/kong/plugins/response-ratelimiting/policies.lua
@@ -3,7 +3,6 @@ local timestamp = require "kong.tools.timestamp"
 local cache = require "kong.tools.database_cache"
 local redis = require "resty.redis"
 local ngx_log = ngx.log
-local connect = require("kong.singletons").dns.connect
 
 local pairs = pairs
 local fmt = string.format
@@ -66,7 +65,7 @@ return {
     increment = function(conf, api_id, identifier, current_timestamp, value, name)
       local red = redis:new()
       red:set_timeout(conf.redis_timeout)
-      local ok, err = connect(red, conf.redis_host, conf.redis_port)
+      local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
         return
@@ -111,7 +110,7 @@ return {
     usage = function(conf, api_id, identifier, current_timestamp, period, name)
       local red = redis:new()
       red:set_timeout(conf.redis_timeout)
-      local ok, err = connect(red, conf.redis_host, conf.redis_port)
+      local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
         return

--- a/kong/plugins/runscope/log.lua
+++ b/kong/plugins/runscope/log.lua
@@ -1,6 +1,5 @@
 local cjson = require "cjson"
 local url = require "socket.url"
-local connect = require("kong.singletons").dns.connect
 
 local _M = {}
 
@@ -60,7 +59,7 @@ local function log(premature, conf, message)
   local sock = ngx.socket.tcp()
   sock:settimeout(conf.timeout)
 
-  ok, err = connect(sock, host, port)
+  ok, err = sock:connect(host, port)
   if not ok then
     ngx_log(ngx_log_ERR, "[runscope] failed to connect to "..host..":"..tostring(port)..": ", err)
     return

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -1,8 +1,6 @@
 local BasePlugin = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
-local singletons = require "kong.singletons"
-local connect = singletons.dns.connect
 
 local TcpLogHandler = BasePlugin:extend()
 
@@ -18,7 +16,7 @@ local function log(premature, conf, message)
   local sock = ngx.socket.tcp()
   sock:settimeout(timeout)
 
-  ok, err = connect(sock, host, port)
+  ok, err = sock:connect(host, port)
   if not ok then
     ngx.log(ngx.ERR, "[tcp-log] failed to connect to "..host..":"..tostring(port)..": ", err)
     return


### PR DESCRIPTION
implements global patch to wrap tcp sockets `connect` function into one that resolves using the internal dns client.