### PR TITLE
fix(cli) prevent start from stopping already-running Kong

### DIFF
--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -4,12 +4,16 @@ local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local serf_signals = require "kong.cmd.utils.serf_signals"
 local conf_loader = require "kong.conf_loader"
 local DAOFactory = require "kong.dao.factory"
+local kill = require "kong.cmd.utils.kill"
 local log = require "kong.cmd.utils.log"
 
 local function execute(args)
   local conf = assert(conf_loader(args.conf, {
     prefix = args.prefix
   }))
+
+  assert(not kill.is_running(conf.nginx_pid),
+         "Kong is already running in "..conf.prefix)
 
   local dao = DAOFactory(conf)
   local err

--- a/spec/02-integration/01-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/01-cmd/02-start_stop_spec.lua
@@ -192,7 +192,7 @@ describe("kong start/stop", function()
       assert.False(ok)
       assert.matches("Error: no such prefix: .*/inexistent", stderr)
     end)
-    it("notifies when Nginx is already running", function()
+    it("notifies when Kong is already running", function()
       assert(helpers.kong_exec("start --prefix "..helpers.test_conf.prefix, {
         pg_database = helpers.test_conf.pg_database
       }))
@@ -201,7 +201,7 @@ describe("kong start/stop", function()
         pg_database = helpers.test_conf.pg_database
       })
       assert.False(ok)
-      assert.matches("nginx is already running in "..helpers.test_conf.prefix, stderr, nil, true)
+      assert.matches("Kong is already running in "..helpers.test_conf.prefix, stderr, nil, true)
     end)
     it("stops other services when could not start", function()
       local kill = require "kong.cmd.utils.kill"
@@ -224,6 +224,21 @@ describe("kong start/stop", function()
 
       assert.falsy(kill.is_running(helpers.test_conf.dnsmasq_pid))
       assert.falsy(kill.is_running(helpers.test_conf.serf_pid))
+    end)
+    it("should not stop Kong if already running in prefix", function()
+      local kill = require "kong.cmd.utils.kill"
+
+      assert(helpers.kong_exec("start --prefix "..helpers.test_conf.prefix, {
+        pg_database = helpers.test_conf.pg_database
+      }))
+
+      local ok, stderr = helpers.kong_exec("start --prefix "..helpers.test_conf.prefix, {
+        pg_database = helpers.test_conf.pg_database
+      })
+      assert.False(ok)
+      assert.matches("Kong is already running in "..helpers.test_conf.prefix, stderr, nil, true)
+
+      assert(kill.is_running(helpers.test_conf.nginx_pid))
     end)
   end)
 end)


### PR DESCRIPTION
* add a check ensuring Kong (Nginx) is not running even before executing
  the prefix_handler, which would maybe have consequences such as
  re-generating SSL certs, or running migrations, etc...
* add a test for this behavior
* error now says "Kong is already running" instead of "Nginx is already
  running", which is also probably more elegant.