### PR TITLE
Return null marker for caching even when no row matches the requirements

### DIFF
--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -30,10 +30,9 @@ local function load_plugin_configuration(api_id, consumer_id, plugin_name)
           return row
         end
       end
-    else
-      -- insert a cached value to not trigger too many DB queries.
-      return {null = true}
     end
+    -- insert a cached value to not trigger too many DB queries.
+    return {null = true}
   end)
 
   if plugin ~= nil and plugin.enabled then


### PR DESCRIPTION
### Summary

When loading a plugin's configuration, if the database query returns some rows but none of the returned rows match in api_id and consumer_id, the function returns nil. In which case the query result isnt cached. This happens for global plugins:
When plugins are first loaded get_or_set is called on global plugins like `plugins:basic-auth`. If there exists no global entry for this plugin, but there is a api/consumer specific entry some rows are returned. Even though rows are returned, none of them will match resulting in the function returning `nil` and the result not being cached. On every request to kong, kong tries to get_or_set `plugins:basic-auth` but fails bringing down throughput. This also causes kong to start returning 500 on every request when database is down.

### Full changelog

* Hotfix: Make sure plugin iterator call back returns non-nil response for proper caching

### Issues resolved

I found no reported issue related to this.
