### PR TITLE
refactor(statsd) rework the statsd plugin to be more configurable

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -5,7 +5,9 @@ function _M.serialize(ngx)
   if ngx.ctx.authenticated_credential ~= nil then
     authenticated_entity = {
       id = ngx.ctx.authenticated_credential.id,
-      consumer_id = ngx.ctx.authenticated_credential.consumer_id
+      consumer_id = ngx.ctx.authenticated_credential.consumer_id,
+      custom_id = ngx.ctx.authenticated_consumer.custom_id,
+      username = ngx.ctx.authenticated_consumer.username
     }
   end
 

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -13,61 +13,106 @@ local pairs = pairs
 local NGX_ERR = ngx.ERR
 
 local gauges = {
-  request_size = function (api_name, message, logger)
-    local stat = api_name..".request.size"
-    logger:gauge(stat, message.request.size, 1)
+  gauge = function (stat_name, stat_value, metric_config, logger)
+    local sample_rate = metric_config.sample_rate
+    logger:stat_type(stat_name, stat_value, sample_rate)
   end,
-  response_size = function (api_name, message, logger)
-    local stat = api_name..".response.size"
-    logger:gauge(stat, message.response.size, 1)
+  timer = function (stat_name, stat_value, metric_config, logger)
+    logger:timer(stat_name, stat_value)
   end,
-  status_count = function (api_name, message, logger)
+  counter = function (stat_name, stat_value, metric_config, logger)
+    local sample_rate = metric_config.sample_rate
+    logger:counter(stat_name, 1, sample_rate)
+  end,
+  set = function (stat_name, stat_value, metric_config, logger)
+    logger:set(stat_name, stat_value)
+  end,
+  histogram = function (stat_name, stat_value, metric_config, logger)
+    logger:histogram(stat_name, stat_value)
+  end,
+  meter = function (stat_name, stat_value, metric_config, logger)
+    logger:meter(stat_name, stat_value)
+  end,
+  status_count = function (api_name, message, metric_config, logger)
     local stat = api_name..".request.status."..message.response.status
-    logger:counter(stat, 1, 1)
+    local total_count = api_name..".request.status.total"
+    local sample_rate = metric_config.sample_rate
+    logger:counter(stat, 1, sample_rate)
+    logger:counter(total_count, 1, sample_rate)
   end,
-  latency = function (api_name, message, logger)
-    local stat = api_name..".latency"
-    logger:gauge(stat, message.latencies.request, 1)
-  end,
-  request_count = function (api_name, message, logger)
-    local stat = api_name..".request.count"
-    logger:counter(stat, 1, 1)
-  end,
-  unique_users = function (api_name, message, logger)
-    if message.authenticated_entity ~= nil and message.authenticated_entity.consumer_id ~= nil then
+  unique_users = function (api_name, message, metric_config, logger)
+    local identifier = metric_config.consumer_identifier
+    if message.authenticated_entity ~= nil and message.authenticated_entity[identifier] ~= nil then
       local stat = api_name..".user.uniques"
-      logger:set(stat, message.authenticated_entity.consumer_id)
+      logger:set(stat, message.authenticated_entity[identifier])
     end
   end,
-  request_per_user = function (api_name, message, logger)
-    if message.authenticated_entity ~= nil and message.authenticated_entity.consumer_id ~= nil then
-      local stat = api_name.."."..string_gsub(message.authenticated_entity.consumer_id, "-", "_")..".request.count"
-      logger:counter(stat, 1, 1)    
+  request_per_user = function (api_name, message, metric_config, logger)
+    local identifier = metric_config.consumer_identifier
+    if message.authenticated_entity ~= nil and message.authenticated_entity[identifier] ~= nil then
+      local sample_rate = metric_config.sample_rate
+      local stat = api_name..".user."..string_gsub(message.authenticated_entity[identifier], "-", "_")..".request.count"
+      logger:counter(stat, 1, sample_rate)
     end
   end,
-  upstream_latency = function (api_name, message, logger)
-    local stat = api_name..".upstream_latency"
-    logger:gauge(stat, message.latencies.proxy, 1)
-  end,
+  status_count_per_user = function (api_name, message, metric_config, logger)
+    local identifier = metric_config.consumer_identifier
+    if message.authenticated_entity ~= nil and message.authenticated_entity[identifier] ~= nil then
+      local stat = api_name..".user."..string_gsub(message.authenticated_entity[identifier], "-", "_")..".request.status."..message.response.status
+      local total_count = api_name..".user."..string_gsub(message.authenticated_entity[identifier], "-", "_")..".request.status.total"
+      local sample_rate = metric_config.sample_rate
+      logger:counter(stat, 1, sample_rate)
+      logger:counter(total_count, 1, sample_rate)
+    end
+  end
 }
 
 local function log(premature, conf, message)
   if premature then return end
-  
+
+  local api_name = string_gsub(message.api.name, "%.", "_")
+
+  local stat_name = {
+    request_size = api_name..".request.size",
+    response_size = api_name..".response.size",
+    latency = api_name..".latency",
+    upstream_latency = api_name..".upstream_latency",
+    kong_latency = api_name..".kong_latency",
+    request_count = api_name..".request.count"
+  }
+
+  local stat_value = {
+    request_size = message.request.size,
+    response_size = message.response.size,
+    latency = message.latencies.request,
+    upstream_latency = message.latencies.proxy,
+    kong_latency = message.latencies.kong,
+    request_count = api_name..".request.count"
+  }
+
   local logger, err = statsd_logger:new(conf)
+
   if err then
     ngx_log(NGX_ERR, "failed to create Statsd logger: ", err)
     return
   end
-  
-  local api_name = string_gsub(message.api.name, "%.", "_")
-  for _, metric in pairs(conf.metrics) do
-    local gauge = gauges[metric]
-    if gauge ~= nil then
-      gauge(api_name, message, logger)
+
+  for _, metric_config in pairs(conf.metrics) do
+    if metric_config.name ~= "status_count" and metric_config.name ~= "unique_users" and metric_config.name ~= "request_per_user" and metric_config.name ~= "status_count_per_user" then
+      local stat_name = stat_name[metric_config.name]
+      local stat_value = stat_value[metric_config.name]
+      local gauge = gauges[metric_config.stat_type]
+      if stat_name ~= nil and gauge ~= nil and stat_value ~= nil then
+        gauge(stat_name, stat_value, metric_config, logger)
+      end
+    else
+      local gauge = gauges[metric_config.name]
+      if gauge ~= nil then
+        gauge(api_name, message, metric_config, logger)
+      end
     end
   end
-  
+
   logger:close_socket()
 end
 
@@ -78,7 +123,7 @@ end
 function StatsdHandler:log(conf)
   StatsdHandler.super.log(self)
   local message = basic_serializer.serialize(ngx)
-  
+
   local ok, err = ngx_timer_at(0, log, conf, message)
   if not ok then
     ngx_log(NGX_ERR, "failed to create timer: ", err)

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -6,8 +6,120 @@ local metrics = {
   "response_size",
   "unique_users",
   "request_per_user",
-  "upstream_latency"
+  "upstream_latency",
+  "kong_latency",
+  "status_count_per_user"
 }
+
+local stat_types = {
+  "gauge",
+  "timer",
+  "counter",
+  "histogram",
+  "meter",
+  "set"
+}
+
+local consumer_identifiers = {
+  "consumer_id",
+  "custom_id",
+  "username"
+}
+
+local default_metrics = {
+  {
+    name = "request_count",
+    stat_type = "counter",
+    sample_rate = 1
+  },
+  {
+    name = "latency",
+    stat_type = "timer"
+  },
+  {
+    name = "request_size",
+    stat_type = "timer"
+  },
+  {
+    name = "status_count",
+    stat_type = "counter",
+    sample_rate = 1
+  },
+  {
+    name = "response_size",
+    stat_type = "timer"
+  },
+  {
+    name = "unique_users",
+    stat_type = "set",
+    consumer_identifier = "custom_id"
+  },
+  {
+    name = "request_per_user",
+    stat_type = "counter",
+    sample_rate = 1,
+    consumer_identifier = "custom_id"
+  },
+  {
+    name = "upstream_latency",
+    stat_type = "timer"
+  },
+  {
+    name = "kong_latency",
+    stat_type = "timer"
+  },
+  {
+    name = "status_count_per_user",
+    stat_type = "counter",
+    sample_rate = 1,
+    consumer_identifier = "custom_id"
+  }
+}
+
+local function check_value(table, element)
+  for _, value in pairs(table) do
+    if value == element then
+      return true
+    end
+  end
+  return false
+end
+
+local function check_schema(value)
+  for _, entry in ipairs(value) do
+    local name_ok = check_value(metrics, entry.name)
+    local type_ok = check_value(stat_types, entry.stat_type)
+
+    if not name_ok then
+      return false, "unrecognized metric name: "..entry.name
+    end
+    if not type_ok then
+      return false, "unrecognized stat_type: "..entry.stat_type
+    end
+    if entry.name == nil or entry.stat_type == nil then
+      return false, "name and stat_type must be defined for all stats"
+    end
+    if (entry.stat_type == "counter" or entry.stat_type == "gauge") and (type(entry.sample_rate) ~= "number") and (entry.sample_rate < 1) then
+      return false, "sample rate must be defined for counters and gauges."
+    end
+    if (entry.stat_type == "status_count_per_user" or entry.stat_type == "request_per_user" or entry.stat_type == "unique_users") and entry.consumer_identifier == nil then
+      return false, "consumer_identifier must be defined for stat_type "..entry.stat_type
+    end
+    if (entry.stat_type == "status_count_per_user" or entry.stat_type == "request_per_user" or entry.stat_type == "unique_users") and entry.consumer_identifier ~= nil then
+      local identifier_ok = check_value(consumer_identifiers, entry.consumer_identifier)
+      if not identifier_ok then
+        return false, "invalid consumer_identifier for stat_type "..entry.stat_type..". Choices are consumer_id, custom_id, and username"
+      end
+    end
+    if entry.name == "unique_users" and entry.stat_type ~= "set" then
+      return false, "unique_users metric only works with stat_type 'set'"
+    end
+    if (entry.name == "status_count" or entry.name == "status_count_per_user" or entry.name == "request_per_user") and entry.stat_type ~= "counter" then
+      return false, entry.name.." metric only works with stat_type 'counter'"
+    end
+  end
+  return true
+end
 
 return {
   fields = {
@@ -16,8 +128,8 @@ return {
     metrics = {
       type = "array",
       required = true,
-      default = metrics,
-      enum = metrics
+      default = default_metrics,
+      func = check_schema
     },
     timeout = {type = "number", default = 10000}
   }


### PR DESCRIPTION
### Summary

Overhauls the statsd plugin to allow for some configuration of the statsd stat type to use, sample rate, and consumer identifier to use. 
### Full changelog
- Changes the basic.lua log-serializer to return custom_id and username so those options are available to use on stats that need a consumer identifier (unique_users, status_count_per_user, request_per_user)
- Drastically changes schema for the plugin to allow the user to determine the stat type (set, gauge, timer, etc) for available stats. Doesn't allow users to make configurations that don't make sense (i.e. can only set unique_users to a set, count stats only allow counter)
- For status_count and status_count_per_user, adds a total counter at the same level to make map / reduce functions easier to use in graphite / grafana. 
- Adds test cases for each stat.
