### PR TITLE
fix (plugin/ldap) fixed cache_ttl

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -68,8 +68,7 @@ local function authenticate(conf, given_credentials)
   if given_username == nil then
     return false
   end
-
-  local credential = cache.get_or_set(cache.ldap_credential_key(given_username), function()
+  local credential = cache.get_or_set(cache.ldap_credential_key(ngx.ctx.api.id, given_username), function()
     ngx_log(ngx_debug, "[ldap-auth] authenticating user against LDAP server: "..conf.ldap_host..":"..conf.ldap_port)
 
     local ok, err = ldap_authenticate(given_username, given_password, conf)

--- a/kong/tools/database_cache.lua
+++ b/kong/tools/database_cache.lua
@@ -29,12 +29,12 @@ function _M.rawset(key, value, exptime)
   return cache:set(key, value, exptime or 0)
 end
 
-function _M.set(key, value)
+function _M.set(key, value, exptime)
   if value then
     value = cjson.encode(value)
   end
 
-  return _M.rawset(key, value)
+  return _M.rawset(key, value, exptime)
 end
 
 function _M.rawget(key)
@@ -106,8 +106,8 @@ function _M.jwtauth_credential_key(secret)
   return CACHE_KEYS.JWTAUTH_CREDENTIAL..":"..secret
 end
 
-function _M.ldap_credential_key(username)
-  return CACHE_KEYS.LDAP_CREDENTIAL.."/"..username
+function _M.ldap_credential_key(api_id, username)
+  return CACHE_KEYS.LDAP_CREDENTIAL.."_"..api_id..":"..username
 end
 
 function _M.acls_key(consumer_id)
@@ -126,7 +126,7 @@ function _M.all_apis_by_dict_key()
   return CACHE_KEYS.ALL_APIS_BY_DIC
 end
 
-function _M.get_or_set(key, cb)
+function _M.get_or_set(key, cb, exptime)
   -- Try to get the value from the cache
   local value = _M.get(key)
   if value then return value end
@@ -153,7 +153,7 @@ function _M.get_or_set(key, cb)
     -- Get from closure
     value = cb()
     if value then
-      local ok, err = _M.set(key, value)
+      local ok, err = _M.set(key, value, exptime)
       if not ok then
         ngx_log(ngx.ERR, err)
       end

--- a/spec/01-unit/11-database_cache_spec.lua
+++ b/spec/01-unit/11-database_cache_spec.lua
@@ -30,5 +30,9 @@ describe("Database cache", function()
   it("returns a valid requests cache key", function()
     assert.are.equal("requests", cache.requests_key())
   end)
+  
+  it("returns a valid LDAPAuthcredentials cache key", function()
+    assert.are.equal("ldap_credentials_0c704b70-3f30-49ad-9418-3968e53c8d98:username", cache.ldap_credential_key("0c704b70-3f30-49ad-9418-3968e53c8d98", "username"))
+  end)
 
 end)

--- a/spec/03-plugins/08-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/08-ldap-auth/01-access_spec.lua
@@ -2,7 +2,7 @@ local cache = require "kong.tools.database_cache"
 local helpers = require "spec.helpers"
 
 describe("Plugin: ldap-auth (access)", function()
-  local client
+  local client, client_admin, api2, plugin2
   setup(function()
     assert(helpers.start_kong())
 
@@ -11,7 +11,7 @@ describe("Plugin: ldap-auth (access)", function()
       request_host = "ldap.com",
       upstream_url = "http://mockbin.com"
     })
-    local api2 = assert(helpers.dao.apis:insert {
+    api2 = assert(helpers.dao.apis:insert {
       name = "test-ldap2",
       request_host = "ldap2.com",
       upstream_url = "http://mockbin.com"
@@ -28,7 +28,7 @@ describe("Plugin: ldap-auth (access)", function()
         attribute = "uid"
       }
     })
-    assert(helpers.dao.plugins:insert {
+    plugin2 = assert(helpers.dao.plugins:insert {
       api_id = api2.id,
       name = "ldap-auth",
       config = {
@@ -37,7 +37,8 @@ describe("Plugin: ldap-auth (access)", function()
         start_tls = false,
         base_dn = "ou=scientists,dc=ldap,dc=mashape,dc=com",
         attribute = "uid",
-        hide_credentials = true
+        hide_credentials = true,
+        cache_ttl = 2
       }
     })
   end)
@@ -47,6 +48,7 @@ describe("Plugin: ldap-auth (access)", function()
 
   before_each(function()
     client = helpers.proxy_client()
+    client_admin = helpers.admin_client()
   end)
   after_each(function()
     if client then client:close() end
@@ -216,24 +218,34 @@ describe("Plugin: ldap-auth (access)", function()
       method = "GET",
       path = "/request",
       headers = {
-        host = "ldap.com",
+        host = "ldap2.com",
         authorization = "ldap "..ngx.encode_base64("einstein:password")
       }
     })
     assert.response(r).has.status(200)
 
     -- Check that cache is populated
-    local cache_key = cache.ldap_credential_key("einstein")
-    local exists = true
-    while(exists) do
-      local r = assert(client:send {
+    local cache_key = cache.ldap_credential_key(api2.id , "einstein")
+    helpers.wait_until(function()
+      local res = assert(client_admin:send {
         method = "GET",
-        path = "/cache/"..cache_key,
+        path = "/cache/"..cache_key
       })
-      if r.status ~= 200 then
-        exists = false
+      res:read_body()
+      return res.status == 200
+    end)
+    
+    -- Check that cache is invalidated
+    helpers.wait_until(function()
+      local res = client_admin:send {
+        method = "GET",
+        path = "/cache/"..cache_key
+      }
+      res:read_body()
+      if res.status ~=404 then
+        ngx.sleep( plugin2.config.cache_ttl / 5 )
       end
-    end
-    assert.equals(200, r.status)
+      return res.status == 404
+    end, plugin2.config.cache_ttl + 60)
   end)
 end)


### PR DESCRIPTION
### Summary

Added TTL back to `database_cache.get_or_set` method for invalidating cached data timely 
### Full changelog

Updated  `database_cache.get_or_set` method to support expiration of cached data
Updated `database_cache.ldap_credential_key` method to make `username` unique across APIs
Added test for cache invalidation   
### Issues resolved

Fix #1695
