### PR TITLE
fix(api) obfuscates sensitive settings from the `/` route

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -1,5 +1,6 @@
 local utils = require "kong.tools.utils"
 local singletons = require "kong.singletons"
+local conf_loader = require "kong.conf_loader"
 
 local find = string.find
 local pairs = pairs
@@ -42,7 +43,7 @@ return {
           enabled_in_cluster = distinct_plugins
         },
         lua_version = lua_version,
-        configuration = singletons.configuration
+        configuration = conf_loader.remove_sensitive(singletons.configuration)
       }
     end
   },

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -331,4 +331,26 @@ describe("Configuration loader", function()
       assert.contains("ssl_cert must be specified", errors)
     end)
   end)
+
+  describe("remove_sensitive()", function()
+    it("replaces sensitive settings", function()
+      local conf = assert(conf_loader(nil, {
+        pg_password = "hide_me",
+        cassandra_password = "hide_me",
+        cluster_encrypt_key = "hide_me"
+      }))
+
+      local purged_conf = conf_loader.remove_sensitive(conf)
+      assert.not_equal("hide_me", purged_conf.pg_password)
+      assert.not_equal("hide_me", purged_conf.cassandra_password)
+      assert.not_equal("hide_me", purged_conf.cluster_encrypt_key)
+    end)
+    it("does not insert placeholder if no value", function()
+      local conf = assert(conf_loader())
+      local purged_conf = conf_loader.remove_sensitive(conf)
+      assert.is_nil(purged_conf.pg_password)
+      assert.is_nil(purged_conf.cassandra_password)
+      assert.is_nil(purged_conf.cluster_encrypt_key)
+    end)
+  end)
 end)


### PR DESCRIPTION
* new `remove_sensitive()` function clones the configuration and
  replaces sensitive settings with a placeholder
* unit test for conf_loader and new tests for the Admin API's `/` route