### PR TITLE
hotfix(galileo) proper empty encoding as empty arr

### DIFF
--- a/kong/plugins/galileo/alf.lua
+++ b/kong/plugins/galileo/alf.lua
@@ -69,6 +69,14 @@ local function hash_to_array(t)
       arr[#arr+1] = {name = k, value = v}
     end
   end
+
+  -- FIXME: temporary workardound
+  -- remove once https://github.com/openresty/lua-cjson/pull/16
+  -- is included in a formal OpenResty release.
+  if #arr == 0 then
+    return cjson.empty_array
+  end
+
   return arr
 end
 

--- a/spec/03-plugins/05-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/05-galileo/01-alf_spec.lua
@@ -26,6 +26,17 @@ local alf_serializer = require "kong.plugins.galileo.alf"
 -- input sets to the serializer.
 local function reload_alf_serializer()
   package.loaded["kong.plugins.galileo.alf"] = nil
+
+  -- FIXME: temporary double-loading of the cjson module
+  -- for the encoding JSON as empty array tests in the
+  -- serialize() suite.
+  -- remove once https://github.com/openresty/lua-cjson/pull/16
+  -- is included in a formal OpenResty release.
+  package.loaded["cjson"] = nil
+  package.loaded["cjson.safe"] = nil
+  require "cjson.safe"
+  require "cjson"
+
   alf_serializer = require "kong.plugins.galileo.alf"
 end
 
@@ -487,6 +498,13 @@ describe("ALF serializer", function()
   end) -- add_entry()
 
   describe("serialize()", function()
+    -- FIXME: temporary double-loading of the cjson module
+    -- for the encoding JSON as empty array tests in the
+    -- serialize() suite.
+    -- remove once https://github.com/openresty/lua-cjson/pull/16
+    -- is included in a formal OpenResty release.
+    reload_alf_serializer()
+
     local cjson = require "cjson.safe"
     it("returns a JSON encoded ALF object", function()
       local alf = alf_serializer.new()


### PR DESCRIPTION
Use a workaround until https://github.com/openresty/lua-cjson/pull/16 is
included in an OpenResty formal release.
