### PR TITLE
Fix/dns comments

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -109,7 +109,7 @@
                                  # to the SSL key for the `admin_listen_ssl`
                                  # address.
 
-#nginx_keepalive = 60            # Sets the maximum number of idle keepalive 
+#upstream_keepalive = 60         # Sets the maximum number of idle keepalive 
                                  # connections to upstream servers that are 
                                  # preserved in the cache of each worker 
                                  # process. When this number is exceeded, the 

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -211,8 +211,8 @@ local function check_and_infer(conf)
     for _, server in ipairs(conf.dns_resolver) do
       local dns = utils.normalize_ip(server)
       if (not dns) or (dns.type ~= "ipv4") then
-        errors[#errors+1] = "dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port"
-        break -- one error is enough
+        errors[#errors+1] = "dns_resolver must be a comma separated list in "..
+                            "the form of IPv4 or IPv4:port, got '"..server.."'"
       end
     end
   end

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -61,7 +61,7 @@ local CONF_INFERENCES = {
   cluster_listen_rpc = {typ = "string"},
   cluster_advertise = {typ = "string"},
   nginx_worker_processes = {typ = "string"},
-  nginx_keepalive = {typ = "number"},
+  upstream_keepalive = {typ = "number"},
 
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -245,7 +245,7 @@ return function(options)
           ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker nb ",
                               ngx.worker.id())
 
-          if ngx.shared.kong then
+          if not options.cli then
             local ok, err = ngx.shared.kong:safe_set("pid: " .. ngx.worker.pid(), seed)
             if not ok then
               ngx.log(ngx.WARN, "could not store PRNG seed in kong shm: ", err)

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -11,7 +11,6 @@ admin_listen_ssl = 0.0.0.0:8444
 nginx_worker_processes = auto
 nginx_optimizations = on
 nginx_daemon = on
-nginx_keepalive = 60
 mem_cache_size = 128m
 ssl = on
 ssl_cert = NONE
@@ -19,6 +18,7 @@ ssl_cert_key = NONE
 admin_ssl = on
 admin_ssl_cert = NONE
 admin_ssl_cert_key = NONE
+upstream_keepalive = 60
 
 database = postgres
 pg_host = 127.0.0.1

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -61,7 +61,7 @@ upstream kong_upstream {
     balancer_by_lua_block {
         kong.balancer()
     }
-    keepalive ${{NGINX_KEEPALIVE}};
+    keepalive ${{UPSTREAM_KEEPALIVE}};
 }
 
 server {

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -238,13 +238,13 @@ describe("Configuration loader", function()
       local conf, err = conf_loader(nil, {
         dns_resolver = "[::1]:53"
       })
-      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port", err)
+      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port, got '[::1]:53'", err)
       assert.is_nil(conf)
 
       local conf, err = conf_loader(nil, {
         dns_resolver = "1.2.3.4:53;4.3.2.1" -- ; as separator
       })
-      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port", err)
+      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port, got '1.2.3.4:53;4.3.2.1'", err)
       assert.is_nil(conf)
 
       conf, err = conf_loader(nil, {

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -31,6 +31,7 @@ http {
     lua_code_cache ${{LUA_CODE_CACHE}};
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
+    lua_shared_dict kong 4m;
     lua_shared_dict cache ${{MEM_CACHE_SIZE}};
     lua_shared_dict cassandra 1m;
     lua_shared_dict cassandra_prepared 5m;


### PR DESCRIPTION
### Summary

Addresses the review comments on the dns branch

### Full changelog

* report all configuration errors
* rename keepalive directive/option to UPSTREAM_KEEPALIVE
* added patch for udp sockets name resolution, using internal dns resolver
* fix test error due to outdated fixture

### Issues resolved

comments by @thibaultcha 
