### PR TITLE
hotfix(cli) seed random number generator in CLI

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,9 @@
 #!/usr/bin/env resty
 
+-- a flag to detect whether our modules (especially kong.core.globalpatches)
+-- are running under resty-cli or in a real ngx_lua, runtime environment.
+ngx.RESTY_CLI = true
+
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523
@@ -7,8 +11,6 @@ for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
   local socket = require(namespace .. ".socket")
   socket.force_luasocket(ngx.get_phase(), true)
 end
-
-package.path = "?/init.lua;"..package.path
 
 if ngx ~= nil then
   ngx.exit = function()end

--- a/bin/kong
+++ b/bin/kong
@@ -1,5 +1,9 @@
 #!/usr/bin/env resty
 
+-- a flag to detect whether our modules (especially kong.core.globalpatches)
+-- are running under resty-cli or in a real ngx_lua, runtime environment.
+ngx.RESTY_CLI = true
+
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523

--- a/bin/kong
+++ b/bin/kong
@@ -12,4 +12,8 @@ for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
   socket.force_luasocket(ngx.get_phase(), true)
 end
 
+if ngx ~= nil then
+  ngx.exit = function()end
+end
+
 require("kong.cmd.init")(arg)

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -1,6 +1,9 @@
+require "kong.core.globalpatches"
+
+math.randomseed()
+
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
-local meta = require "kong.meta"
 
 local options = [[
  --v         verbose
@@ -77,7 +80,7 @@ return function(args)
     log.set_lvl(log.levels.debug)
   end
 
-  log.verbose("Kong: %s", meta._VERSION)
+  log.verbose("Kong: %s", _KONG._VERSION)
   log.debug("ngx_lua: %s", ngx.config.ngx_lua_version)
   log.debug("nginx: %s", ngx.config.nginx_version)
   log.debug("Lua: %s", jit and jit.version or _VERSION)


### PR DESCRIPTION
### Summary

If spawning multiple nodes at once (making use of the CLI from different
host machines), we need to make sure none of them are using the same
seed. To enforce this, we make use of the patched `math.randomseed()`
function, which should greatly reduce the probability of seed collision.

To allow for this change, we need a special flag indicating our scripts
if we are running inside of our CLI, so that out `math.randomseed()`
  does not complain about being called in resty-cli's 'timer' context.

### Full changelog

* add `ngx.RESTY_CLI` flag in `bin/kong`
* add an edge case in our patched `math.randomseed()`
* apply `kong.core.globalpatches` to our CLI environment

### Issues resolved

Fix #1592
