### PR TITLE
fix(conf) fallback for lack of value for var placeholders

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -177,7 +177,7 @@ local function compile_conf(kong_config, conf_template)
   local post_template = pl_template.substitute(conf_template, compile_env)
   return string.gsub(post_template, "(${%b{}})", function(w)
     local name = w:sub(4, -3)
-    return compile_env[name:lower()]
+    return compile_env[name:lower()] or ""
   end)
 end
 


### PR DESCRIPTION
In the case when `anonymous_reports=on` + `socket.toip` is not 
resolving (ex: no internet connection) Nginx would be started with an 
invalid configuration file because Kong's nginx config template would have an untouched
`${{SYSLOG_REPORTS}}` placeholder left. See `prefix_handker.lua`'s `compile_conf()` function.

This ensures that by default, some of those variables (holding the directive name + value) are at least removed from the template before starting.