### PR TITLE
hotfix(dao) disable old hack to resolve hostsfile

### DIFF
--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -4,10 +4,7 @@ local BaseDB = require "kong.dao.base_db"
 local utils = require "kong.tools.utils"
 local uuid = utils.uuid
 
-local ngx_stub = _G.ngx
-_G.ngx = nil
 local cassandra = require "cassandra"
-_G.ngx = ngx_stub
 
 local CassandraDB = BaseDB:extend()
 


### PR DESCRIPTION
Disable old hack to resolve hostsfile, we now use the lua-resty-socket module but never removed the old hack. The old hack was forcing LuaSocket usage in `init_by_lua` context, but recent changes bite use and now LuaSocket were always used instead of cosockets.
