### PR TITLE
fix(cli) include version information in debug and verbose logging

### DIFF
--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -1,5 +1,6 @@
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
+local meta = require "kong.meta"
 
 local options = [[
  --v         verbose
@@ -77,6 +78,11 @@ return function(args)
     log.set_lvl(log.levels.debug)
     args.trace = true
   end
+
+  log.verbose("Kong: %s", meta._VERSION)
+  log.debug("ngx_lua: %s", ngx.config.ngx_lua_version)
+  log.debug("nginx: %s", ngx.config.nginx_version)
+  log.debug("Lua: %s", jit and jit.version or _VERSION)
 
   xpcall(function() cmd_exec(args) end, function(err)
     if not args.trace then


### PR DESCRIPTION
### Summary

adds version information to the cli output on log levels `debug` (`--vv` option) and `verbose` (`--v` option)

### Issues resolved

general information provided in requests for support is usually lacking this information.