### PR TITLE
kong.conf.default: clarify purpose of cluster_listen_rpc

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -228,10 +228,10 @@
                                  # TCP and UDP on this address.
                                  # Only IPv4 addresses are supported.
 
-#cluster_listen_rpc = 127.0.0.1:7373  # Address and port used by this node to
-                                      # communicate with the cluster.
-                                      # Only contains TCP traffic over the
-                                      # local network.
+#cluster_listen_rpc = 127.0.0.1:7373  # Address and port used to communicate
+                                      # with the cluster through the agent
+                                      # running on this node. Only contains
+                                      # TCP traffic local to this node.
 
 #cluster_advertise =             # By default, the `cluster_listen` address
                                  # is advertised over the cluster.


### PR DESCRIPTION
### Summary

In kong.conf.default comments, clarify purpose of cluster_listen_rpc parameter.

### Full changelog

* kong.conf.default: clarify purpose of cluster_listen_rpc in comments

As a new kong user, I was unsure of the purpose of cluster_listen_rpc from reading the docs. After reading through the code, I'd like to submit this to make that clearer for other new users.

I'd also like to update the paragraph at https://getkong.org/docs/0.9.x/configuration/#clustering-section with the same text; I'm still looking into the best way to do so.

Thank you for taking the time to look at my request.