### PR TITLE
Bug fix: Admin changes are not reflecting in proxy

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -225,8 +225,8 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   log.verbose("saving serf shell script handler to %s", kong_config.serf_event)
   -- setting serf admin ip
   local admin_ip = kong_config.admin_ip
-  if kong_config.admin_ip == '0.0.0.0' then
-    admin_ip = '127.0.0.1';
+  if kong_config.admin_ip == "0.0.0.0" then
+    admin_ip = "127.0.0.1";
   end
   -- saving serf script handler
   local script = fmt(script_template, admin_ip, kong_config.admin_port, resty_bin)

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -223,7 +223,13 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   if not resty_bin then return nil, err end
 
   log.verbose("saving serf shell script handler to %s", kong_config.serf_event)
-  local script = fmt(script_template, "127.0.0.1", kong_config.admin_port, resty_bin)
+  -- setting serf admin ip
+  admin_ip = kong_config.admin_ip
+  if kong_config.admin_ip == '0.0.0.0' then
+    admin_ip = '127.0.0.1';
+  end
+  -- saving serf script handler
+  local script = fmt(script_template, admin_ip, kong_config.admin_port, resty_bin)
   pl_file.write(kong_config.serf_event, script)
   local ok, _, _, stderr = pl_utils.executeex("chmod +x "..kong_config.serf_event)
   if not ok then return nil, stderr end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -224,7 +224,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
 
   log.verbose("saving serf shell script handler to %s", kong_config.serf_event)
   -- setting serf admin ip
-  admin_ip = kong_config.admin_ip
+  local admin_ip = kong_config.admin_ip
   if kong_config.admin_ip == '0.0.0.0' then
     admin_ip = '127.0.0.1';
   end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -226,7 +226,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   -- setting serf admin ip
   local admin_ip = kong_config.admin_ip
   if kong_config.admin_ip == "0.0.0.0" then
-    admin_ip = "127.0.0.1";
+    admin_ip = "127.0.0.1"
   end
   -- saving serf script handler
   local script = fmt(script_template, admin_ip, kong_config.admin_port, resty_bin)


### PR DESCRIPTION
### Summary

In case of admin ip changed from default.
The admin api changes are not being pushed to serf.
As the default ip (127.0.0.1) is hardcoded in the script.

### Full changelog

* Set the new admin ip if changed from default.

### Issues resolved

Fix #1509 

Setting the admin IP if changed from default.
Fix for issue: https://github.com/Mashape/kong/issues/1509