### PR TITLE
fix(chore) change over to the renamed dns library

### DIFF
--- a/kong-0.9.5-0.rockspec
+++ b/kong-0.9.5-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "dns == 0.2.1",
+  "lua-resty-dns-client == 0.3.0",
   "lua-resty-worker-events == 0.3.0",
 }
 build = {

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -1,4 +1,4 @@
-local dns_client = require "dns.client"
+local dns_client = require "resty.dns.client"
 
 local toip = dns_client.toip
 

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -372,7 +372,7 @@ return function(options)
       return sock
     end
     -- STEP 5: load code that should be using the patched versions, if any (because of dependency chain)
-    toip = require("dns.client").toip  -- this will load utils and penlight modules for example
+    toip = require("resty.dns.client").toip  -- this will load utils and penlight modules for example
 
   end
 

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -2,10 +2,10 @@ local dns_client
 
 --- Load and setup the DNS client according to the provided configuration.
 -- @param conf (table) Kong configuration
--- @return the initialized `dns.client` module, or an error
+-- @return the initialized `resty.dns.client` module, or an error
 local setup_client = function(conf)
   if not dns_client then 
-    dns_client = require "dns.client"
+    dns_client = require "resty.dns.client"
   end
 
   conf = conf or {}
@@ -22,11 +22,11 @@ local setup_client = function(conf)
     
   local opts = {
     hosts = hosts,
-    resolv_conf = nil,     -- defaults to system resolv.conf
+    resolvConf = nil,      -- defaults to system resolv.conf
     nameservers = servers, -- provided list or taken from resolv.conf
     retrans = nil,         -- taken from system resolv.conf; attempts
     timeout = nil,         -- taken from system resolv.conf; timeout
-    bad_ttl = nil,         -- ttl in seconds for bad dns responses (empty/error)
+    badTtl = nil,          -- ttl in seconds for bad dns responses (empty/error)
   }
   
   assert(dns_client.init(opts))


### PR DESCRIPTION
updated dependencies after changing the dns library name.