### PR TITLE
chore(deps) bump lua-cassandra to 0.5.4

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+ngx.RESTY_CLI = true
+
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523

--- a/bin/kong
+++ b/bin/kong
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+ngx.RESTY_CLI = true
+
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.
 -- See https://github.com/Mashape/kong/issues/1523

--- a/kong-0.9.1-0.rockspec
+++ b/kong-0.9.1-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.3",
   "version == 0.2",
   "lapis == 1.5.1",
-  "lua-cassandra == 0.5.3",
+  "lua-cassandra == 0.5.4",
   "pgmoon-mashape == 2.0.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.1",

--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -4,10 +4,16 @@ local BaseDB = require "kong.dao.base_db"
 local utils = require "kong.tools.utils"
 local uuid = utils.uuid
 
-local ngx_stub = _G.ngx
-_G.ngx = nil
-local cassandra = require "cassandra"
-_G.ngx = ngx_stub
+local cassandra
+
+if ngx.RESTY_CLI then
+  local ngx_stub = _G.ngx
+  _G.ngx = nil
+  cassandra = require "cassandra"
+  _G.ngx = ngx_stub
+else
+  cassandra = require "cassandra"
+end
 
 local CassandraDB = BaseDB:extend()
 


### PR DESCRIPTION
* ensures proper usage for shm and cosocket fallbacks when outside of
  ngx_lua