### PR TITLE
fix(cli) honor -c flag even if config exists at default location

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -263,8 +263,9 @@ local function load(path, custom_conf)
   if path and not pl_path.exists(path) then
     -- file conf has been specified and must exist
     return nil, "no file at: "..path
-  else
-    -- try to look for a conf, but no big deal if none
+  elseif not path then
+    -- try to look for a conf in default locations, but no big
+    -- deal if none is found: we will use our defaults.
     for _, default_path in ipairs(DEFAULT_PATHS) do
       if pl_path.exists(default_path) then
         path = default_path
@@ -376,6 +377,9 @@ end
 
 return setmetatable({
   load = load,
+  add_default_path = function(path)
+    DEFAULT_PATHS[#DEFAULT_PATHS+1] = path
+  end,
   remove_sensitive = function(conf)
     local purged_conf = tablex.deepcopy(conf)
     for k in pairs(CONF_SENSITIVE) do

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -312,6 +312,17 @@ describe("Configuration loader", function()
       assert.True(helpers.path.isabs(conf.ssl_cert))
       assert.True(helpers.path.isabs(conf.ssl_cert_key))
     end)
+    it("honors path if provided even if a default file exists", function()
+      conf_loader.add_default_path("spec/fixtures/to-strip.conf")
+
+      finally(function()
+        package.loaded["kong.conf_loader"] = nil
+        conf_loader = require "kong.conf_loader"
+      end)
+
+      local conf = assert(conf_loader(helpers.test_conf_path))
+      assert.equal("postgres", conf.database)
+    end)
   end)
 
   describe("errors", function()


### PR DESCRIPTION
* fix a condition to prevent loading one of the default locations if a
-c flag has been given
* add a function to extend the default path, only used in tests
* new test

Fix #1675