### PR TITLE
feat(plugins) new path-router plugin to route by querystring params

### DIFF
--- a/kong-0.9.1-0.rockspec
+++ b/kong-0.9.1-0.rockspec
@@ -261,5 +261,8 @@ build = {
     ["kong.plugins.bot-detection.rules"] = "kong/plugins/bot-detection/rules.lua",
     ["kong.plugins.bot-detection.cache"] = "kong/plugins/bot-detection/cache.lua",
     ["kong.plugins.bot-detection.hooks"] = "kong/plugins/bot-detection/hooks.lua",
+
+    ["kong.plugins.path-router.handler"] = "kong/plugins/path-router/handler.lua",
+    ["kong.plugins.path-router.schema"] = "kong/plugins/path-router/schema.lua"
   }
 }

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -3,7 +3,7 @@ local plugins = {
   "file-log", "http-log", "key-auth", "hmac-auth", "basic-auth", "ip-restriction",
   "galileo", "request-transformer", "response-transformer",
   "request-size-limiting", "rate-limiting", "response-ratelimiting", "syslog",
-  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection"
+  "loggly", "datadog", "runscope", "ldap-auth", "statsd", "bot-detection", "path-router"
 }
 
 local plugin_map = {}

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -48,6 +48,8 @@ return {
         upstream_url = upstream_url.."?"..utils.encode_args(uri_args)
       end
 
+      print(upstream_url)
+
       -- Set the `$upstream_url` and `$upstream_host` variables for the `proxy_pass` nginx
       -- directive in kong.yml.
       ngx.var.upstream_url = upstream_url

--- a/kong/plugins/path-router/handler.lua
+++ b/kong/plugins/path-router/handler.lua
@@ -1,0 +1,50 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local responses = require "kong.tools.responses"
+local pl_string = require "pl.stringx"
+local pl_table = require "pl.tablex"
+local url = require "socket.url"
+
+local PathRouterHandler = BasePlugin:extend()
+
+function PathRouterHandler:new()
+  PathRouterHandler.super.new(self, " PathRouter")
+end
+
+function PathRouterHandler:access(conf)
+  PathRouterHandler.super.access(self)
+
+  if conf.querystring and conf.querystring.mappings then
+    local querystring_parameters = ngx.req.get_uri_args()
+    for _, mapping in ipairs(conf.querystring.mappings) do
+      if querystring_parameters[mapping.name] and querystring_parameters[mapping.name] == mapping.value then
+
+        -- Split the paths
+        local forward_path_parts = pl_string.split(mapping.forward_path, "?")
+        if #forward_path_parts == 2 then
+          -- Merge the querystring parameters
+          querystring_parameters = pl_table.merge(querystring_parameters, ngx.decode_args(forward_path_parts[2]), true)
+        end
+
+        local parsed_url = url.parse(ngx.ctx.upstream_url)
+        local newurl = ngx.re.gsub(ngx.ctx.upstream_url, parsed_url.path, forward_path_parts[1])
+        if newurl then
+          -- Set the upstream URL
+          ngx.ctx.upstream_url = newurl
+          if mapping.strip then
+            querystring_parameters[mapping.name] = nil
+          end
+        else
+          return responses.send_HTTP_INTERNAL_SERVER_ERROR()
+        end
+
+        -- Set the new querystring params
+        ngx.req.set_uri_args(querystring_parameters)
+        break
+      end
+    end
+  end
+end
+
+PathRouterHandler.PRIORITY = 801
+
+return PathRouterHandler

--- a/kong/plugins/path-router/schema.lua
+++ b/kong/plugins/path-router/schema.lua
@@ -1,0 +1,13 @@
+return {
+  fields = {
+    querystring = { 
+      mappings = {
+        type = "table",
+        name = {type = "string", required = true},
+        value = {type = "string", required = true},
+        forward_path = {type = "string", required = true},
+        strip = {type="boolean"}
+      }
+    }
+  }
+}

--- a/spec/03-plugins/17-path-router/01-access_spec.lua
+++ b/spec/03-plugins/17-path-router/01-access_spec.lua
@@ -1,0 +1,137 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+describe("Plugin: path-router (access)", function()
+  local client, admin_client
+  setup(function()
+    assert(helpers.start_kong())
+    client = helpers.proxy_client()
+    admin_client = helpers.admin_client()
+
+    local api1 = assert(helpers.dao.apis:insert {
+      request_host = "path-router.com",
+      upstream_url = "http://mockbin.com"
+    })
+    local api2 = assert(helpers.dao.apis:insert {
+      request_path = "/test",
+      strip_request_path = true,
+      upstream_url = "http://mockbin.com"
+    })
+    local api3 = assert(helpers.dao.apis:insert {
+      request_path = "/request",
+      upstream_url = "http://mockbin.com"
+    })
+
+    local config = {
+      querystring = {
+        mappings = {
+          {
+            name = "param1",
+            value = "hello",
+            forward_path = "/request?sup=param1"
+          },
+          {
+            name = "param1",
+            value = "hello2",
+            forward_path = "/request?sup=param2",
+            strip = true
+          }
+        }
+      }
+    }
+
+    assert(helpers.dao.plugins:insert {
+      name = "path-router",
+      api_id = api1.id,
+      config = config
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "path-router",
+      api_id = api2.id,
+      config = config
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "path-router",
+      api_id = api3.id,
+      config = config
+    })
+
+  end)
+  teardown(function()
+    if client and admin_client then
+      client:close()
+      admin_client:close()
+    end
+    helpers.stop_kong()
+  end)
+
+  describe("host resolver", function()
+    it("routes when the param matches without strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/pippo/?param1=hello",
+        headers = {
+          ["Host"] = "path-router.com"
+        }
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param1", body.queryString.sup)
+      assert.equal("hello", body.queryString.param1)
+    end)
+    it("routes when the param matches with strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/pippo/?param1=hello2",
+        headers = {
+          ["Host"] = "path-router.com"
+        }
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param2", body.queryString.sup)
+      assert.is_nil(body.queryString.param1)
+    end)
+  end)
+
+  describe("path resolver", function()
+    it("routes when the param matches without strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/test/pippo/?param1=hello"
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param1", body.queryString.sup)
+      assert.equal("hello", body.queryString.param1)
+    end)
+    it("routes when the param matches with strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/test/pippo/?param1=hello2"
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param2", body.queryString.sup)
+      assert.is_nil(body.queryString.param1)
+    end)
+  end)
+
+  describe("path resolver without strip", function()
+    it("routes when the param matches without strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request?param1=hello"
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param1", body.queryString.sup)
+      assert.equal("hello", body.queryString.param1)
+    end)
+    it("routes when the param matches with strip", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request?param1=hello2"
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("param2", body.queryString.sup)
+      assert.is_nil(body.queryString.param1)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
This plugin allows to route the request to a different upstream path based on the value of a query-string parameter. An example would be:

``` shell
curl 127.0.0.1:8001/apis \
       -d "request_path=/test" \
       -d "strip_request_path=true" \
       -d "upstream_url=http://mockbin.com"

curl 127.0.0.1:8001/apis/test/plugins \
  -d "name=path-router" \
  -d "config.querystring.mappings.1.name=param1" \
  -d "config.querystring.mappings.1.value=value1" \
  -d "config.querystring.mappings.1.forward_path=/somewhere-else"
  -d "config.querystring.mappings.1.strip=true"
```

When a request is made to `127.0.0.1:8000/test/request`, nothing happens and the upstream will be `http://mockbin.com/request`.

When a request is made to `127.0.0.1:8000/test/request?param1=value1`, the plugin is triggered and the upstream will be `http://mockbin.com/somewhere-else`.

Maybe this plugin is not necessary if the router is extended to also support mapping of querystring parameters, which would be a better implementation (related to #505).
