### PR TITLE
hotfix(cli) prevent executing 'kill' on missing pids

### DIFF
--- a/kong/cmd/utils/kill.lua
+++ b/kong/cmd/utils/kill.lua
@@ -1,15 +1,24 @@
 local pl_path = require "pl.path"
+local log = require "kong.cmd.utils.log"
 
-local cmd_tmpl = [[
-kill %s `cat %s` >/dev/null 2>&1
-]]
+local cmd_tmpl = [[kill %s `cat %s` >/dev/null 2>&1]]
 
 local function kill(pid_file, args)
+  log.debug("sending signal to pid at: %s", pid_file)
   local cmd = string.format(cmd_tmpl, args or "-0", pid_file)
-  return os.execute(cmd)
+  if pl_path.exists(pid_file) then
+    log.debug(cmd)
+    return os.execute(cmd)
+  else
+    log.debug("no pid file at: %s", pid_file)
+    return 0
+  end
 end
 
 local function is_running(pid_file)
+  -- we do our own pid_file exists check here because
+  -- we want to return `nil` in case of NOT running,
+  -- and not `0` like `kill` would return.
   if pl_path.exists(pid_file) then
     return kill(pid_file) == 0
   end


### PR DESCRIPTION
### Summary

This would occasionally output some ungraceful "no pid file at" error to
`stderr`. Instead, we catch those and now print a proper debug log.

