### PR TITLE
kong.conf.default: clarify purpose of cluster_listen_rpc

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -191,10 +191,10 @@
                                  # TCP and UDP on this address.
                                  # Only IPv4 addresses are supported.
 
-#cluster_listen_rpc = 127.0.0.1:7373  # Address and port used by this node to
-                                      # communicate with the cluster.
-                                      # Only contains TCP traffic over the
-                                      # local network.
+#cluster_listen_rpc = 127.0.0.1:7373  # Address and port used to communicate
+                                      # with the cluster through the agent
+                                      # running on this node. Contains only
+                                      # TCP traffic local to this node.
 
 #cluster_advertise =             # By default, the `cluster_listen` address
                                  # is advertised over the cluster.


### PR DESCRIPTION
### Summary

In master kong.conf.default comments, clarify purpose of cluster_listen_rpc parameter.

### Full changelog

* kong.conf.default: clarify purpose of cluster_listen_rpc in comments

As a new kong user, I was unsure of the purpose of cluster_listen_rpc from reading the docs. After reading through the code, I'd like to submit this to make that clearer for other new users.

This is intended for 0.9.x releases; last week I was unclear on the branch and submitted this fix to the next branch as https://github.com/Mashape/kong/pull/1860

Thank you again.

