### PR TITLE
refactor(globalpatches) as a closure with options

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -5,17 +5,5 @@ require("kong.core.globalpatches")({
   rbusted = true
 })
 
--- force LuaSocket usage to resolve `/etc/hosts` until
--- supported by resty-cli.
--- See https://github.com/Mashape/kong/issues/1523
-for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
-  local socket = require(namespace .. ".socket")
-  socket.force_luasocket(ngx.get_phase(), true)
-end
-
-if ngx ~= nil then
-  ngx.exit = function()end
-end
-
 -- Busted command-line runner
 require 'busted.runner'({ standalone = false })

--- a/bin/busted
+++ b/bin/busted
@@ -1,6 +1,9 @@
 #!/usr/bin/env resty
 
-require("kong.core.globalpatches")({cli = true})
+require("kong.core.globalpatches")({
+  cli = true,
+  rbusted = true
+})
 
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.

--- a/bin/busted
+++ b/bin/busted
@@ -1,8 +1,6 @@
 #!/usr/bin/env resty
 
--- a flag to detect whether our modules (especially kong.core.globalpatches)
--- are running under resty-cli or in a real ngx_lua, runtime environment.
-ngx.RESTY_CLI = true
+require("kong.core.globalpatches")({cli = true})
 
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.

--- a/bin/kong
+++ b/bin/kong
@@ -1,17 +1,7 @@
 #!/usr/bin/env resty
 
-require("kong.core.globalpatches")({cli = true})
-
--- force LuaSocket usage to resolve `/etc/hosts` until
--- supported by resty-cli.
--- See https://github.com/Mashape/kong/issues/1523
-for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
-  local socket = require(namespace .. ".socket")
-  socket.force_luasocket(ngx.get_phase(), true)
-end
-
-if ngx ~= nil then
-  ngx.exit = function()end
-end
+require("kong.core.globalpatches")({
+  cli = true
+})
 
 require("kong.cmd.init")(arg)

--- a/bin/kong
+++ b/bin/kong
@@ -1,8 +1,6 @@
 #!/usr/bin/env resty
 
--- a flag to detect whether our modules (especially kong.core.globalpatches)
--- are running under resty-cli or in a real ngx_lua, runtime environment.
-ngx.RESTY_CLI = true
+require("kong.core.globalpatches")({cli = true})
 
 -- force LuaSocket usage to resolve `/etc/hosts` until
 -- supported by resty-cli.

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -3,6 +3,16 @@ return function(options)
 
   if options.cli then
     ngx.IS_CLI = true
+
+    ngx.exit = function()end
+
+    -- force LuaSocket usage to resolve `/etc/hosts` until
+    -- supported by resty-cli.
+    -- See https://github.com/Mashape/kong/issues/1523
+    for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
+      local socket = require(namespace .. ".socket")
+      socket.force_luasocket(ngx.get_phase(), true)
+    end
   end
 
   if options.rbusted then
@@ -21,7 +31,7 @@ return function(options)
       if assert_mt then
         assert_mt.__call = function(self, bool, message, level, ...)
           if not bool then
-            local lvl = 1
+            local lvl = 2
             if type(level) == "number" then
               lvl = level + 1
             end

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -1,43 +1,55 @@
-local meta = require "kong.meta"
-local randomseed = math.randomseed
+return function(options)
+  options = options or {}
 
-_G._KONG = {
-  _NAME = meta._NAME,
-  _VERSION = meta._VERSION
-}
-
-local seed
-
---- Seeds the random generator, use with care.
--- Once - properly - seeded, this method is replaced with a stub
--- one. This is to enforce best-practises for seeding in ngx_lua,
--- and prevents third-party modules from overriding our correct seed
--- (many modules make a wrong usage of `math.randomseed()` by calling
--- it multiple times or do not use unique seed for Nginx workers).
---
--- This patched method will create a unique seed per worker process,
--- using a combination of both time and the worker's pid.
--- luacheck: globals math
-_G.math.randomseed = function()
-  if not seed then
-    -- If we're in runtime nginx, we have multiple workers so we _only_
-    -- accept seeding when in the 'init_worker' phase.
-    -- That is because that phase is the earliest one before the
-    -- workers have a chance to process business logic, and because
-    -- if we'd do that in the 'init' phase, the Lua VM is not forked
-    -- yet and all workers would end-up using the same seed.
-    if not ngx.RESTY_CLI and ngx.get_phase() ~= "init_worker" then
-      error("math.randomseed() must be called in init_worker", 2)
-    end
-
-    seed = ngx.time() + ngx.worker.pid()
-    ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker nb ", ngx.worker.id(),
-                       " (pid: ", ngx.worker.pid(), ")")
-    randomseed(seed)
-  else
-    ngx.log(ngx.DEBUG, "attempt to seed random number generator, but ",
-                       "already seeded with ", seed)
+  if options.cli then
+    ngx.IS_CLI = true
   end
 
-  return seed
+  do
+    local meta = require "kong.meta"
+
+    _G._KONG = {
+      _NAME = meta._NAME,
+      _VERSION = meta._VERSION
+    }
+  end
+
+  do
+    local randomseed = math.randomseed
+    local seed
+
+    --- Seeds the random generator, use with care.
+    -- Once - properly - seeded, this method is replaced with a stub
+    -- one. This is to enforce best-practises for seeding in ngx_lua,
+    -- and prevents third-party modules from overriding our correct seed
+    -- (many modules make a wrong usage of `math.randomseed()` by calling
+    -- it multiple times or do not use unique seed for Nginx workers).
+    --
+    -- This patched method will create a unique seed per worker process,
+    -- using a combination of both time and the worker's pid.
+    -- luacheck: globals math
+    _G.math.randomseed = function()
+      if not seed then
+        -- If we're in runtime nginx, we have multiple workers so we _only_
+        -- accept seeding when in the 'init_worker' phase.
+        -- That is because that phase is the earliest one before the
+        -- workers have a chance to process business logic, and because
+        -- if we'd do that in the 'init' phase, the Lua VM is not forked
+        -- yet and all workers would end-up using the same seed.
+        if not options.cli and ngx.get_phase() ~= "init_worker" then
+          error("math.randomseed() must be called in init_worker", 2)
+        end
+
+        seed = ngx.time() + ngx.worker.pid()
+        ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker nb ", ngx.worker.id(),
+                           " (pid: ", ngx.worker.pid(), ")")
+        randomseed(seed)
+      else
+        ngx.log(ngx.DEBUG, "attempt to seed random number generator, but ",
+                           "already seeded with ", seed)
+      end
+
+      return seed
+    end
+  end
 end

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -5,51 +5,82 @@ return function(options)
     ngx.IS_CLI = true
   end
 
-  do
-    local meta = require "kong.meta"
+  if options.rbusted then
 
-    _G._KONG = {
-      _NAME = meta._NAME,
-      _VERSION = meta._VERSION
-    }
-  end
+    do
+      -- patch luassert's 'assert' because very often we use the Lua idiom:
+      -- local res = assert(some_method())
+      -- in our tests.
+      -- luassert's 'assert' would error out in case the assertion fails, and
+      -- if 'some_method()' returns a third return value because we attempt to
+      -- perform arithmetic (+1) to the 'level' argument of 'assert'.
+      -- This error would often supersed the actual error (arg #2) and be painful
+      -- to debug.
+      local assert = require "luassert.assert"
+      local assert_mt = getmetatable(assert)
+      if assert_mt then
+        assert_mt.__call = function(self, bool, message, level, ...)
+          if not bool then
+            local lvl = 1
+            if type(level) == "number" then
+              lvl = level + 1
+            end
+            error(message or "assertion failed!", lvl)
+          end
+          return bool, message, level, ...
+        end
+      end
+    end
 
-  do
-    local randomseed = math.randomseed
-    local seed
+  else
 
-    --- Seeds the random generator, use with care.
-    -- Once - properly - seeded, this method is replaced with a stub
-    -- one. This is to enforce best-practises for seeding in ngx_lua,
-    -- and prevents third-party modules from overriding our correct seed
-    -- (many modules make a wrong usage of `math.randomseed()` by calling
-    -- it multiple times or do not use unique seed for Nginx workers).
-    --
-    -- This patched method will create a unique seed per worker process,
-    -- using a combination of both time and the worker's pid.
-    -- luacheck: globals math
-    _G.math.randomseed = function()
-      if not seed then
-        -- If we're in runtime nginx, we have multiple workers so we _only_
-        -- accept seeding when in the 'init_worker' phase.
-        -- That is because that phase is the earliest one before the
-        -- workers have a chance to process business logic, and because
-        -- if we'd do that in the 'init' phase, the Lua VM is not forked
-        -- yet and all workers would end-up using the same seed.
-        if not options.cli and ngx.get_phase() ~= "init_worker" then
-          error("math.randomseed() must be called in init_worker", 2)
+    do
+      local meta = require "kong.meta"
+
+      _G._KONG = {
+        _NAME = meta._NAME,
+        _VERSION = meta._VERSION
+      }
+    end
+
+    do
+      local randomseed = math.randomseed
+      local seed
+
+      --- Seeds the random generator, use with care.
+      -- Once - properly - seeded, this method is replaced with a stub
+      -- one. This is to enforce best-practises for seeding in ngx_lua,
+      -- and prevents third-party modules from overriding our correct seed
+      -- (many modules make a wrong usage of `math.randomseed()` by calling
+      -- it multiple times or do not use unique seed for Nginx workers).
+      --
+      -- This patched method will create a unique seed per worker process,
+      -- using a combination of both time and the worker's pid.
+      -- luacheck: globals math
+      _G.math.randomseed = function()
+        if not seed then
+          -- If we're in runtime nginx, we have multiple workers so we _only_
+          -- accept seeding when in the 'init_worker' phase.
+          -- That is because that phase is the earliest one before the
+          -- workers have a chance to process business logic, and because
+          -- if we'd do that in the 'init' phase, the Lua VM is not forked
+          -- yet and all workers would end-up using the same seed.
+          if not options.cli and ngx.get_phase() ~= "init_worker" then
+            error("math.randomseed() must be called in init_worker", 2)
+          end
+
+          seed = ngx.time() + ngx.worker.pid()
+          ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker nb ", ngx.worker.id(),
+                             " (pid: ", ngx.worker.pid(), ")")
+          randomseed(seed)
+        else
+          ngx.log(ngx.DEBUG, "attempt to seed random number generator, but ",
+                             "already seeded with ", seed)
         end
 
-        seed = ngx.time() + ngx.worker.pid()
-        ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker nb ", ngx.worker.id(),
-                           " (pid: ", ngx.worker.pid(), ")")
-        randomseed(seed)
-      else
-        ngx.log(ngx.DEBUG, "attempt to seed random number generator, but ",
-                           "already seeded with ", seed)
+        return seed
       end
-
-      return seed
     end
+
   end
 end

--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -6,7 +6,7 @@ local uuid = utils.uuid
 
 local cassandra
 
-if ngx.RESTY_CLI then
+if ngx.IS_CLI then
   local ngx_stub = _G.ngx
   _G.ngx = nil
   cassandra = require "cassandra"

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -24,7 +24,7 @@
 -- |[[    ]]|
 -- ==========
 
-require "kong.core.globalpatches"
+require("kong.core.globalpatches")()
 
 local core = require "kong.core.handler"
 local Serf = require "kong.serf"

--- a/spec/01-unit/00-globalpatches_spec.lua
+++ b/spec/01-unit/00-globalpatches_spec.lua
@@ -1,0 +1,11 @@
+describe("globalpatches", function()
+  describe("assert", function()
+    it("does not errors zhen arg #3 is not a number", function()
+      -- if not patched, this would throw:
+      -- luassert/assert.lua:155: attempt to perform arithmetic on a string value
+      assert.error_matches(function()
+        assert(false, "some error", "some return value")
+      end, "some error", nil, true)
+    end)
+  end)
+end)


### PR DESCRIPTION
This should be cleaner than relying on a global set in the resty-cli
scripts. This way, we:

- keep all interactions with _G in `kong.core.globalpatches` only
- are accurate as to how to load those patches and potentially support
other options in the future, rather than trying to detect `arg` in
`globalpatches`.