### PR TITLE
fix(cli): changing the order in the DEFAULT_PATHS table

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -10,8 +10,8 @@ local tablex = require "pl.tablex"
 local log = require "kong.cmd.utils.log"
 
 local DEFAULT_PATHS = {
-  "/etc/kong.conf",
-  "/etc/kong/kong.conf"
+  "/etc/kong/kong.conf",
+  "/etc/kong.conf"
 }
 
 local PREFIX_PATHS = {


### PR DESCRIPTION
### Summary

changing the order in the DEFAULT_PATHS table
/etc/kong/kong.conf is supposed to be the preferred way.

### Issues resolved

Fix #1697 
