### PR TITLE
hotfix(conf) load custom plugins property

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -335,7 +335,6 @@ local function load(path, custom_conf)
       custom_plugins[plugin_name] = true
     end
     conf.plugins = tablex.merge(constants.PLUGINS_AVAILABLE, custom_plugins, true)
-    conf.custom_plugins = nil
     setmetatable(conf.plugins, nil) -- remove Map mt
   end
 

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -51,14 +51,12 @@ describe("Configuration loader", function()
   it("returns a plugins table", function()
     local constants = require "kong.constants"
     local conf = assert(conf_loader())
-    assert.is_nil(conf.custom_plugins)
     assert.same(constants.PLUGINS_AVAILABLE, conf.plugins)
   end)
   it("loads custom plugins", function()
     local conf = assert(conf_loader(nil, {
       custom_plugins = "hello-world,my-plugin"
     }))
-    assert.is_nil(conf.custom_plugins)
     assert.True(conf.plugins["hello-world"])
     assert.True(conf.plugins["my-plugin"])
   end)

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -202,6 +202,18 @@ describe("NGINX conf compiler", function()
       local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_conf))
       assert.same(conf, in_prefix_kong_conf)
     end)
+    it("writes custom plugins in Kong conf", function()
+      local conf = assert(conf_loader(nil, {
+        custom_plugins = { "foo", "bar" },
+        prefix = tmp_config.prefix
+      }))
+
+      assert(prefix_handler.prepare_prefix(conf))
+
+      local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_conf))
+      assert.True(in_prefix_kong_conf.plugins.foo)
+      assert.True(in_prefix_kong_conf.plugins.bar)
+    end)
     it("dumps Serf script", function()
       assert(prefix_handler.prepare_prefix(tmp_config))
 


### PR DESCRIPTION
Ensure custom_plugins are passed from the config file to the prefix
config file, and hence down to the runtime OpenResty Kong.