### PR TITLE
chore(dep) bump OpenResty + travis improvements

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,7 +1,7 @@
 set -e
 
 export BUSTED_ARGS="-o gtest -v --exclude-tags=ci"
-export TEST_CMD="KONG_SERF_PATH=$SERF_INSTALL/serf bin/busted $BUSTED_ARGS"
+export TEST_CMD="KONG_SERF_PATH=$SERF_PATH bin/busted $BUSTED_ARGS"
 
 if [ "$TEST_SUITE" == "lint" ]; then
   make lint

--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -1,31 +1,61 @@
 set -e
 
-export OPENRESTY_INSTALL=$CACHE_DIR/openresty
-export LUAROCKS_INSTALL=$CACHE_DIR/luarocks
-export SERF_INSTALL=$CACHE_DIR/serf
+#---------
+# Download
+#---------
+OPENSSL_DOWNLOAD=$DOWNLOAD_CACHE/openssl-$OPENSSL
+OPENRESTY_DOWNLOAD=$DOWNLOAD_CACHE/openresty-$OPENRESTY
+LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS
+SERF_DOWNLOAD=$DOWNLOAD_CACHE/serf-$SERF
 
-mkdir -p $CACHE_DIR
+mkdir -p $OPENSSL_DOWNLOAD $OPENRESTY_DOWNLOAD $LUAROCKS_DOWNLOAD $SERF_DOWNLOAD
 
-if [ ! "$(ls -A $CACHE_DIR)" ]; then
-  # Not in cache
+if [ ! "$(ls -A $OPENSSL_DOWNLOAD)" ]; then
+  pushd $DOWNLOAD_CACHE
+    curl -L http://www.openssl.org/source/openssl-$OPENSSL.tar.gz | tar xz
+  popd
+fi
 
-  # ---------------
-  # Install OpenSSL
-  # ---------------
-  OPENSSL_BASE=openssl-$OPENSSL
-  curl -L http://www.openssl.org/source/$OPENSSL_BASE.tar.gz | tar xz
+if [ ! "$(ls -A $OPENRESTY_DOWNLOAD)" ]; then
+  pushd $DOWNLOAD_CACHE
+    curl -L https://openresty.org/download/openresty-$OPENRESTY.tar.gz | tar xz
+  popd
+fi
 
-  # -----------------
-  # Install OpenResty
-  # -----------------
-  OPENRESTY_BASE=openresty-$OPENRESTY
-  mkdir -p $OPENRESTY_INSTALL
-  curl -L https://openresty.org/download/$OPENRESTY_BASE.tar.gz | tar xz
+if [ ! "$(ls -A $LUAROCKS_DOWNLOAD)" ]; then
+  git clone https://github.com/keplerproject/luarocks.git $LUAROCKS_DOWNLOAD
+fi
 
-  pushd $OPENRESTY_BASE
+if [ ! "$(ls -A $SERF_DOWNLOAD)" ]; then
+  pushd $SERF_DOWNLOAD
+    wget https://releases.hashicorp.com/serf/${SERF}/serf_${SERF}_linux_amd64.zip
+    unzip serf_${SERF}_linux_amd64.zip
+  popd
+fi
+
+#--------
+# Install
+#--------
+OPENSSL_INSTALL=$INSTALL_CACHE/openssl-$OPENSSL
+OPENRESTY_INSTALL=$INSTALL_CACHE/openresty-$OPENRESTY
+LUAROCKS_INSTALL=$INSTALL_CACHE/luarocks-$LUAROCKS
+SERF_INSTALL=$INSTALL_CACHE/serf-$SERF
+
+mkdir -p $OPENSSL_INSTALL $OPENRESTY_INSTALL $LUAROCKS_INSTALL $SERF_INSTALL
+
+if [ ! "$(ls -A $OPENSSL_INSTALL)" ]; then
+  pushd $OPENSSL_DOWNLOAD
+    ./config shared --prefix=$OPENSSL_INSTALL
+    make
+    make install
+  popd
+fi
+
+if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
+  pushd $OPENRESTY_DOWNLOAD
     ./configure \
       --prefix=$OPENRESTY_INSTALL \
-      --with-openssl=../$OPENSSL_BASE \
+      --with-openssl=$OPENSSL_DOWNLOAD \
       --with-ipv6 \
       --with-pcre-jit \
       --with-http_ssl_module \
@@ -34,17 +64,10 @@ if [ ! "$(ls -A $CACHE_DIR)" ]; then
     make
     make install
   popd
+fi
 
-  rm -rf $OPENRESTY_BASE
-
-  # ----------------
-  # Install Luarocks
-  # ----------------
-  LUAROCKS_BASE=luarocks-$LUAROCKS
-  mkdir -p $LUAROCKS_INSTALL
-  git clone https://github.com/keplerproject/luarocks.git $LUAROCKS_BASE
-
-  pushd $LUAROCKS_BASE
+if [ ! "$(ls -A $LUAROCKS_INSTALL)" ]; then
+  pushd $LUAROCKS_DOWNLOAD
     git checkout v$LUAROCKS
     ./configure \
       --prefix=$LUAROCKS_INSTALL \
@@ -54,18 +77,14 @@ if [ ! "$(ls -A $CACHE_DIR)" ]; then
     make build
     make install
   popd
-
-  rm -rf $LUAROCKS_BASE
-
-  # ------------
-  # Install Serf
-  # ------------
-  mkdir -p $SERF_INSTALL
-  pushd $SERF_INSTALL
-    wget https://releases.hashicorp.com/serf/${SERF}/serf_${SERF}_linux_amd64.zip
-    unzip serf_${SERF}_linux_amd64.zip
-  popd
 fi
+
+if [ ! "$(ls -A $SERF_INSTALL)" ]; then
+  ln -s $SERF_DOWNLOAD/serf $SERF_INSTALL/serf
+fi
+
+export OPENSSL_DIR=$OPENSSL_INSTALL # for LuaSec install
+export SERF_PATH=$SERF_INSTALL/serf # for our test instance (not in default bin/sh $PATH)
 
 export PATH=$PATH:$OPENRESTY_INSTALL/nginx/sbin:$OPENRESTY_INSTALL/bin:$LUAROCKS_INSTALL/bin:$SERF_INSTALL
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+language: c
+
+compiler:
+  - gcc
+
 notifications:
   email: false
 
@@ -15,16 +20,25 @@ addons:
 env:
   global:
     - SERF=0.7.0
-    - LUAROCKS=2.3.0
+    - LUAROCKS=2.4.0
     - OPENSSL=1.0.2h
     - CASSANDRA=2.2.7
-    - OPENRESTY=1.9.15.1
-    - $CACHE_DIR=$HOME/cache
+    - OPENRESTY_BASE=1.9.15.1
+    - OPENRESTY_LATEST=1.11.2.1
+    - OPENRESTY=$OPENRESTY_BASE
+    - DOWNLOAD_CACHE=$HOME/download-cache
+    - INSTALL_CACHE=$HOME/install-cache
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=unit
     - TEST_SUITE=integration
+      OPENRESTY=$OPENRESTY_BASE
     - TEST_SUITE=plugins
+      OPENRESTY=$OPENRESTY_BASE
+    - TEST_SUITE=integration
+      OPENRESTY=$OPENRESTY_LATEST
+    - TEST_SUITE=plugins
+      OPENRESTY=$OPENRESTY_LATEST
 
 before_install:
   - source .ci/setup_env.sh
@@ -39,5 +53,6 @@ cache:
   apt: true
   pip: true
   directories:
-    - $CACHE_DIR
+    - $DOWNLOAD_CACHE
+    - $INSTALL_CACHE
     - $HOME/.ccm/repository

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -18,7 +18,7 @@ return {
   -- third-party dependencies' required version, as they would be specified
   -- to lua-version's `set()` in the form {from, to}
   _DEPENDENCIES = {
-    nginx = {"1.9.15.1", "1.9.15.1"},
+    nginx = {"1.9.15.1", "1.11.2.1"},
     serf = {"0.7.0", "0.7.0"},
     --resty = {}, -- not version dependent for now
     --dnsmasq = {} -- not version dependent for now


### PR DESCRIPTION
### Summary

Add OpenResty `1.11.2.1` to the range of supported versions for Kong. Improve the travis setup environment to have multiple cached versions of our dependencies.

### Full changelog

* 🌠  **support for OpenResty 1.11.2.1**
* upgraded Travis-CI caching mechanism to support multiple versions
  cached
* bump Luarocks version in travis-ci
* add integration+plugins test suites under OpenResty 1.11.2.1