### PR TITLE
hotfix(cli) fix recursive calls to the startup errorhandler

### DIFF
--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -23,17 +23,17 @@ local function execute(args)
     assert(nginx_signals.start(conf))
     log("Kong started")
   end, function(e)
+    err = e or "" -- cannot throw from this function
+  end)
+
+  if err then
     log.verbose("could not start Kong, stopping services")
     pcall(nginx_signals.stop(conf))
     pcall(serf_signals.stop(conf, dao))
     if conf.dnsmasq then
       pcall(dnsmasq_signals.stop(conf))
     end
-    err = e -- cannot throw from this function
     log.verbose("stopped services")
-  end)
-
-  if err then
     error(err) -- report to main error handler
   end
 end


### PR DESCRIPTION
The `pcall`s used to stop the services seem to inherit the errorhandler
from the `xpcall` up on the stack. This causes a recursive call if stopping the services
errors for some reason.