### PR TITLE
tests(dao) fix some C* tests failures

### DIFF
--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -263,7 +263,7 @@ function _M:run_migrations(on_migrate, on_success)
 
   local migrations_modules = self:migrations_modules()
   local cur_migrations, err = self:current_migrations()
-  if err then return ret_error_string(self.db.name, nil, err) end
+  if err then return nil, err end
 
   local ok, err, migrations_ran = migrate(self, "core", migrations_modules, cur_migrations, on_migrate, on_success)
   if not ok then return ret_error_string(self.db.name, nil, err) end

--- a/spec/02-integration/02-dao/02-migrations_spec.lua
+++ b/spec/02-integration/02-dao/02-migrations_spec.lua
@@ -107,6 +107,7 @@ helpers.for_each_dao(function(kong_config)
           kong_config.pg_port = pg_port
           kong_config.cassandra_port = cassandra_port
           kong_config.cassandra_timeout = cassandra_timeout
+          ngx.shared.cassandra:flush_all()
         end)
         kong_config.pg_port = 3333
         kong_config.cassandra_port = 3333


### PR DESCRIPTION
### Summary

Clean the shm after the forced failure in this test, so that the next
time we spawn a C* DAO, the shm does not contain misleading
informations about the `127.0.0.1` peer.

### Full changelog

* fix some C* DAO tests
* fix DAO migrations error that would add twice the `[db_type error]` prefix to error messages.
