### PR TITLE
Fix/fault tolerancy

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -34,8 +34,11 @@ return {
         local _, err = cache.sh_incr(cache_key, value)
         if err then
           ngx_log("[rate-limiting] could not increment counter for period '"..period.."': "..tostring(err))
+          return nil, err
         end
       end
+
+      return true
     end,
     usage = function(conf, api_id, identifier, current_timestamp, name)
       local periods = timestamp.get_timestamps(current_timestamp)
@@ -75,14 +78,14 @@ return {
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
-        return
+        return nil, err
       end
 
       if conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
-          return
+          return nil, err
         end
       end
 
@@ -92,7 +95,7 @@ return {
         local exists, err = red:exists(cache_key)
         if err then
           ngx_log(ngx.ERR, "failed to query Redis: ", err)
-          return
+          return nil, err
         end
 
         red:init_pipeline((not exists or exists == 0) and 2 or 1)
@@ -104,15 +107,17 @@ return {
         local _, err = red:commit_pipeline()
         if err then
           ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
-          return
+          return nil, err
         end
       end
 
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
         ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
-        return
+        return nil, err
       end
+      
+      return true
     end,
     usage = function(conf, api_id, identifier, current_timestamp, name)
       local red = redis:new()
@@ -120,14 +125,14 @@ return {
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
         ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
-        return
+        return nil, err
       end
 
       if conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
-          return
+          return nil, err
         end
       end
 

--- a/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
@@ -530,6 +530,68 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
           assert.is_nil(res.headers["x-ratelimit-remaining-video-minute"])
         end)
       end)
+
+    elseif policy == "redis" then
+      describe("Fault tolerancy", function()
+
+        before_each(function()
+          local api1 = assert(helpers.dao.apis:insert {
+            request_host = "failtest3.com",
+            upstream_url = "http://mockbin.com"
+          })
+          assert(helpers.dao.plugins:insert {
+            name = "response-ratelimiting",
+            api_id = api1.id,
+            config = {
+              fault_tolerant = false,
+              policy = policy,
+              redis_host = "5.5.5.5",
+              limits = {video = {minute = 6}}
+            }
+          })
+
+          local api2 = assert(helpers.dao.apis:insert {
+            request_host = "failtest4.com",
+            upstream_url = "http://mockbin.com"
+          })
+          assert(helpers.dao.plugins:insert {
+            name = "response-ratelimiting",
+            api_id = api2.id,
+            config = {
+              fault_tolerant = true,
+              policy = policy,
+              redis_host = "5.5.5.5",
+              limits = {video = {minute = 6}}
+            }
+          })
+        end)
+
+        it("does not work if an error occurs", function()
+          -- Make another request
+          local res = assert(helpers.proxy_client():send {
+            method = "GET",
+            path = "/status/200/",
+            headers = {
+              ["Host"] = "failtest3.com"
+            }
+          })
+          local body = assert.res_status(500, res)
+          assert.are.equal([[{"message":"An unexpected error occurred"}]], body)
+        end)
+        it("keeps working if an error occurs", function()
+          -- Make another request
+          local res = assert(helpers.proxy_client():send {
+            method = "GET",
+            path = "/status/200/",
+            headers = {
+              ["Host"] = "failtest4.com"
+            }
+          })
+          assert.res_status(200, res)
+          assert.falsy(res.headers["x-ratelimit-limit-video-minute"])
+          assert.falsy(res.headers["x-ratelimit-remaining-video-minute"])
+        end)
+      end)
     end
 
     describe("Expirations", function()


### PR DESCRIPTION
### Full changelog

* Fixes `config.fault_tolerant=true` in Rate-Limiting and Response Rate-Limiting plugins when using the `redis` policy.
