### PR TITLE
feat(request-transformer) adds rename option

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -48,8 +48,8 @@ local function get_content_type(content_type)
   elseif string_find(content_type:lower(), "multipart/form-data", nil, true) then
     return MULTI
   elseif string_find(content_type:lower(), "application/x-www-form-urlencoded", nil, true) then
-    return ENCODED  
-  end   
+    return ENCODED
+  end
 end
 
 local function iter(config_array)
@@ -84,6 +84,15 @@ local function transform_headers(conf)
   -- Remove header(s)
   for _, name, value in iter(conf.remove.headers) do
     req_clear_header(name)
+  end
+
+  -- Rename headers(s)
+  for _, old_name, new_name in iter(conf.rename.headers) do
+    if req_get_headers()[old_name] then
+      local value = req_get_headers()[old_name]
+      req_set_header(new_name, value)
+      req_clear_header(old_name)
+    end
   end
 
   -- Replace header(s)
@@ -125,6 +134,17 @@ local function transform_querystrings(conf)
     req_set_uri_args(querystring)
   end
 
+  -- Rename querystring(s)
+  if conf.rename.querystring then
+    local querystring = req_get_uri_args()
+    for _, old_name, new_name in iter(conf.rename.querystring) do
+      local value = querystring[old_name]
+      querystring[new_name] = value
+      querystring[old_name] = nil
+    end
+    req_set_uri_args(querystring)
+  end
+
   -- Replace querystring(s)
   if conf.replace.querystring then
     local querystring = req_get_uri_args()
@@ -158,7 +178,7 @@ local function transform_querystrings(conf)
 end
 
 local function transform_json_body(conf, body, content_length)
-  local removed, replaced, added, appended = false, false, false, false
+  local removed, renamed, replaced, added, appended = false, false, false, false, false
   local content_length = (body and #body) or 0
   local parameters = parse_json(body)
   if parameters == nil and content_length > 0 then return false, nil end
@@ -170,7 +190,16 @@ local function transform_json_body(conf, body, content_length)
     end
   end
 
-  if content_length > 0 and #conf.replace.body > 0 then 
+  if content_length > 0 and #conf.rename.body > 0 then
+    for _, old_name, new_name in iter(conf.rename.body) do
+      local value = parameters[old_name]
+      parameters[new_name] = value
+      parameters[old_name] = nil
+      renamed = true
+    end
+  end
+
+  if content_length > 0 and #conf.replace.body > 0 then
     for _, name, value in iter(conf.replace.body) do
       if parameters[name] then
         parameters[name] = value
@@ -186,7 +215,7 @@ local function transform_json_body(conf, body, content_length)
         added = true
       end
     end
-  end  
+  end
 
   if #conf.append.body > 0 then
     for _, name, value in iter(conf.append.body) do
@@ -196,13 +225,13 @@ local function transform_json_body(conf, body, content_length)
     end
   end
 
-  if removed or replaced or added or appended then 
+  if removed or renamed or replaced or added or appended then
     return true, cjson.encode(parameters)
   end
 end
 
 local function transform_url_encoded_body(conf, body, content_length)
-  local removed, replaced, added, appended = false, false, false, false
+  local renamed, removed, replaced, added, appended = false, false, false, false, false
   local parameters = decode_args(body)
 
   if content_length > 0 and #conf.remove.body > 0 then
@@ -212,7 +241,16 @@ local function transform_url_encoded_body(conf, body, content_length)
     end
   end
 
-  if content_length > 0 and #conf.replace.body > 0 then 
+  if content_length > 0 and #conf.rename.body > 0 then
+    for _, old_name, new_name in iter(conf.rename.body) do
+      local value = parameters[old_name]
+      parameters[new_name] = value
+      parameters[old_name] = nil
+      renamed = true
+    end
+  end
+
+  if content_length > 0 and #conf.replace.body > 0 then
     for _, name, value in iter(conf.replace.body) do
       if parameters[name] then
         parameters[name] = value
@@ -238,14 +276,25 @@ local function transform_url_encoded_body(conf, body, content_length)
     end
   end
 
-  if removed or replaced or added or appended then 
+  if removed or renamed or replaced or added or appended then
     return true, encode_args(parameters)
   end
 end
 
 local function transform_multipart_body(conf, body, content_length, content_type_value)
-  local removed, replaced, added, appended = false, false, false, false
+  local removed, renamed, replaced, added, appended = false, false, false, false, false
   local parameters = multipart(body and body or "", content_type_value)
+
+  if content_length > 0 and #conf.rename.body > 0 then
+    for _, old_name, new_name in iter(conf.rename.body) do
+      if parameters:get(old_name) then
+        local value = parameters:get(old_name).value
+        parameters:set_simple(new_name, value)
+        parameters:delete(old_name)
+        renamed = true
+      end
+    end
+  end
 
   if content_length > 0 and #conf.remove.body > 0 then
     for _, name, value in iter(conf.remove.body) do
@@ -273,7 +322,7 @@ local function transform_multipart_body(conf, body, content_length, content_type
     end
   end
 
-  if removed or replaced or added or appended then 
+  if removed or renamed or replaced or added or appended then
     return true, parameters:tostring()
   end
 end
@@ -281,7 +330,7 @@ end
 local function transform_body(conf)
   local content_type_value = req_get_headers()[CONTENT_TYPE]
   local content_type = get_content_type(content_type_value)
-  if content_type == nil or #conf.remove.body < 1 and #conf.replace.body < 1 and #conf.add.body < 1 and #conf.append.body < 1 then return end
+  if content_type == nil or #conf.rename.body < 1 and #conf.remove.body < 1 and #conf.replace.body < 1 and #conf.add.body < 1 and #conf.append.body < 1 then return end
 
   -- Call req_read_body to read the request body first
   req_read_body()

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -3,7 +3,7 @@ local find = string.find
 local function check_for_value(value)
   for i, entry in ipairs(value) do
     local ok = find(entry, ":")
-    if not ok then 
+    if not ok then
       return false, "key '"..entry.."' has no value"
     end
   end
@@ -19,6 +19,16 @@ return {
           body = {type = "array", default = {}}, -- does not need colons
           headers = {type = "array", default = {}}, -- does not need colons
           querystring = {type = "array", default = {}} -- does not need colons
+        }
+      }
+    },
+    rename = {
+      type = "table",
+      schema = {
+        fields = {
+          body = {type = "array", default = {}},
+          headers = {type = "array", default = {}},
+          querystring = {type = "array", default = {}}
         }
       }
     },


### PR DESCRIPTION
### Summary

feat(request-transformer) adds rename option
### Full changelog

This feature allows the renaming of querystrings, body's and headers and
follows conventions of replace, remove, append and add. 

Example Usage:
Passing "name:value" will modify a json body { name: "keep" } to { value: "keep" }  
#### Note

Due to blunders in the rebasing process, this PR replaces #1497 
