### PR TITLE
fix(oauth2) Issue with application/json GET requests

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -91,10 +91,11 @@ local function retrieve_parameters()
   -- OAuth2 parameters could be in both the querystring or body
   local body_parameters
   local content_type = req_get_headers()[CONTENT_TYPE]
-  if content_type and string_find(content_type:lower(), "multipart/form-data", nil, true) then
-    body_parameters = Multipart(ngx.req.get_body_data(), content_type):get_all()
-  elseif content_type and string_find(content_type:lower(), "application/json", nil, true) then
-    body_parameters = json.decode(ngx.req.get_body_data())
+  local body_data = ngx.req.get_body_data()
+  if content_type and body_data and string_find(content_type:lower(), "multipart/form-data", nil, true) then
+    body_parameters = Multipart(body_data, content_type):get_all()
+  elseif content_type and body_data and string_find(content_type:lower(), "application/json", nil, true) then
+    body_parameters = json.decode(body_data)
   else
     body_parameters = ngx.req.get_post_args()
   end


### PR DESCRIPTION
Hello Kong maintainers,
Side note -- I've tried to be a good open source citizen, but getting a Kong development environment turned out to be too time consuming for this project, therefore I can't provide tests for this PR, besides my word that it's working for us.
### Summary

We've noticed an issue in the OAuth2 plugin that would return a server error on HTTP GET requests of content-type application/json. This commit fixes it.
### Full changelog
- Fix OAuth2 plugin for GET requests with a content-type of application/json
### Issues resolved

GET requests can come through with a content-type of 'application/json',
but will lack a body. The existing code will break on this case, by
trying to parse a body that doesn't exist -- this commit adds the
condition that the body must exist before we try parsing it.
