### PR TITLE
Allow multiple origin domains for CORS

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -7,8 +7,23 @@ CorsHandler.PRIORITY = 2000
 
 local OPTIONS = "OPTIONS"
 
+local function host_in_domain(domain, conf)
+  for i, d in ipairs(conf.origin_domains) do
+    if string.match(domain, '[%.|//]'..d..'$') then
+      return true
+    end
+  end
+  return false
+end
+
 local function configure_origin(ngx, conf)
-  if conf.origin == nil then
+  local origin = ngx.req.get_headers()["origin"] or nil
+  if conf.origin_domains ~= nil then
+   if origin ~= nil and host_in_domain(origin, conf) then
+      ngx.header["Access-Control-Allow-Origin"] = origin
+      ngx.header["Vary"] = "Origin"
+    end
+  elseif conf.origin == nil then
     ngx.header["Access-Control-Allow-Origin"] = "*"
   else
     ngx.header["Access-Control-Allow-Origin"] = conf.origin

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -7,6 +7,7 @@ return {
     methods = { type = "array", enum = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE" } },
     max_age = { type = "number" },
     credentials = { type = "boolean", default = false },
-    preflight_continue = { type = "boolean", default = false }
+    preflight_continue = { type = "boolean", default = false },
+    origin_domains = { type = "array" }
   }
 }


### PR DESCRIPTION
### Summary

When several domains consume an API, the CORS header Access-Control-Allow-Origin is not as useful, because it only allows one domain, or all domains (with "*"). The specs do not allow for a list of domains. This change works around this by comparing the Origin header to a list of configured domain in the array 'origin_domains'. It tests if the end of the domain matches either ".{domain}" or "//{domain}". Thus, if origins_domain="example.com, example.net", a request from Origin="http://www.example.com" would be allowed, as does a request from Origin="http://example.com". But Origin="http://my-example.com" is not allowed. In this case, no Access-Control-Allow-Origin header is set.
If both origin and origin_domains are configured, origin_domains take precedence over origin.
### Full changelog
- Changes to CORS plugin schema to have extra configuration for origin_domains[]
- Changes to CORS plugin handler to test for multiple domain and set correct header
- Changes to test script to test if the correct header is set when the origin domain matches
- Changes to test script to test if the header remains empty when the origin domain does not match
### Issues resolved

Fix #1043 
