### PR TITLE
hotfix(oauth2) safely parse body even when empty

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1,5 +1,5 @@
 local url = require "socket.url"
-local json = require "cjson"
+local cjson = require "cjson.safe"
 local utils = require "kong.tools.utils"
 local cache = require "kong.tools.database_cache"
 local pl_stringx = require "pl.stringx"
@@ -89,12 +89,13 @@ end
 local function retrieve_parameters()
   ngx.req.read_body()
   -- OAuth2 parameters could be in both the querystring or body
-  local body_parameters
+  local body_parameters, err
   local content_type = req_get_headers()[CONTENT_TYPE]
   if content_type and string_find(content_type:lower(), "multipart/form-data", nil, true) then
     body_parameters = Multipart(ngx.req.get_body_data(), content_type):get_all()
   elseif content_type and string_find(content_type:lower(), "application/json", nil, true) then
-    body_parameters = json.decode(ngx.req.get_body_data())
+    body_parameters, err = cjson.decode(ngx.req.get_body_data())
+    if err then body_parameters = {} end
   else
     body_parameters = ngx.req.get_post_args()
   end

--- a/spec/03-plugins/99-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/99-oauth2/03-access_spec.lua
@@ -1456,6 +1456,18 @@ describe("#ci Plugin: oauth2 (access)", function()
   end)
 
   describe("Making a request", function()
+    it("fails when no access_token is being sent in an application/json body", function()
+      local res = assert(proxy_ssl_client:send {
+        method = "POST",
+        path = "/request",
+        headers = {
+          ["Host"] = "oauth2.com",
+          ["Content-Type"] = "application/json"
+        }
+      })
+      local body = assert.res_status(401, res)
+      assert.equal([[{"error_description":"The access token is missing","error":"invalid_request"}]], body)
+    end)
     it("works when a correct access_token is being sent in the querystring", function()
       local token = provision_token()
 


### PR DESCRIPTION
### Full changelog

* OAuth 2 plugin now properly parses empty bodies.

### Issues resolved

Fix #1710 and #1853.
