### PR TITLE
fix(cli) drop the --trace option as it provides little information.

### DIFF
--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -4,7 +4,6 @@ local log = require "kong.cmd.utils.log"
 local options = [[
  --v         verbose
  --vv        debug
- --trace     with traceback
 ]]
 
 local cmds_arr = {}
@@ -75,14 +74,13 @@ return function(args)
     log.set_lvl(log.levels.verbose)
   elseif args.vv then
     log.set_lvl(log.levels.debug)
-    args.trace = true
   end
 
   xpcall(function() cmd_exec(args) end, function(err)
-    if not args.trace then
+    if not (args.v or args.vv) then
       err = err:match "^.-:.-:.(.*)$"
       io.stderr:write("Error: "..err.."\n")
-      io.stderr:write("\n  Run with --trace to see traceback\n")
+      io.stderr:write("\n  Run with --v (verbose) or --vv (debug) for more details\n")
     else
       local trace = debug.traceback(err, 2)
       io.stderr:write("Error: \n")


### PR DESCRIPTION
the `--trace` is confusing as with support requests people tend to include the output, which contains very little information, where they should have included the `debug` level logging from the `--vv` option.

This drops the `--trace` option, but includes the information generated automatically in both `verbose` (the `--v` option) and `debug` (the `--vv` option)  level loggings.