### PR TITLE
fix(dao) correct counter for migrations ran

### DIFF
--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -247,16 +247,15 @@ function Factory:run_migrations(on_migrate, on_success)
   local cur_migrations, err = self:current_migrations()
   if err then return ret_error_string(_db.db_type, nil, err) end
 
-  local ok, err = migrate(self, "core", migrations_modules, cur_migrations, on_migrate, on_success)
+  local ok, err, migrations_ran = migrate(self, "core", migrations_modules, cur_migrations, on_migrate, on_success)
   if not ok then return ret_error_string(_db.db_type, nil, err) end
 
-  local migrations_ran = 0
   for identifier in pairs(migrations_modules) do
     if identifier ~= "core" then
       local ok, err, n_ran = migrate(self, identifier, migrations_modules, cur_migrations, on_migrate, on_success)
       if not ok then return ret_error_string(_db.db_type, nil, err)
       else
-        migrations_ran = math.max(migrations_ran, n_ran)
+        migrations_ran = migrations_ran + n_ran
       end
     end
   end


### PR DESCRIPTION
Replace #1648 (older commit)

* include core migrations in the counter
* replace math.max() by an addition (what was I trying to do?)

Fix #1639