### PR TITLE
Fix the second luacheck link

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ usage of the tests suites and the Makefile.
 
 Finally, a very useful tool in Lua development (as with many other dynamic
 languages) is performing static linting of your code. You can use [luacheck]
-(installed with `make dev`) for this:
+\(installed with `make dev`\) for this:
 
 ```
 $ make lint


### PR DESCRIPTION
**Note: new features are to be opened against next, hotfixes against master.**

### Summary

Parentheses must be escaped. Otherwise Github's Markdown implementation will treat that part as the URL.

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX

