### PR TITLE
fix(galileo) default 'body_Size' when 'log_bodies=true' but no body

### DIFF
--- a/kong/plugins/galileo/alf.lua
+++ b/kong/plugins/galileo/alf.lua
@@ -150,8 +150,13 @@ function _M:add_entry(_ngx, req_body_str, resp_body_str)
         mimeType = resp_content_type
       }
     end
-  else
+  end
+
+  if not req_body_size then
     req_body_size = tonumber(request_content_len) or 0
+  end
+
+  if not resp_body_size then
     resp_body_size = tonumber(resp_content_len) or 0
   end
 

--- a/kong/plugins/galileo/buffer.lua
+++ b/kong/plugins/galileo/buffer.lua
@@ -33,7 +33,7 @@ local min = math.min
 local pow = math.pow
 local now = ngx.now
 local ERR = ngx.ERR
-local DEBUG = ngx.INFO
+local DEBUG = ngx.DEBUG
 local WARN = ngx.WARN
 
 local _buffer_max_mb = 200

--- a/spec/03-plugins/05-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/05-galileo/01-alf_spec.lua
@@ -229,6 +229,15 @@ describe("ALF serializer", function()
         local entry = assert(alf:add_entry(_ngx, body_str))
         assert.equal(#body_str, entry.request.bodySize)
       end)
+      it("zeroes bodySize if body logging but no body", function()
+        _G.ngx.req.get_headers = function()
+          return {}
+        end
+        reload_alf_serializer()
+        local alf = alf_serializer.new(true) -- log_bodies enabled
+        local entry = assert(alf:add_entry(_ngx))
+        assert.equal(0, entry.request.bodySize)
+      end)
       it("zeroes bodySize if no body logging or Content-Length", function()
         _G.ngx.req.get_headers = function()
           return {}
@@ -356,6 +365,15 @@ describe("ALF serializer", function()
         local alf = alf_serializer.new(true) -- log_bodies enabled
         local entry = assert(alf:add_entry(_ngx, nil, body_str))
         assert.equal(#body_str, entry.response.bodySize)
+      end)
+      it("zeroes bodySize if body logging but no body", function()
+        _G.ngx.resp.get_headers = function()
+          return {}
+        end
+        reload_alf_serializer()
+        local alf = alf_serializer.new(true) -- log_bodies enabled
+        local entry = assert(alf:add_entry(_ngx))
+        assert.equal(0, entry.response.bodySize)
       end)
       it("zeroes bodySize if no body logging or Content-Length", function()
         _G.ngx.resp.get_headers = function()


### PR DESCRIPTION
### Full changelog

* update the code to fallback on a default value if those sizes are
 still unset, rather than doing that in an `else`
* add request/response tests
* correctly log at `DEBUG` level in the buffer

Fix #1656