### PR TITLE
perf(resolver) use ngx.re API instead of string module

### DIFF
--- a/kong/core/resolver.lua
+++ b/kong/core/resolver.lua
@@ -6,6 +6,14 @@ local responses = require "kong.tools.responses"
 
 local table_insert = table.insert
 local table_sort = table.sort
+local re_match = ngx.re.match
+local re_find = ngx.re.find
+local sub = string.sub
+local gsub = string.gsub
+local log = ngx.log
+local ERR = ngx.ERR
+local req_set_header = ngx.req.set_header
+local req_get_headers = ngx.req.get_headers
 local ipairs = ipairs
 local type = type
 
@@ -64,6 +72,7 @@ function _M.load_apis_in_memory()
       table_insert(request_path_arr, {
         api = api,
         request_path = api.request_path,
+        request_path_regex = "^"..(api.request_path == "/" and "/" or api.request_path.."/"),
         strip_request_path_pattern = create_strip_request_path_pattern(api.request_path)
       })
     end
@@ -113,28 +122,28 @@ end
 
 -- To do so, we have to compare entire URI segments (delimited by "/").
 -- Comparing by entire segment allows us to avoid edge-cases such as:
--- uri = /mockbin-with-pattern/xyz
+-- uri_path = /mockbin-with-pattern/xyz
 -- api.request_path regex = ^/mockbin
 -- ^ This would wrongfully match. Wether:
 -- api.request_path regex = ^/mockbin/
 -- ^ This does not match.
 
 -- Because we need to compare by entire URI segments, all URIs need to have a trailing slash, otherwise:
--- uri = /mockbin
+-- uri_path = /mockbin
 -- api.request_path regex = ^/mockbin/
 -- ^ This would not match.
 -- @param  `uri` The URI for this request.
 -- @param  `request_path_arr`    An array of all APIs that have a request_path property.
-function _M.find_api_by_request_path(uri, request_path_arr)
-  if uri:sub(-1) ~= "/" then
-    uri = uri.."/"
+function _M.find_api_by_request_path(uri_path, request_path_arr)
+  if sub(uri_path, -1) ~= "/" then
+    uri_path = uri_path.."/"
   end
 
   for _, item in ipairs(request_path_arr) do
-    local m, err = ngx.re.match(uri, "^"..(item.request_path == "/" and "/" or item.request_path.."/"))
+    local from, _, err = re_find(uri_path, item.request_path_regex, "oj")
     if err then
-      ngx.log(ngx.ERR, "[resolver] error matching requested request_path: "..err)
-    elseif m then
+      log(ERR, "[resolver] error matching requested request_path: ", err)
+    elseif from then
       return item.api, item.strip_request_path_pattern
     end
   end
@@ -143,7 +152,7 @@ end
 -- Replace `/request_path` with `request_path`, and then prefix with a `/`
 -- or replace `/request_path/foo` with `/foo`, and then do not prefix with `/`.
 function _M.strip_request_path(uri, strip_request_path_pattern, upstream_url_has_path)
-  local uri = uri:gsub(strip_request_path_pattern, "", 1)
+  local uri = gsub(uri, strip_request_path_pattern, "", 1)
 
   -- Sometimes uri can be an empty string, and adding a slash "/"..uri will lead to a trailing slash
   -- We don't want to add a trailing slash in one specific scenario, when the upstream_url already has
@@ -182,8 +191,8 @@ local function find_api(uri, headers)
   api, matched_host, hosts_list = _M.find_api_by_request_host(headers, apis_dics)
   -- If it was found by Host, return
   if api then
-    ngx.req.set_header(constants.HEADERS.FORWARDED_HOST, matched_host)
-    return nil, api, matched_host, hosts_list
+    req_set_header(constants.HEADERS.FORWARDED_HOST, matched_host)
+    return nil, api, matched_host, hosts_list, nil
   end
 
   -- Otherwise, we look for it by request_path. We have to loop over all APIs and compare the requested URI.
@@ -193,12 +202,23 @@ local function find_api(uri, headers)
 end
 
 local function url_has_path(url)
-  local _, count_slashes = url:gsub("/", "")
+  local _, count_slashes = gsub(url, "/", "")
   return count_slashes > 2
 end
 
+local function strip_querystring(uri)
+  local m, err = re_match(uri, "^(.*)\\?", "oj") -- grab everything before "?"
+  if err then
+    log(ERR, "[resolver] error stripping querystring from URI: ", err)
+  elseif m and m[1] then
+    uri = m[1]
+  end
+
+  return uri
+end
+
 function _M.execute(request_uri, request_headers)
-  local uri = request_uri:match("^([^%?]+)")  -- grab everything before "?"
+  local uri = strip_querystring(request_uri)
   local err, api, matched_host, hosts_list, strip_request_path_pattern = find_api(uri, request_headers)
   if err then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
@@ -216,13 +236,13 @@ function _M.execute(request_uri, request_headers)
   -- If API was retrieved by request_path and the request_path needs to be stripped
   if strip_request_path_pattern and api.strip_request_path then
     uri = _M.strip_request_path(uri, strip_request_path_pattern, url_has_path(upstream_url))
-    ngx.req.set_header(constants.HEADERS.FORWARDED_PREFIX, api.request_path)
+    req_set_header(constants.HEADERS.FORWARDED_PREFIX, api.request_path)
   end
 
   upstream_url = upstream_url..uri
 
   if api.preserve_host then
-    upstream_host = matched_host or ngx.req.get_headers()["host"]
+    upstream_host = matched_host or req_get_headers()["host"]
   end
 
   if upstream_host == nil then


### PR DESCRIPTION
### Summary

Improve the performance of our resolver by avoiding string concatenation
on hot code paths and using the `ngx.re` API alongside with PCRE's
JIT compilation and compile-once mode instead of Lua's `string` module.

Note: this won't be a miracle solution making the resolver much faster.
It only partially improve the performance by using a different API, but
the implementation logic is still iterating over all the possible
`request_path` to test the request URI against it, one by one, so we
still have an O(n) matching function.

* use ngx.re API with `oj` flags in hot code paths
* cache some global calls
* compute `request_path_regex` ahead of time to avoid string
concatenation at runetime