### PR TITLE
hotfix(serf) properly clean up nodes table and regenerate node name

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -45,6 +45,11 @@ local stop_script_template = [[
 #!/bin/sh
 
 CMD="\
+ngx.RESTY_CLI = true \
+for _, namespace in ipairs({'cassandra', 'pgmoon-mashape'}) do \
+  local socket = require(namespace .. '.socket') \
+  socket.force_luasocket(ngx.get_phase(), true) \
+end \
 local conf_loader = require 'kong.conf_loader' \
 local DAOFactory = require 'kong.dao.factory' \
 local Serf = require 'kong.serf' \

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -20,6 +20,8 @@ local PREFIX_PATHS = {
   serf_pid = {"pids", "serf.pid"},
   serf_log = {"logs", "serf.log"},
   serf_event = {"serf", "serf_event.sh"},
+  serf_start = {"serf", "serf_start.sh"},
+  serf_stop = {"serf", "serf_stop.sh"},
   serf_node_id = {"serf", "serf.id"}
   ;
   nginx_pid = {"pids", "nginx.pid"},

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -214,7 +214,7 @@ describe("NGINX conf compiler", function()
       local identifier = helpers.file.read(tmp_config.serf_node_id)
       assert.is_string(identifier)
     end)
-    it("preserves Serf identifier if already exists", function()
+    it("does not preserve Serf identifier if already exists", function()
       -- prepare twice
       assert(prefix_handler.prepare_prefix(tmp_config))
       local identifier_1 = helpers.file.read(tmp_config.serf_node_id)
@@ -222,7 +222,7 @@ describe("NGINX conf compiler", function()
       assert(prefix_handler.prepare_prefix(tmp_config))
       local identifier_2 = helpers.file.read(tmp_config.serf_node_id)
 
-      assert.equal(identifier_1, identifier_2)
+      assert.not_equal(identifier_1, identifier_2)
     end)
 
     describe("ssl", function()

--- a/spec/02-integration/01-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/01-cmd/02-start_stop_spec.lua
@@ -139,6 +139,21 @@ describe("kong start/stop", function()
       assert(helpers.kong_exec("stop --prefix "..helpers.test_conf.prefix))
       assert.False(helpers.path.exists(helpers.test_conf.serf_pid))
     end)
+    it("removes node from database on forced shutdown", function()
+      assert.equal(0, helpers.dao.nodes:count())
+
+      assert(helpers.kong_exec("start --conf "..helpers.test_conf_path))
+      assert.truthy(helpers.path.exists(helpers.test_conf.serf_pid))
+      assert.equal(1, helpers.dao.nodes:count())
+
+      os.execute("pkill -9 serf")
+
+      helpers.wait_until(function()
+        return helpers.dao.nodes:count() == 0
+      end)
+
+      assert.truthy(helpers.path.exists(helpers.test_conf.serf_pid))
+    end)
   end)
 
   describe("dnsmasq", function()


### PR DESCRIPTION
### Full changelog
- Properly clean up node tables on `SIGTERM` and `SIGKILL`.
- Regenerates the `serf.id` value every time Kong starts/restarts.
### Issues closed

Closes #1739.
