### PR TITLE
Dropping support for 1.9.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
   global:
     - SERF=0.7.0
     - LUAROCKS=2.4.0
-    - OPENSSL=1.0.2h
+    - OPENSSL=1.0.2j
     - CASSANDRA=2.2.7
-    - OPENRESTY=1.9.15.1
+    - OPENRESTY=1.11.2.1
     - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
   matrix:

--- a/kong/dao/postgres_db.lua
+++ b/kong/dao/postgres_db.lua
@@ -281,6 +281,8 @@ end
 
 -- Delete old expired TTL entities
 function PostgresDB:clear_expired_ttl()
+  ngx.log(ngx.DEBUG, "clearing expired TTLs")
+
   local query = "SELECT * FROM ttls WHERE expire_at < CURRENT_TIMESTAMP(0) at time zone 'utc'"
   local res, err = self:query(query)
   if err then

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -18,7 +18,7 @@ return {
   -- third-party dependencies' required version, as they would be specified
   -- to lua-version's `set()` in the form {from, to}
   _DEPENDENCIES = {
-    nginx = {"1.9.15.1", "1.11.2.1"},
+    nginx = {"1.11.2.1"},
     serf = {"0.7.0", "0.8.0"},
     --resty = {}, -- not version dependent for now
     --dnsmasq = {} -- not version dependent for now


### PR DESCRIPTION
* Dropping support for OpenResty 1.9.15.1
* Fixes an error in the auto-clustering event
* Adds a `DEBUG` log when clearing PostgreSQL TTLs
