### PR TITLE
fix(oauth2) removing Kong from error message

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -132,7 +132,7 @@ local function authorize(conf)
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else
     if conf.provision_key ~= parameters.provision_key then
-      response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid Kong provision_key"}
+      response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid provision_key"}
     elseif not parameters.authenticated_userid or utils.strip(parameters.authenticated_userid) == "" then
       response_params = {[ERROR] = "invalid_authenticated_userid", error_description = "Missing authenticated_userid parameter"}
     else
@@ -306,7 +306,7 @@ local function issue_token(conf)
       elseif grant_type == GRANT_CLIENT_CREDENTIALS then
         -- Only check the provision_key if the authenticated_userid is being set
         if parameters.authenticated_userid and conf.provision_key ~= parameters.provision_key then
-          response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid Kong provision_key"}
+          response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid provision_key"}
         else
           -- Check scopes
           local ok, scopes = retrieve_scopes(parameters, conf)
@@ -319,7 +319,7 @@ local function issue_token(conf)
       elseif grant_type == GRANT_PASSWORD then
         -- Check that it comes from the right client
         if conf.provision_key ~= parameters.provision_key then
-          response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid Kong provision_key"}
+          response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid provision_key"}
         elseif not parameters.authenticated_userid or utils.strip(parameters.authenticated_userid) == "" then
           response_params = {[ERROR] = "invalid_authenticated_userid", error_description = "Missing authenticated_userid parameter"}
         else

--- a/spec/03-plugins/99-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/99-oauth2/03-access_spec.lua
@@ -203,7 +203,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
         assert.are.equal("no-store", res.headers["cache-control"])
         assert.are.equal("no-cache", res.headers["pragma"])
       end)
@@ -474,7 +474,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
       end)
       it("returns success with a path", function()
         local res = assert(proxy_ssl_client:send {
@@ -816,7 +816,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
       end)
       it("fails when setting authenticated_userid and invalid provision_key", function()
         local res = assert(proxy_ssl_client:send {
@@ -836,7 +836,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
       end)
       it("returns success", function()
         local res = assert(proxy_ssl_client:send {
@@ -1097,7 +1097,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
       end)
       it("fails when no provision key is being sent", function()
         local res = assert(proxy_ssl_client:send {
@@ -1115,7 +1115,7 @@ describe("#ci Plugin: oauth2 (access)", function()
           }
         })
         local body = assert.res_status(400, res)
-        assert.equal([[{"error_description":"Invalid Kong provision_key","error":"invalid_provision_key"}]], body)
+        assert.equal([[{"error_description":"Invalid provision_key","error":"invalid_provision_key"}]], body)
       end)
       it("fails when no authenticated user id is being sent", function()
         local res = assert(proxy_ssl_client:send {


### PR DESCRIPTION
### Summary

Removing the word "Kong" from the error message.

### Full changelog

* OAuth 2: Removing the word "Kong" from the error message when the `provision_key` is missing or wrong.

### Issues resolved

Related to #1617.
