### PR TITLE
Fix nginx conf, proxy_set_header: X-Forwarded-For header

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -79,7 +79,7 @@ server {
         }
 
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For '$X-Forwarded-For,$origin_remote_addr';
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $upstream_host;
         proxy_pass_header Server;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -73,7 +73,7 @@ http {
             }
 
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For '$X-Forwarded-For,$origin_remote_addr';
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $upstream_host;
             proxy_pass_header Server;


### PR DESCRIPTION

### Summary

if use nginx module `ngx_http_realip_module`,   the following configuration statement is wrong

```
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```

Correct configuration

```
proxy_set_header  X-Forwarded-For '$X-Forwarded-For,$origin_remote_addr';
```

### Issues resolved

Fix #1762 
