### PR TITLE
fix(globalpatches) log seed error instead of erroring out

### DIFF
--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -76,7 +76,9 @@ return function(options)
           -- if we'd do that in the 'init' phase, the Lua VM is not forked
           -- yet and all workers would end-up using the same seed.
           if not options.cli and ngx.get_phase() ~= "init_worker" then
-            error("math.randomseed() must be called in init_worker", 2)
+            local debug = require "debug"
+            ngx.log(ngx.WARN, "math.randomseed() must be called in init_worker context\n",
+                              debug.traceback())
           end
 
           seed = ngx.time() + ngx.worker.pid()


### PR DESCRIPTION
### Summary

log the issues instead of erroring out to prevent `lua_code_cache=off`
from being aborted when math.randomseed is called from defectuous
modules.

### Full changelog

* replace `error(...)` with `ngx.log(ngx.WARN, ...)`

### Issues resolved

Fix #1716