### PR TITLE
chore(dep) bump OpenResty support to 1.11.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,22 @@ env:
     - LUAROCKS=2.4.0
     - OPENSSL=1.0.2h
     - CASSANDRA=2.2.7
-    - OPENRESTY=1.9.15.1
+    - OPENRESTY_BASE=1.9.15.1
+    - OPENRESTY_LATEST=1.11.2.1
+    - OPENRESTY=$OPENRESTY_BASE
     - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=unit
     - TEST_SUITE=integration
+      OPENRESTY=$OPENRESTY_BASE
     - TEST_SUITE=plugins
+      OPENRESTY=$OPENRESTY_BASE
+    - TEST_SUITE=integration
+      OPENRESTY=$OPENRESTY_LATEST
+    - TEST_SUITE=plugins
+      OPENRESTY=$OPENRESTY_LATEST
 
 before_install:
   - source .ci/setup_env.sh

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -18,7 +18,7 @@ return {
   -- third-party dependencies' required version, as they would be specified
   -- to lua-version's `set()` in the form {from, to}
   _DEPENDENCIES = {
-    nginx = {"1.9.15.1", "1.9.15.1"},
+    nginx = {"1.9.15.1", "1.11.2.1"},
     serf = {"0.7.0", "0.7.0"},
     --resty = {}, -- not version dependent for now
     --dnsmasq = {} -- not version dependent for now


### PR DESCRIPTION
### Summary

Add OpenResty `1.11.2.1` to the range of supported versions for Kong.

### Full changelog

* 🌠  **support for OpenResty 1.11.2.1**