### PR TITLE
fix: bring backcassandra usage post-dns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ lint:
 						--globals 'ngx' \
 						--globals 'assert' \
 						--no-redefined \
-						--no-unused-args
+						--no-unused-args \
+						--ignore 6..
 
 test:
 	@$(TEST_CMD) spec/01-unit

--- a/kong-0.9.5-0.rockspec
+++ b/kong-0.9.5-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "version == 0.2",
   "lapis == 1.5.1",
   "lua-cassandra == dev-0",
-  "pgmoon == 1.6.0",
+  "pgmoon-mashape == 2.0.1",
   "luatz == 0.3",
   "lua_system_constants == 0.1.1",
   "lua-resty-iputils == 0.2.1",

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -26,7 +26,7 @@ return function(options)
 
 
 
-  do  -- implement a Lua based shm, for; cli (and hence rbusted)
+  do  -- implement a Lua based shm for: cli (and hence rbusted)
 
     if options.cli then
       -- ngx.shared.DICT proxy
@@ -166,7 +166,7 @@ return function(options)
 
 
 
-  do -- randomseeding patch, for; cli, rbusted and Kong
+  do -- randomseeding patch for: cli, rbusted and OpenResty
 
     if options.rbusted then
 
@@ -282,7 +282,7 @@ return function(options)
 
 
 
-  do  -- pure lua semaphore patch, for; rbusted
+  do  -- pure lua semaphore patch for: rbusted
 
     if options.rbusted then
       -- when testing, busted will cleanup the global environment for test
@@ -335,7 +335,7 @@ return function(options)
   end
 
 
-  do -- cosockets connect patch for dns resolution, for; cli, rbusted and Kong
+  do -- cosockets connect patch for dns resolution for: cli, rbusted and OpenResty
     if options.cli then
       -- Because the CLI runs in `xpcall`, we cannot use yielding cosockets.
       -- Hence, we need to stick to luasocket when using cassandra or pgmoon


### PR DESCRIPTION
### Summary

The DNS branch enables the usage of cosockets in the CLI because they
can now resolve `/etc/hosts` hostnames. However, they *yield*, which is an
issue since the CLI runs inside a `xpcall` context.

### Full changelog

* re-implement the `force_luasocket` patch for pgmoon/lua-cassandra
* re-introduce pgmoon-mashape
* proper punctuation in globalpatches docs

### Issues resolved

Fix:

```
next ⇒ KONG_DATABASE=cassandra bin/busted spec/02-integration/03-admin_api/02-apis_routes_spec.lua
✱
0 successes / 0 failures / 1 error / 0 pending : 0.010228 seconds

Error → ...lar/ngx_openresty/1.11.2.1/lualib/resty/dns/resolver.lua @ 841
suite spec/02-integration/03-admin_api/02-apis_routes_spec.lua
...lar/ngx_openresty/1.11.2.1/lualib/resty/dns/resolver.lua:841: attempt to yield across C-call boundary
```
