### PR TITLE
fix(oauth2) create Cassandra index on oauth2_authorization_codes

### DIFF
--- a/kong/plugins/oauth2/migrations/cassandra.lua
+++ b/kong/plugins/oauth2/migrations/cassandra.lua
@@ -113,5 +113,11 @@ return {
     down = [[
       ALTER TABLE oauth2_authorization_codes DROP credential_id;
     ]]
+  },
+  {
+    name = "2016-09-19-oauth2_code_index",
+    up = [[
+      CREATE INDEX IF NOT EXISTS ON oauth2_authorization_codes(credential_id);
+    ]]
   }
 }


### PR DESCRIPTION
### Summary

In Cassandra OAuth2 applications can be deleted again by creating a Cassandra index on `oauth2_authorization_codes(credential_id)`.

### Full changelog

* Fixed an issue that prevented an OAuth2 credential to be deleted when using Cassandra.

### Issues resolved

Fix #1654.
