### PR TITLE
Metadata Plugin

### DIFF
--- a/kong-0.9.7-0.rockspec
+++ b/kong-0.9.7-0.rockspec
@@ -261,5 +261,9 @@ build = {
     ["kong.plugins.bot-detection.rules"] = "kong/plugins/bot-detection/rules.lua",
     ["kong.plugins.bot-detection.cache"] = "kong/plugins/bot-detection/cache.lua",
     ["kong.plugins.bot-detection.hooks"] = "kong/plugins/bot-detection/hooks.lua",
+
+    ["kong.plugins.metadata-insertion.handler"] = "kong/plugins/metadata-insertion/handler.lua",
+    ["kong.plugins.metadata-insertion.access"] = "kong/plugins/metadata-insertion/access.lua",
+    ["kong.plugins.metadata-insertion.schema"] = "kong/plugins/metadata-insertion/schema.lua",
   }
 }

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -335,7 +335,6 @@ local function load(path, custom_conf)
       custom_plugins[plugin_name] = true
     end
     conf.plugins = tablex.merge(constants.PLUGINS_AVAILABLE, custom_plugins, true)
-    conf.custom_plugins = nil
     setmetatable(conf.plugins, nil) -- remove Map mt
   end
 

--- a/kong/dao/cassandra_db.lua
+++ b/kong/dao/cassandra_db.lua
@@ -4,10 +4,7 @@ local BaseDB = require "kong.dao.base_db"
 local utils = require "kong.tools.utils"
 local uuid = utils.uuid
 
-local ngx_stub = _G.ngx
-_G.ngx = nil
 local cassandra = require "cassandra"
-_G.ngx = ngx_stub
 
 local CassandraDB = BaseDB:extend()
 

--- a/kong/plugins/galileo/alf.lua
+++ b/kong/plugins/galileo/alf.lua
@@ -69,6 +69,14 @@ local function hash_to_array(t)
       arr[#arr+1] = {name = k, value = v}
     end
   end
+
+  -- FIXME: temporary workardound
+  -- remove once https://github.com/openresty/lua-cjson/pull/16
+  -- is included in a formal OpenResty release.
+  if #arr == 0 then
+    return cjson.empty_array
+  end
+
   return arr
 end
 

--- a/kong/plugins/metadata-insertion/access.lua
+++ b/kong/plugins/metadata-insertion/access.lua
@@ -1,0 +1,173 @@
+local _M = {}
+local request_querystring_factory = require "kong.plugins.metadata-insertion.factory.request_querystring_factory"
+local request_headers_factory = require "kong.plugins.metadata-insertion.factory.request_headers_factory"
+local debug = require "kong.plugins.metadata-insertion.tool.debug"
+local cache = require "kong.tools.database_cache"
+local singletons = require "kong.singletons"
+local responses = require "kong.tools.responses"
+local currentUserMetadata
+
+function _M.execute(conf)
+
+    if ngx.ctx.authenticated_consumer == nil then
+        return responses.send_HTTP_UNAUTHORIZED("Metadata plugin can't be used without having an authenticated user.")
+    end
+
+    currentUserMetadata = getPersistentMetadata()
+    appendMetadataFromTransitoryStore(currentUserMetadata)
+
+    local _, err = pcall(function ()
+
+        -----------------------------
+        -- Data Insertion Processing
+        -----------------------------
+        updateQuerystring(conf)
+        updateHeaders(conf)
+    end)
+
+    if err then
+        return responses.send_HTTP_BAD_REQUEST(err)
+    end
+end
+
+function getPersistentMetadata()
+    -- retrieve metadata from cache or database for current user
+    currentUserMetadata = cache.get_or_set("metadata_keyvaluestore."..ngx.ctx.authenticated_consumer.id, function()
+        local metadata, err = singletons.dao.metadata_keyvaluestore:find_all({consumer_id = ngx.ctx.authenticated_consumer.id})
+        if err then
+            return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        end
+        return metadata
+    end)
+
+    if currentUserMetadata then
+        return currentUserMetadata
+    end
+
+    return {}
+end
+
+function appendMetadataFromTransitoryStore(currentUserMetadata)
+
+    -- loop through transitory store and add the metadata in memory
+    -- transitory store take precedence over persitent metadata
+    if ngx.ctx.metadata_transitory_store and type(ngx.ctx.metadata_transitory_store) == "table" then
+
+        for _, transitoryStoreElem in ipairs(ngx.ctx.metadata_transitory_store) do
+
+            local persistentMetadataFound = false
+
+            -- replace persitent metadata with transitory store if it exist in both place
+            for index, persistentMetadataElem in ipairs(currentUserMetadata) do
+                if persistentMetadataElem.key == transitoryStoreElem.key then
+                    currentUserMetadata[index] = transitoryStoreElem
+                    persistentMetadataFound = true
+                end
+            end
+
+            -- if nothing found in persistent metadata, let's make sure we add the transitory store element as new
+            if persistentMetadataFound == false then
+                table.insert(currentUserMetadata, transitoryStoreElem)
+            end
+
+        end
+
+    end
+end
+
+function updateQuerystring(confDataInsertion)
+
+  local RequestQuerystringFactory = request_querystring_factory:new()
+
+  RequestQuerystringFactory:mergeArgsWithRequestArgs()
+
+  -- Remove querystring(s)
+  if confDataInsertion.remove and confDataInsertion.remove.querystring then
+    for _, key in ipairs(confDataInsertion.remove.querystring) do
+      RequestQuerystringFactory:removeArgByKey(key)
+    end
+  end
+
+  -- Replace querystring(s)
+  if confDataInsertion.replace and confDataInsertion.replace.querystring then
+    for _, querystringModifier in pairs(confDataInsertion.replace.querystring) do
+      local parameterName, parameterValue = retrieveMetadataForConfigToken(querystringModifier)
+      RequestQuerystringFactory:replaceArgByKey(parameterName, parameterValue)
+    end
+  end
+
+  -- Add querystring(s)
+  if confDataInsertion.add and confDataInsertion.add.querystring then
+    for _, querystringModifier in pairs(confDataInsertion.add.querystring) do
+      local parameterName, parameterValue = retrieveMetadataForConfigToken(querystringModifier)
+      RequestQuerystringFactory:add(parameterName, parameterValue)
+    end
+  end
+
+  RequestQuerystringFactory:persist()
+
+end
+
+function updateHeaders(confDataInsertion)
+
+  local RequestHeadersFactory = request_headers_factory:new()
+
+  RequestHeadersFactory:mergeArgsWithRequestArgs()
+
+  -- Remove querystring(s)
+  if confDataInsertion.remove and confDataInsertion.remove.headers then
+    for _, key in ipairs(confDataInsertion.remove.headers) do
+      RequestHeadersFactory:removeArgByKey(key)
+    end
+  end
+
+  -- Replace querystring(s)
+  if confDataInsertion.replace and confDataInsertion.replace.headers then
+    for _, headersModifier in pairs(confDataInsertion.replace.headers) do
+      local parameterName, parameterValue = retrieveMetadataForConfigToken(headersModifier)
+      RequestHeadersFactory:replaceArgByKey(parameterName, parameterValue)
+    end
+  end
+
+  -- Add querystring(s)
+  if confDataInsertion.add and confDataInsertion.add.headers then
+    for _, headersModifier in pairs(confDataInsertion.add.headers) do
+      local parameterName, parameterValue = retrieveMetadataForConfigToken(headersModifier)
+      RequestHeadersFactory:add(parameterName, parameterValue)
+    end
+  end
+
+  RequestHeadersFactory:persist()
+
+end
+
+function retrieveMetadataForConfigToken(querystringModifier)
+  local args = {}
+
+  for stringChunk in string.gmatch(querystringModifier, "%S+") do
+    table.insert(args, stringChunk)
+  end
+
+  assert(table.getn(args) == 2, "Invalid format")
+
+  -- Prepare arg name
+  local argName = args[1]
+  argName = argName:gsub(":", "")
+
+  -- Prepare arg value (replace placeholder name by metadata value)
+  local argValuePlaceholderName = args[2]
+  argValuePlaceholderName = argValuePlaceholderName:gsub("%%", "")
+  local parameterValue = resolveParameterValuePlaceholderWithMetadata(argValuePlaceholderName)
+  return argName, parameterValue
+end
+
+function resolveParameterValuePlaceholderWithMetadata(dataProvisioningName)
+    for _, elem in ipairs(currentUserMetadata) do
+        if elem.key == dataProvisioningName then
+            return elem.value
+        end
+    end
+    error("This API needs metadata that the current user does not provide.")
+end
+
+return _M

--- a/kong/plugins/metadata-insertion/api.lua
+++ b/kong/plugins/metadata-insertion/api.lua
@@ -6,15 +6,12 @@ return {
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
     end,
-
     GET = function(self, dao_factory)
       crud.paginated_set(self, dao_factory.metadata_keyvaluestore)
     end,
-
     PUT = function(self, dao_factory)
       crud.put(self.params, dao_factory.metadata_keyvaluestore)
     end,
-
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.metadata_keyvaluestore)
     end

--- a/kong/plugins/metadata-insertion/api.lua
+++ b/kong/plugins/metadata-insertion/api.lua
@@ -1,0 +1,22 @@
+local crud = require "kong.api.crud_helpers"
+
+return {
+  ["/consumers/:username_or_id/metadata/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.metadata_keyvaluestore)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.metadata_keyvaluestore)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.metadata_keyvaluestore)
+    end
+  }
+}

--- a/kong/plugins/metadata-insertion/daos.lua
+++ b/kong/plugins/metadata-insertion/daos.lua
@@ -1,0 +1,16 @@
+local SCHEMA = {
+  primary_key = {"id"},
+  table = "metadata_keyvaluestore",
+  fields = {
+    id = {type = "id", dao_insert_value = true},
+    created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
+    consumer_id = {type = "id", required = true, foreign = "consumers:id"},
+    key = {type = "string", required = true},
+    value = {type = "string", required = true}
+  },
+  marshall_event = function(self, t)
+    return {id = t.id, consumer_id = t.consumer_id, key = t.key}
+  end
+}
+
+return {metadata_keyvaluestore = SCHEMA}

--- a/kong/plugins/metadata-insertion/daos.lua
+++ b/kong/plugins/metadata-insertion/daos.lua
@@ -1,16 +1,16 @@
 local SCHEMA = {
-  primary_key = {"id"},
+  primary_key = { "id" },
   table = "metadata_keyvaluestore",
   fields = {
-    id = {type = "id", dao_insert_value = true},
-    created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
-    consumer_id = {type = "id", required = true, foreign = "consumers:id"},
-    key = {type = "string", required = true},
-    value = {type = "string", required = true}
+    id = { type = "id", dao_insert_value = true },
+    created_at = { type = "timestamp", immutable = true, dao_insert_value = true },
+    consumer_id = { type = "id", required = true, foreign = "consumers:id" },
+    key = { type = "string", required = true },
+    value = { type = "string", required = true }
   },
   marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id, key = t.key}
+    return { id = t.id, consumer_id = t.consumer_id, key = t.key }
   end
 }
 
-return {metadata_keyvaluestore = SCHEMA}
+return { metadata_keyvaluestore = SCHEMA }

--- a/kong/plugins/metadata-insertion/factory/request_headers_factory.lua
+++ b/kong/plugins/metadata-insertion/factory/request_headers_factory.lua
@@ -5,46 +5,46 @@ local RequestHeadersFactory = {}
 local args = {}
 
 function RequestHeadersFactory:new()
-    return RequestHeadersFactory
+  return RequestHeadersFactory
 end
 
 function RequestHeadersFactory:getArgs()
-    return args
+  return args
 end
 
 function RequestHeadersFactory:mergeArgsWithRequestArgs()
-    local requestArgs = req_get_headers()
-    for k, v in pairs(requestArgs) do
-        args[k] = v
-    end
+  local requestArgs = req_get_headers()
+  for k, v in pairs(requestArgs) do
+    args[k] = v
+  end
 end
 
 function RequestHeadersFactory:persist()
-    for key, value in pairs(args) do
-        if key:lower() ~= HOST then
-            if value == "metadata_asked_for_removal" then
-                req_set_header(key, nil)
-            else
-                req_set_header(key, value)
-            end
-        end
+  for key, value in pairs(args) do
+    if key:lower() ~= HOST then
+      if value == "metadata_asked_for_removal" then
+        req_set_header(key, nil)
+      else
+        req_set_header(key, value)
+      end
     end
+  end
 end
 
 function RequestHeadersFactory:removeArgByKey(key)
-    if args[key] then
-        args[key] = "metadata_asked_for_removal"
-    end
+  if args[key] then
+    args[key] = "metadata_asked_for_removal"
+  end
 end
 
 function RequestHeadersFactory:replaceArgByKey(key, value)
-    if args[key] then
-        args[key] = value
-    end
+  if args[key] then
+    args[key] = value
+  end
 end
 
 function RequestHeadersFactory:add(key, value)
-    args[key]  = value
+  args[key] = value
 end
 
 return RequestHeadersFactory

--- a/kong/plugins/metadata-insertion/factory/request_headers_factory.lua
+++ b/kong/plugins/metadata-insertion/factory/request_headers_factory.lua
@@ -1,0 +1,50 @@
+local req_set_header = ngx.req.set_header
+local req_get_headers = ngx.req.get_headers
+local HOST = "host"
+local RequestHeadersFactory = {}
+local args = {}
+
+function RequestHeadersFactory:new()
+    return RequestHeadersFactory
+end
+
+function RequestHeadersFactory:getArgs()
+    return args
+end
+
+function RequestHeadersFactory:mergeArgsWithRequestArgs()
+    local requestArgs = req_get_headers()
+    for k, v in pairs(requestArgs) do
+        args[k] = v
+    end
+end
+
+function RequestHeadersFactory:persist()
+    for key, value in pairs(args) do
+        if key:lower() ~= HOST then
+            if value == "metadata_asked_for_removal" then
+                req_set_header(key, nil)
+            else
+                req_set_header(key, value)
+            end
+        end
+    end
+end
+
+function RequestHeadersFactory:removeArgByKey(key)
+    if args[key] then
+        args[key] = "metadata_asked_for_removal"
+    end
+end
+
+function RequestHeadersFactory:replaceArgByKey(key, value)
+    if args[key] then
+        args[key] = value
+    end
+end
+
+function RequestHeadersFactory:add(key, value)
+    args[key]  = value
+end
+
+return RequestHeadersFactory

--- a/kong/plugins/metadata-insertion/factory/request_querystring_factory.lua
+++ b/kong/plugins/metadata-insertion/factory/request_querystring_factory.lua
@@ -1,0 +1,42 @@
+local req_get_uri_args = ngx.req.get_uri_args
+local req_set_uri_args = ngx.req.set_uri_args
+
+local RequestQuerystringFactory = {}
+local args = {}
+
+function RequestQuerystringFactory:new()
+    return RequestQuerystringFactory
+end
+
+function RequestQuerystringFactory:getArgs()
+    return args
+end
+
+function RequestQuerystringFactory:mergeArgsWithRequestArgs()
+    local requestArgs = req_get_uri_args()
+    for k, v in pairs(requestArgs) do
+        args[k] = v
+    end
+end
+
+function RequestQuerystringFactory:persist()
+    req_set_uri_args(args)
+end
+
+function RequestQuerystringFactory:removeArgByKey(key)
+    if args[key] then
+        args[key] = nil
+    end
+end
+
+function RequestQuerystringFactory:replaceArgByKey(key, value)
+    if args[key] then
+        args[key] = value
+    end
+end
+
+function RequestQuerystringFactory:add(key, value)
+    args[key]  = value
+end
+
+return RequestQuerystringFactory

--- a/kong/plugins/metadata-insertion/factory/request_querystring_factory.lua
+++ b/kong/plugins/metadata-insertion/factory/request_querystring_factory.lua
@@ -5,38 +5,38 @@ local RequestQuerystringFactory = {}
 local args = {}
 
 function RequestQuerystringFactory:new()
-    return RequestQuerystringFactory
+  return RequestQuerystringFactory
 end
 
 function RequestQuerystringFactory:getArgs()
-    return args
+  return args
 end
 
 function RequestQuerystringFactory:mergeArgsWithRequestArgs()
-    local requestArgs = req_get_uri_args()
-    for k, v in pairs(requestArgs) do
-        args[k] = v
-    end
+  local requestArgs = req_get_uri_args()
+  for k, v in pairs(requestArgs) do
+    args[k] = v
+  end
 end
 
 function RequestQuerystringFactory:persist()
-    req_set_uri_args(args)
+  req_set_uri_args(args)
 end
 
 function RequestQuerystringFactory:removeArgByKey(key)
-    if args[key] then
-        args[key] = nil
-    end
+  if args[key] then
+    args[key] = nil
+  end
 end
 
 function RequestQuerystringFactory:replaceArgByKey(key, value)
-    if args[key] then
-        args[key] = value
-    end
+  if args[key] then
+    args[key] = value
+  end
 end
 
 function RequestQuerystringFactory:add(key, value)
-    args[key]  = value
+  args[key] = value
 end
 
 return RequestQuerystringFactory

--- a/kong/plugins/metadata-insertion/handler.lua
+++ b/kong/plugins/metadata-insertion/handler.lua
@@ -1,0 +1,15 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local access = require "kong.plugins.metadata-insertion.access"
+
+local MetadataInsertionHandler = BasePlugin:extend()
+
+function MetadataInsertionHandler:new()
+  MetadataInsertionHandler.super.new(self, "metadata-insertion")
+end
+
+function MetadataInsertionHandler:access(conf)
+  MetadataInsertionHandler.super.access(self)
+  access.execute(conf)
+end
+
+return MetadataInsertionHandler

--- a/kong/plugins/metadata-insertion/hooks.lua
+++ b/kong/plugins/metadata-insertion/hooks.lua
@@ -1,0 +1,17 @@
+local events = require "kong.core.events"
+local cache = require "kong.tools.database_cache"
+
+local function invalidate(message_t)
+  if message_t.collection == "metadata_keyvaluestore" then
+    cache.delete(cache.metadata_keyvaluestore(message_t.old_entity and message_t.old_entity.key or message_t.entity.key))
+  end
+end
+
+return {
+  [events.TYPES.ENTITY_UPDATED] = function(message_t)
+    invalidate(message_t)
+  end,
+  [events.TYPES.ENTITY_DELETED] = function(message_t)
+    invalidate(message_t)
+  end
+}

--- a/kong/plugins/metadata-insertion/migrations/cassandra.lua
+++ b/kong/plugins/metadata-insertion/migrations/cassandra.lua
@@ -1,0 +1,21 @@
+return {
+  {
+    name = "2017-01-05-000000_init_metadata",
+    up =  [[
+      CREATE TABLE IF NOT EXISTS metadata_keyvaluestore(
+        id uuid,
+        consumer_id uuid,
+        key text,
+        value text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON metadata_keyvaluestore(key);
+      CREATE INDEX IF NOT EXISTS metadata_keyvaluestore_consumer_id ON metadata_keyvaluestore(consumer_id);
+    ]],
+    down = [[
+      DROP TABLE metadata_keyvaluestore;
+    ]]
+  }
+}

--- a/kong/plugins/metadata-insertion/migrations/postgres.lua
+++ b/kong/plugins/metadata-insertion/migrations/postgres.lua
@@ -1,0 +1,28 @@
+return {
+  {
+    name = "2017-01-05-000000_init_metadata",
+    up = [[
+      CREATE TABLE IF NOT EXISTS metadata_keyvaluestore(
+        id uuid,
+        consumer_id uuid REFERENCES consumers (id) ON DELETE CASCADE,
+        key text,
+        value text,
+        created_at timestamp without time zone default (CURRENT_TIMESTAMP(0) at time zone 'utc'),
+        PRIMARY KEY (id)
+      );
+
+      DO $$
+      BEGIN
+        IF (SELECT to_regclass('metadata_keyvaluestore_key_idx')) IS NULL THEN
+          CREATE INDEX metadata_keyvaluestore_key_idx ON metadata_keyvaluestore(key);
+        END IF;
+        IF (SELECT to_regclass('metadata_keyvaluestore_consumer_idx')) IS NULL THEN
+          CREATE INDEX metadata_keyvaluestore_consumer_idx ON metadata_keyvaluestore(consumer_id);
+        END IF;
+      END$$;
+    ]],
+    down = [[
+      DROP TABLE metadata_keyvaluestore;
+    ]]
+  }
+}

--- a/kong/plugins/metadata-insertion/schema.lua
+++ b/kong/plugins/metadata-insertion/schema.lua
@@ -1,0 +1,43 @@
+local find = string.find
+local function check_for_value(value)
+    for i, entry in ipairs(value) do
+        local ok = find(entry, ":")
+        if not ok then
+            return false, "key '"..entry.."' has no value"
+        end
+    end
+    return true
+end
+
+return {
+  no_consumer = true,
+  fields = {
+      add = {
+          type = "table",
+          schema = {
+              fields = {
+                  querystring = {type = "array", default = {}, func = check_for_value},
+                  headers = {type = "array", default = {}, func = check_for_value }
+              }
+          }
+      },
+      replace = {
+          type = "table",
+          schema = {
+              fields = {
+                  querystring = {type = "array", default = {}, func = check_for_value},
+                  headers = {type = "array", default = {}, func = check_for_value }
+              }
+          }
+      },
+      remove = {
+          type = "table",
+          schema = {
+              fields = {
+                  querystring = {type = "array"},
+                  headers = {type = "array" }
+              }
+          }
+      }
+    }
+}

--- a/kong/plugins/metadata-insertion/schema.lua
+++ b/kong/plugins/metadata-insertion/schema.lua
@@ -1,43 +1,43 @@
 local find = string.find
 local function check_for_value(value)
-    for i, entry in ipairs(value) do
-        local ok = find(entry, ":")
-        if not ok then
-            return false, "key '"..entry.."' has no value"
-        end
+  for i, entry in ipairs(value) do
+    local ok = find(entry, ":")
+    if not ok then
+      return false, "key '" .. entry .. "' has no value"
     end
-    return true
+  end
+  return true
 end
 
 return {
   no_consumer = true,
   fields = {
-      add = {
-          type = "table",
-          schema = {
-              fields = {
-                  querystring = {type = "array", default = {}, func = check_for_value},
-                  headers = {type = "array", default = {}, func = check_for_value }
-              }
-          }
-      },
-      replace = {
-          type = "table",
-          schema = {
-              fields = {
-                  querystring = {type = "array", default = {}, func = check_for_value},
-                  headers = {type = "array", default = {}, func = check_for_value }
-              }
-          }
-      },
-      remove = {
-          type = "table",
-          schema = {
-              fields = {
-                  querystring = {type = "array"},
-                  headers = {type = "array" }
-              }
-          }
+    add = {
+      type = "table",
+      schema = {
+        fields = {
+          querystring = { type = "array", default = {}, func = check_for_value },
+          headers = { type = "array", default = {}, func = check_for_value }
+        }
+      }
+    },
+    replace = {
+      type = "table",
+      schema = {
+        fields = {
+          querystring = { type = "array", default = {}, func = check_for_value },
+          headers = { type = "array", default = {}, func = check_for_value }
+        }
+      }
+    },
+    remove = {
+      type = "table",
+      schema = {
+        fields = {
+          querystring = { type = "array" },
+          headers = { type = "array" }
+        }
       }
     }
+  }
 }

--- a/kong/plugins/metadata-insertion/tool/debug.lua
+++ b/kong/plugins/metadata-insertion/tool/debug.lua
@@ -1,0 +1,53 @@
+return {
+
+    print_r = function(t)
+        local print_r_cache={}
+        local function sub_print_r(t,indent)
+            if (print_r_cache[tostring(t)]) then
+                print(indent.."*"..tostring(t))
+            else
+                print_r_cache[tostring(t)]=true
+                if (type(t)=="table") then
+                    for pos,val in pairs(t) do
+                        if (type(val)=="table") then
+                            print(indent.."["..pos.."] => "..tostring(t).." {")
+                            sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
+                            print(indent..string.rep(" ",string.len(pos)+6).."}")
+                        else
+                            print(indent.."["..pos.."] => "..tostring(val))
+                        end
+                    end
+                else
+                    print(indent..tostring(t))
+                end
+            end
+        end
+        sub_print_r(t,"  ")
+    end,
+
+    log_r = function (t)
+        local print_r_cache={}
+        local function sub_print_r(t,indent)
+            if (print_r_cache[tostring(t)]) then
+                ngx.log(ngx.ERR, "=== : " .. indent.."*"..tostring(t))
+            else
+                print_r_cache[tostring(t)]=true
+                if (type(t)=="table") then
+                    for pos,val in pairs(t) do
+                        if (type(val)=="table") then
+                            ngx.log(ngx.ERR, "=== : " .. indent.."["..pos.."] => "..tostring(t).." {")
+                            sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
+                            ngx.log(ngx.ERR, "=== : " .. indent..string.rep(" ",string.len(pos)+6).."}")
+                        else
+                            ngx.log(ngx.ERR, "=== : " ..  indent.."["..pos.."] => "..tostring(val))
+                        end
+                    end
+                else
+                    ngx.log(ngx.ERR, "=== : " .. indent..tostring(t))
+                end
+            end
+        end
+        sub_print_r(t,"  ")
+    end
+
+}

--- a/kong/plugins/metadata-insertion/tool/debug.lua
+++ b/kong/plugins/metadata-insertion/tool/debug.lua
@@ -1,53 +1,52 @@
 return {
-
-    print_r = function(t)
-        local print_r_cache={}
-        local function sub_print_r(t,indent)
-            if (print_r_cache[tostring(t)]) then
-                print(indent.."*"..tostring(t))
+  print_r = function(t)
+    local print_r_cache = {}
+    local function sub_print_r(t, indent)
+      if (print_r_cache[tostring(t)]) then
+        print(indent .. "*" .. tostring(t))
+      else
+        print_r_cache[tostring(t)] = true
+        if (type(t) == "table") then
+          for pos, val in pairs(t) do
+            if (type(val) == "table") then
+              print(indent .. "[" .. pos .. "] => " .. tostring(t) .. " {")
+              sub_print_r(val, indent .. string.rep(" ", string.len(pos) + 8))
+              print(indent .. string.rep(" ", string.len(pos) + 6) .. "}")
             else
-                print_r_cache[tostring(t)]=true
-                if (type(t)=="table") then
-                    for pos,val in pairs(t) do
-                        if (type(val)=="table") then
-                            print(indent.."["..pos.."] => "..tostring(t).." {")
-                            sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
-                            print(indent..string.rep(" ",string.len(pos)+6).."}")
-                        else
-                            print(indent.."["..pos.."] => "..tostring(val))
-                        end
-                    end
-                else
-                    print(indent..tostring(t))
-                end
+              print(indent .. "[" .. pos .. "] => " .. tostring(val))
             end
+          end
+        else
+          print(indent .. tostring(t))
         end
-        sub_print_r(t,"  ")
-    end,
-
-    log_r = function (t)
-        local print_r_cache={}
-        local function sub_print_r(t,indent)
-            if (print_r_cache[tostring(t)]) then
-                ngx.log(ngx.ERR, "=== : " .. indent.."*"..tostring(t))
-            else
-                print_r_cache[tostring(t)]=true
-                if (type(t)=="table") then
-                    for pos,val in pairs(t) do
-                        if (type(val)=="table") then
-                            ngx.log(ngx.ERR, "=== : " .. indent.."["..pos.."] => "..tostring(t).." {")
-                            sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
-                            ngx.log(ngx.ERR, "=== : " .. indent..string.rep(" ",string.len(pos)+6).."}")
-                        else
-                            ngx.log(ngx.ERR, "=== : " ..  indent.."["..pos.."] => "..tostring(val))
-                        end
-                    end
-                else
-                    ngx.log(ngx.ERR, "=== : " .. indent..tostring(t))
-                end
-            end
-        end
-        sub_print_r(t,"  ")
+      end
     end
 
+    sub_print_r(t, "  ")
+  end,
+  log_r = function(t)
+    local print_r_cache = {}
+    local function sub_print_r(t, indent)
+      if (print_r_cache[tostring(t)]) then
+        ngx.log(ngx.ERR, "=== : " .. indent .. "*" .. tostring(t))
+      else
+        print_r_cache[tostring(t)] = true
+        if (type(t) == "table") then
+          for pos, val in pairs(t) do
+            if (type(val) == "table") then
+              ngx.log(ngx.ERR, "=== : " .. indent .. "[" .. pos .. "] => " .. tostring(t) .. " {")
+              sub_print_r(val, indent .. string.rep(" ", string.len(pos) + 8))
+              ngx.log(ngx.ERR, "=== : " .. indent .. string.rep(" ", string.len(pos) + 6) .. "}")
+            else
+              ngx.log(ngx.ERR, "=== : " .. indent .. "[" .. pos .. "] => " .. tostring(val))
+            end
+          end
+        else
+          ngx.log(ngx.ERR, "=== : " .. indent .. tostring(t))
+        end
+      end
+    end
+
+    sub_print_r(t, "  ")
+  end
 }

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1,5 +1,5 @@
 local url = require "socket.url"
-local json = require "cjson"
+local cjson = require "cjson.safe"
 local utils = require "kong.tools.utils"
 local cache = require "kong.tools.database_cache"
 local pl_stringx = require "pl.stringx"
@@ -89,12 +89,13 @@ end
 local function retrieve_parameters()
   ngx.req.read_body()
   -- OAuth2 parameters could be in both the querystring or body
-  local body_parameters
+  local body_parameters, err
   local content_type = req_get_headers()[CONTENT_TYPE]
   if content_type and string_find(content_type:lower(), "multipart/form-data", nil, true) then
     body_parameters = Multipart(ngx.req.get_body_data(), content_type):get_all()
   elseif content_type and string_find(content_type:lower(), "application/json", nil, true) then
-    body_parameters = json.decode(ngx.req.get_body_data())
+    body_parameters, err = cjson.decode(ngx.req.get_body_data())
+    if err then body_parameters = {} end
   else
     body_parameters = ngx.req.get_post_args()
   end

--- a/kong/plugins/oauth2/migrations/postgres.lua
+++ b/kong/plugins/oauth2/migrations/postgres.lua
@@ -82,6 +82,42 @@ return {
     ]]
   },
   {
+    name = "2016-04-14-283949_serialize_redirect_uri",
+    up = function(_, _, factory)
+      local schema = factory.oauth2_credentials.schema
+      schema.fields.redirect_uri.type = "string"
+      local json = require "cjson"
+      local apps, err = factory.oauth2_credentials.db:find_all('oauth2_credentials', nil, schema);
+      if err then
+        return err
+      end
+      for _, app in ipairs(apps) do
+        local redirect_uri = {};
+        redirect_uri[1] = app.redirect_uri
+        local redirect_uri_str = json.encode(redirect_uri)
+        local req = "UPDATE oauth2_credentials SET redirect_uri='"..redirect_uri_str.."' WHERE id='"..app.id.."'"
+        local _, err = factory.oauth2_credentials.db:queries(req)
+        if err then
+          return err
+        end
+      end
+    end,
+    down = function(_,_,factory)
+      local apps, err = factory.oauth2_credentials:find_all()
+      if err then
+        return err
+      end
+      for _, app in ipairs(apps) do
+        local redirect_uri = app.redirect_uri[1]
+        local req = "UPDATE oauth2_credentials SET redirect_uri='"..redirect_uri.."' WHERE id='"..app.id.."'"
+        local _, err = factory.oauth2_credentials.db:queries(req)
+        if err then
+          return err
+        end
+      end
+    end
+  },
+  {
     name = "2016-07-15-oauth2_code_credential_id",
     up = [[
       DELETE FROM oauth2_authorization_codes;

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -51,14 +51,12 @@ describe("Configuration loader", function()
   it("returns a plugins table", function()
     local constants = require "kong.constants"
     local conf = assert(conf_loader())
-    assert.is_nil(conf.custom_plugins)
     assert.same(constants.PLUGINS_AVAILABLE, conf.plugins)
   end)
   it("loads custom plugins", function()
     local conf = assert(conf_loader(nil, {
       custom_plugins = "hello-world,my-plugin"
     }))
-    assert.is_nil(conf.custom_plugins)
     assert.True(conf.plugins["hello-world"])
     assert.True(conf.plugins["my-plugin"])
   end)

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -202,6 +202,18 @@ describe("NGINX conf compiler", function()
       local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_conf))
       assert.same(conf, in_prefix_kong_conf)
     end)
+    it("writes custom plugins in Kong conf", function()
+      local conf = assert(conf_loader(nil, {
+        custom_plugins = { "foo", "bar" },
+        prefix = tmp_config.prefix
+      }))
+
+      assert(prefix_handler.prepare_prefix(conf))
+
+      local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_conf))
+      assert.True(in_prefix_kong_conf.plugins.foo)
+      assert.True(in_prefix_kong_conf.plugins.bar)
+    end)
     it("dumps Serf script", function()
       assert(prefix_handler.prepare_prefix(tmp_config))
 

--- a/spec/03-plugins/0001-metadata-insertion/access_spec.lua
+++ b/spec/03-plugins/0001-metadata-insertion/access_spec.lua
@@ -5,462 +5,454 @@ local cjson = require "cjson"
 local consumer
 local debug = require "kong.plugins.metadata-insertion.tool.debug"
 
-
 function setConsumerDummyData()
 
-    -- SETUP DUMMY DATA
-    consumer = assert(helpers.dao.consumers:insert {
-        username = "bob"
-    })
+  -- SETUP DUMMY DATA
+  consumer = assert(helpers.dao.consumers:insert {
+    username = "bob"
+  })
 
-    assert(helpers.dao.keyauth_credentials:insert {
-        consumer_id = consumer.id,
-        key = "bob-api-key"
-    })
+  assert(helpers.dao.keyauth_credentials:insert {
+    consumer_id = consumer.id,
+    key = "bob-api-key"
+  })
 
-    assert(helpers.dao.metadata_keyvaluestore:insert {
-        consumer_id = consumer.id,
-        key = "location",
-        value = "europe"
-    })
+  assert(helpers.dao.metadata_keyvaluestore:insert {
+    consumer_id = consumer.id,
+    key = "location",
+    value = "europe"
+  })
 
-    assert(helpers.dao.metadata_keyvaluestore:insert {
-        consumer_id = consumer.id,
-        key = "third_party_api_key",
-        value = "some-generic-api-key"
-    })
-
+  assert(helpers.dao.metadata_keyvaluestore:insert {
+    consumer_id = consumer.id,
+    key = "third_party_api_key",
+    value = "some-generic-api-key"
+  })
 end
 
 describe("Metadata-Insertion Plugin", function()
 
-    teardown(function()
-        if client then client:close() end
-        if admin_client then admin_client:close() end
+  teardown(function()
+    if client then client:close() end
+    if admin_client then admin_client:close() end
+  end)
+
+  before_each(function()
+    assert(helpers.start_kong())
+    admin_client = helpers.admin_client()
+    client = helpers.proxy_client()
+  end)
+
+  after_each(function()
+    assert(helpers.stop_kong())
+    if client then client:close() end
+    if admin_client then admin_client:close() end
+  end)
+
+  describe("Response", function()
+
+    it("Should return metadata previously created", function()
+
+      setConsumerDummyData()
+
+      local res = admin_client:send {
+        method = "GET",
+        path = "/consumers/bob/metadata",
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      }
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+
+      assert(json.data[1].key == "location", "Invalid parameter name")
+      assert(json.data[2].key == "third_party_api_key", "Invalid parameter name")
+      assert(json.data[1].value == "europe", "Invalid value")
+      assert(json.data[2].value == "some-generic-api-key", "Invalid value")
     end)
 
-    before_each(function()
-        assert(helpers.start_kong())
-        admin_client = helpers.admin_client()
-        client = helpers.proxy_client()
-    end)
+    it("Should return metadata previously created with crud API access point", function()
 
-    after_each(function()
-        assert(helpers.stop_kong())
-        if client then client:close() end
-        if admin_client then admin_client:close() end
-    end)
+      -- SETUP DUMMY DATA
+      consumer = assert(helpers.dao.consumers:insert {
+        username = "bob"
+      })
 
-    describe("Response", function()
+      assert(helpers.dao.keyauth_credentials:insert {
+        consumer_id = consumer.id,
+        key = "bob-api-key"
+      })
 
-        it("Should return metadata previously created", function()
+      assert(admin_client:send {
+        method = "POST",
+        path = "/consumers/" .. consumer.id .. "/metadata/",
+        body = {
+          key = "some-field",
+          value = "some-value"
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
 
-            setConsumerDummyData()
+      if admin_client then admin_client:close() end
+      admin_client = helpers.admin_client()
 
-            local res = admin_client:send {
-                method = "GET",
-                path = "/consumers/bob/metadata",
-                headers = {
-                    ["Content-Type"] = "application/json"
-                }
+      local res = admin_client:send {
+        method = "GET",
+        path = "/consumers/bob/metadata",
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      }
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+
+      assert(json.data[1].key == "some-field", "Metadata added with POST request seems to be missing")
+      assert(json.data[1].value == "some-value", "Metadata added with POST request seems to be missing")
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          add = {
+            querystring = {
+              "location: %some-field%"
+            },
+            headers = {
+              "location: %some-field%"
             }
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-
-            assert(json.data[1].key == "location", "Invalid parameter name")
-            assert(json.data[2].key == "third_party_api_key", "Invalid parameter name")
-            assert(json.data[1].value == "europe", "Invalid value")
-            assert(json.data[2].value ==  "some-generic-api-key", "Invalid value")
-        end)
-
-        it("Should return metadata previously created with crud API access point", function()
-
-            -- SETUP DUMMY DATA
-            consumer = assert(helpers.dao.consumers:insert {
-                username = "bob"
-            })
-
-            assert(helpers.dao.keyauth_credentials:insert {
-                consumer_id = consumer.id,
-                key = "bob-api-key"
-            })
-
-            assert(admin_client:send {
-                method = "POST",
-                path = "/consumers/" .. consumer.id .. "/metadata/",
-                body = {
-                    key = "some-field",
-                    value = "some-value"
-                },
-                headers = {
-                    ["Content-Type"] = "application/json"
-                }
-            })
-
-            if admin_client then admin_client:close() end
-            admin_client = helpers.admin_client()
-
-            local res = admin_client:send {
-                method = "GET",
-                path = "/consumers/bob/metadata",
-                headers = {
-                    ["Content-Type"] = "application/json"
-                }
-            }
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-
-            assert(json.data[1].key == "some-field", "Metadata added with POST request seems to be missing")
-            assert(json.data[1].value == "some-value", "Metadata added with POST request seems to be missing")
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    add = {
-                        querystring = {
-                            "location: %some-field%"
-                        },
-                        headers = {
-                            "location: %some-field%"
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/request?apikey=bob-api-key",
-                headers = {
-                    ["Host"] = "mockbin.com"
-                }
-            }))
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-
-            assert(json.headers.location == "some-value", "Metadata added with POST request seems to not work properly")
-            assert(json.queryString.location == "some-value", "Metadata added with POST request seems to not work properly")
-
-        end)
-
-        it("Should transform request with consumer metadata", function()
-
-            setConsumerDummyData()
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    add = {
-                        querystring = {
-                            "location: %location%",
-                            "apikey: %third_party_api_key%"
-                        },
-                        headers = {
-                            "user_country: %location%",
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/request?apikey=bob-api-key",
-                headers = {
-                    ["Host"] = "mockbin.com"
-                }
-            }))
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-
-            assert(json.headers.user_country == "europe", "Invalid user_country in headers")
-            assert(json.queryString.apikey == "some-generic-api-key", "Invalid api key in Querystring")
-            assert(json.queryString.location == "europe", "Invalid location in QueryString")
-
-        end)
-
-        it("Should throw error when trying to access an API without the proper metadata available", function()
-
-            consumer = assert(helpers.dao.consumers:insert {
-                username = "empty-user"
-            })
-
-            assert(helpers.dao.keyauth_credentials:insert {
-                consumer_id = consumer.id,
-                key = "empty-user-api-key"
-            })
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    add = {
-                        querystring = {
-                            "location: %location%",
-                            "apikey: %third_party_api_key%"
-                        },
-                        headers = {
-                            "user_country: %location%",
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/request?apikey=empty-user-api-key",
-                headers = {
-                    ["Host"] = "mockbin.com"
-                }
-            }))
-
-            assert.res_status(400, res)
-
-        end)
-
-        it("Should replace value from headers and querystring", function()
-
-            setConsumerDummyData()
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    replace = {
-                        querystring = {
-                            "location: %location%"
-                        },
-                        headers = {
-                            "third-party-api-key: %third_party_api_key%"
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/request?apikey=bob-api-key&location=bob_location_will_be_overwritten",
-                headers = {
-                    ["Host"] = "mockbin.com",
-                    ["third-party-api-key"] = "will_be_overwritten"
-                }
-            }))
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-            assert(json.queryString.location == "europe", "Invalid location in QueryString")
-            assert(json.headers["third-party-api-key"] == "some-generic-api-key", "Invalid third-party-api-key in headers")
-        end)
-
-        it("Should remove value from headers and querystring", function()
-
-            setConsumerDummyData()
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    remove = {
-                        querystring = {
-                            "location"
-                        },
-                        headers = {
-                            "third-party-api-key"
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/request?apikey=bob-api-key&location=will_be_removed",
-                headers = {
-                    ["Host"] = "mockbin.com",
-                    ["third-party-api-key"] = "will_be_removed"
-                }
-            }))
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-            assert(json.queryString.location == nil, "Location in querystring should be nil")
-            assert(json.headers["third-party-api-key"] == nil, "Invalid third-party-api-key in headers should be nil")
-        end)
-
-        it("Should trigger forbidden access when no user is authenticated", function()
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    replace = {
-                        querystring = {
-                            "whatever: %whatever%"
-                        }
-                    }
-                }
-            })
-
-            local res = assert(client:send({
-                method = "GET",
-                path = "/status",
-                headers = {
-                    ["Host"] = "mockbin.com"
-                }
-            }))
-
-            assert.res_status(401, res)
-        end)
-
-        it("Should transform request with consumer metadata but prioritise value from metadata transitory store", function()
-
-            -- must re-init the kong instance with new parameters
-            assert(helpers.stop_kong())
-            if client then client:close() end
-            if admin_client then admin_client:close() end
-
-            assert(helpers.start_kong({
-                custom_plugins = "metadata-insertion,metadata-transitory-store",
-                lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua"
-            }))
-
-            client = helpers.proxy_client()
-            admin_client = helpers.admin_client()
-
-            local api1 = assert(helpers.dao.apis:insert {
-                request_host = "mockbin.com",
-                upstream_url = "http://www.mockbin.com"
-            })
-
-            setConsumerDummyData()
-
-            assert(helpers.dao.plugins:insert {
-                name = "key-auth",
-                api_id = api1.id,
-                config = {
-                    hide_credentials = true
-                }
-            })
-
-            assert(helpers.dao.plugins:insert {
-                api_id = api1.id,
-                name = "metadata-insertion",
-                config = {
-                    add = {
-                        querystring = {
-                            "location: %location%",
-                            "apikey: %third_party_api_key%",
-                            "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
-                        },
-                        headers = {
-                            "user_country: %location%",
-                            "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
-                        }
-                    }
-                }
-            })
-
-            assert(admin_client:send {
-              method = "POST",
-              path = "/apis/" .. api1.id .. "/plugins/",
-              body = {
-                  name = "metadata-transitory-store"
-              },
-              headers = {
-                  ["Content-Type"] = "application/json"
-              }
-            })
-
-            local res = assert(client:send({
-               method = "GET",
-               path = "/request?apikey=bob-api-key",
-               headers = {
-                   ["Host"] = "mockbin.com"
-               }
-            }))
-
-            local body = assert.res_status(200, res)
-            local json = cjson.decode(body)
-
-            assert(json.headers.user_country == "location-from-transitory", "Invalid user_country in headers")
-            assert(json.queryString.apikey == "api-key-from-transitory", "Invalid apikey in QueryString")
-            assert(json.queryString.location == "location-from-transitory", "Invalid location in QueryString")
-            assert(json.queryString.field_only_available_in_transitory_store == "field_only_available_in_transitory_store", "Exclusive field in transitory store not added to metadata")
-
-        end)
-
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=bob-api-key",
+        headers = {
+          ["Host"] = "mockbin.com"
+        }
+      }))
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+
+      assert(json.headers.location == "some-value", "Metadata added with POST request seems to not work properly")
+      assert(json.queryString.location == "some-value", "Metadata added with POST request seems to not work properly")
     end)
 
+    it("Should transform request with consumer metadata", function()
+
+      setConsumerDummyData()
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          add = {
+            querystring = {
+              "location: %location%",
+              "apikey: %third_party_api_key%"
+            },
+            headers = {
+              "user_country: %location%",
+            }
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=bob-api-key",
+        headers = {
+          ["Host"] = "mockbin.com"
+        }
+      }))
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+
+      assert(json.headers.user_country == "europe", "Invalid user_country in headers")
+      assert(json.queryString.apikey == "some-generic-api-key", "Invalid api key in Querystring")
+      assert(json.queryString.location == "europe", "Invalid location in QueryString")
+    end)
+
+    it("Should throw error when trying to access an API without the proper metadata available", function()
+
+      consumer = assert(helpers.dao.consumers:insert {
+        username = "empty-user"
+      })
+
+      assert(helpers.dao.keyauth_credentials:insert {
+        consumer_id = consumer.id,
+        key = "empty-user-api-key"
+      })
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          add = {
+            querystring = {
+              "location: %location%",
+              "apikey: %third_party_api_key%"
+            },
+            headers = {
+              "user_country: %location%",
+            }
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=empty-user-api-key",
+        headers = {
+          ["Host"] = "mockbin.com"
+        }
+      }))
+
+      assert.res_status(400, res)
+    end)
+
+    it("Should replace value from headers and querystring", function()
+
+      setConsumerDummyData()
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          replace = {
+            querystring = {
+              "location: %location%"
+            },
+            headers = {
+              "third-party-api-key: %third_party_api_key%"
+            }
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=bob-api-key&location=bob_location_will_be_overwritten",
+        headers = {
+          ["Host"] = "mockbin.com",
+          ["third-party-api-key"] = "will_be_overwritten"
+        }
+      }))
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert(json.queryString.location == "europe", "Invalid location in QueryString")
+      assert(json.headers["third-party-api-key"] == "some-generic-api-key", "Invalid third-party-api-key in headers")
+    end)
+
+    it("Should remove value from headers and querystring", function()
+
+      setConsumerDummyData()
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          remove = {
+            querystring = {
+              "location"
+            },
+            headers = {
+              "third-party-api-key"
+            }
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=bob-api-key&location=will_be_removed",
+        headers = {
+          ["Host"] = "mockbin.com",
+          ["third-party-api-key"] = "will_be_removed"
+        }
+      }))
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert(json.queryString.location == nil, "Location in querystring should be nil")
+      assert(json.headers["third-party-api-key"] == nil, "Invalid third-party-api-key in headers should be nil")
+    end)
+
+    it("Should trigger forbidden access when no user is authenticated", function()
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          replace = {
+            querystring = {
+              "whatever: %whatever%"
+            }
+          }
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/status",
+        headers = {
+          ["Host"] = "mockbin.com"
+        }
+      }))
+
+      assert.res_status(401, res)
+    end)
+
+    it("Should transform request with consumer metadata but prioritise value from metadata transitory store", function()
+
+      -- must re-init the kong instance with new parameters
+      assert(helpers.stop_kong())
+      if client then client:close() end
+      if admin_client then admin_client:close() end
+
+      assert(helpers.start_kong({
+        custom_plugins = "metadata-insertion,metadata-transitory-store",
+        lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua"
+      }))
+
+      client = helpers.proxy_client()
+      admin_client = helpers.admin_client()
+
+      local api1 = assert(helpers.dao.apis:insert {
+        request_host = "mockbin.com",
+        upstream_url = "http://www.mockbin.com"
+      })
+
+      setConsumerDummyData()
+
+      assert(helpers.dao.plugins:insert {
+        name = "key-auth",
+        api_id = api1.id,
+        config = {
+          hide_credentials = true
+        }
+      })
+
+      assert(helpers.dao.plugins:insert {
+        api_id = api1.id,
+        name = "metadata-insertion",
+        config = {
+          add = {
+            querystring = {
+              "location: %location%",
+              "apikey: %third_party_api_key%",
+              "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
+            },
+            headers = {
+              "user_country: %location%",
+              "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
+            }
+          }
+        }
+      })
+
+      assert(admin_client:send {
+        method = "POST",
+        path = "/apis/" .. api1.id .. "/plugins/",
+        body = {
+          name = "metadata-transitory-store"
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      local res = assert(client:send({
+        method = "GET",
+        path = "/request?apikey=bob-api-key",
+        headers = {
+          ["Host"] = "mockbin.com"
+        }
+      }))
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+
+      assert(json.headers.user_country == "location-from-transitory", "Invalid user_country in headers")
+      assert(json.queryString.apikey == "api-key-from-transitory", "Invalid apikey in QueryString")
+      assert(json.queryString.location == "location-from-transitory", "Invalid location in QueryString")
+      assert(json.queryString.field_only_available_in_transitory_store == "field_only_available_in_transitory_store", "Exclusive field in transitory store not added to metadata")
+    end)
+  end)
 end)

--- a/spec/03-plugins/0001-metadata-insertion/access_spec.lua
+++ b/spec/03-plugins/0001-metadata-insertion/access_spec.lua
@@ -1,0 +1,466 @@
+local helpers = require "spec.helpers"
+local client
+local admin_client
+local cjson = require "cjson"
+local consumer
+local debug = require "kong.plugins.metadata-insertion.tool.debug"
+
+
+function setConsumerDummyData()
+
+    -- SETUP DUMMY DATA
+    consumer = assert(helpers.dao.consumers:insert {
+        username = "bob"
+    })
+
+    assert(helpers.dao.keyauth_credentials:insert {
+        consumer_id = consumer.id,
+        key = "bob-api-key"
+    })
+
+    assert(helpers.dao.metadata_keyvaluestore:insert {
+        consumer_id = consumer.id,
+        key = "location",
+        value = "europe"
+    })
+
+    assert(helpers.dao.metadata_keyvaluestore:insert {
+        consumer_id = consumer.id,
+        key = "third_party_api_key",
+        value = "some-generic-api-key"
+    })
+
+end
+
+describe("Metadata-Insertion Plugin", function()
+
+    teardown(function()
+        if client then client:close() end
+        if admin_client then admin_client:close() end
+    end)
+
+    before_each(function()
+        assert(helpers.start_kong())
+        admin_client = helpers.admin_client()
+        client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+        assert(helpers.stop_kong())
+        if client then client:close() end
+        if admin_client then admin_client:close() end
+    end)
+
+    describe("Response", function()
+
+        it("Should return metadata previously created", function()
+
+            setConsumerDummyData()
+
+            local res = admin_client:send {
+                method = "GET",
+                path = "/consumers/bob/metadata",
+                headers = {
+                    ["Content-Type"] = "application/json"
+                }
+            }
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+
+            assert(json.data[1].key == "location", "Invalid parameter name")
+            assert(json.data[2].key == "third_party_api_key", "Invalid parameter name")
+            assert(json.data[1].value == "europe", "Invalid value")
+            assert(json.data[2].value ==  "some-generic-api-key", "Invalid value")
+        end)
+
+        it("Should return metadata previously created with crud API access point", function()
+
+            -- SETUP DUMMY DATA
+            consumer = assert(helpers.dao.consumers:insert {
+                username = "bob"
+            })
+
+            assert(helpers.dao.keyauth_credentials:insert {
+                consumer_id = consumer.id,
+                key = "bob-api-key"
+            })
+
+            assert(admin_client:send {
+                method = "POST",
+                path = "/consumers/" .. consumer.id .. "/metadata/",
+                body = {
+                    key = "some-field",
+                    value = "some-value"
+                },
+                headers = {
+                    ["Content-Type"] = "application/json"
+                }
+            })
+
+            if admin_client then admin_client:close() end
+            admin_client = helpers.admin_client()
+
+            local res = admin_client:send {
+                method = "GET",
+                path = "/consumers/bob/metadata",
+                headers = {
+                    ["Content-Type"] = "application/json"
+                }
+            }
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+
+            assert(json.data[1].key == "some-field", "Metadata added with POST request seems to be missing")
+            assert(json.data[1].value == "some-value", "Metadata added with POST request seems to be missing")
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    add = {
+                        querystring = {
+                            "location: %some-field%"
+                        },
+                        headers = {
+                            "location: %some-field%"
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/request?apikey=bob-api-key",
+                headers = {
+                    ["Host"] = "mockbin.com"
+                }
+            }))
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+
+            assert(json.headers.location == "some-value", "Metadata added with POST request seems to not work properly")
+            assert(json.queryString.location == "some-value", "Metadata added with POST request seems to not work properly")
+
+        end)
+
+        it("Should transform request with consumer metadata", function()
+
+            setConsumerDummyData()
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    add = {
+                        querystring = {
+                            "location: %location%",
+                            "apikey: %third_party_api_key%"
+                        },
+                        headers = {
+                            "user_country: %location%",
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/request?apikey=bob-api-key",
+                headers = {
+                    ["Host"] = "mockbin.com"
+                }
+            }))
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+
+            assert(json.headers.user_country == "europe", "Invalid user_country in headers")
+            assert(json.queryString.apikey == "some-generic-api-key", "Invalid api key in Querystring")
+            assert(json.queryString.location == "europe", "Invalid location in QueryString")
+
+        end)
+
+        it("Should throw error when trying to access an API without the proper metadata available", function()
+
+            consumer = assert(helpers.dao.consumers:insert {
+                username = "empty-user"
+            })
+
+            assert(helpers.dao.keyauth_credentials:insert {
+                consumer_id = consumer.id,
+                key = "empty-user-api-key"
+            })
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    add = {
+                        querystring = {
+                            "location: %location%",
+                            "apikey: %third_party_api_key%"
+                        },
+                        headers = {
+                            "user_country: %location%",
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/request?apikey=empty-user-api-key",
+                headers = {
+                    ["Host"] = "mockbin.com"
+                }
+            }))
+
+            assert.res_status(400, res)
+
+        end)
+
+        it("Should replace value from headers and querystring", function()
+
+            setConsumerDummyData()
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    replace = {
+                        querystring = {
+                            "location: %location%"
+                        },
+                        headers = {
+                            "third-party-api-key: %third_party_api_key%"
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/request?apikey=bob-api-key&location=bob_location_will_be_overwritten",
+                headers = {
+                    ["Host"] = "mockbin.com",
+                    ["third-party-api-key"] = "will_be_overwritten"
+                }
+            }))
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert(json.queryString.location == "europe", "Invalid location in QueryString")
+            assert(json.headers["third-party-api-key"] == "some-generic-api-key", "Invalid third-party-api-key in headers")
+        end)
+
+        it("Should remove value from headers and querystring", function()
+
+            setConsumerDummyData()
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    remove = {
+                        querystring = {
+                            "location"
+                        },
+                        headers = {
+                            "third-party-api-key"
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/request?apikey=bob-api-key&location=will_be_removed",
+                headers = {
+                    ["Host"] = "mockbin.com",
+                    ["third-party-api-key"] = "will_be_removed"
+                }
+            }))
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert(json.queryString.location == nil, "Location in querystring should be nil")
+            assert(json.headers["third-party-api-key"] == nil, "Invalid third-party-api-key in headers should be nil")
+        end)
+
+        it("Should trigger forbidden access when no user is authenticated", function()
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    replace = {
+                        querystring = {
+                            "whatever: %whatever%"
+                        }
+                    }
+                }
+            })
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/status",
+                headers = {
+                    ["Host"] = "mockbin.com"
+                }
+            }))
+
+            assert.res_status(401, res)
+        end)
+
+        it("Should transform request with consumer metadata but prioritise value from metadata transitory store", function()
+
+            -- must re-init the kong instance with new parameters
+            assert(helpers.stop_kong())
+            if client then client:close() end
+            if admin_client then admin_client:close() end
+
+            assert(helpers.start_kong({
+                custom_plugins = "metadata-insertion,metadata-transitory-store",
+                lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua"
+            }))
+
+            client = helpers.proxy_client()
+            admin_client = helpers.admin_client()
+
+            local api1 = assert(helpers.dao.apis:insert {
+                request_host = "mockbin.com",
+                upstream_url = "http://www.mockbin.com"
+            })
+
+            setConsumerDummyData()
+
+            assert(helpers.dao.plugins:insert {
+                name = "key-auth",
+                api_id = api1.id,
+                config = {
+                    hide_credentials = true
+                }
+            })
+
+            assert(helpers.dao.plugins:insert {
+                api_id = api1.id,
+                name = "metadata-insertion",
+                config = {
+                    add = {
+                        querystring = {
+                            "location: %location%",
+                            "apikey: %third_party_api_key%",
+                            "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
+                        },
+                        headers = {
+                            "user_country: %location%",
+                            "field_only_available_in_transitory_store: %field_only_available_in_transitory_store%"
+                        }
+                    }
+                }
+            })
+
+            assert(admin_client:send {
+              method = "POST",
+              path = "/apis/" .. api1.id .. "/plugins/",
+              body = {
+                  name = "metadata-transitory-store"
+              },
+              headers = {
+                  ["Content-Type"] = "application/json"
+              }
+            })
+
+            local res = assert(client:send({
+               method = "GET",
+               path = "/request?apikey=bob-api-key",
+               headers = {
+                   ["Host"] = "mockbin.com"
+               }
+            }))
+
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+
+            assert(json.headers.user_country == "location-from-transitory", "Invalid user_country in headers")
+            assert(json.queryString.apikey == "api-key-from-transitory", "Invalid apikey in QueryString")
+            assert(json.queryString.location == "location-from-transitory", "Invalid location in QueryString")
+            assert(json.queryString.field_only_available_in_transitory_store == "field_only_available_in_transitory_store", "Exclusive field in transitory store not added to metadata")
+
+        end)
+
+    end)
+
+end)

--- a/spec/03-plugins/05-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/05-galileo/01-alf_spec.lua
@@ -26,6 +26,17 @@ local alf_serializer = require "kong.plugins.galileo.alf"
 -- input sets to the serializer.
 local function reload_alf_serializer()
   package.loaded["kong.plugins.galileo.alf"] = nil
+
+  -- FIXME: temporary double-loading of the cjson module
+  -- for the encoding JSON as empty array tests in the
+  -- serialize() suite.
+  -- remove once https://github.com/openresty/lua-cjson/pull/16
+  -- is included in a formal OpenResty release.
+  package.loaded["cjson"] = nil
+  package.loaded["cjson.safe"] = nil
+  require "cjson.safe"
+  require "cjson"
+
   alf_serializer = require "kong.plugins.galileo.alf"
 end
 
@@ -487,6 +498,13 @@ describe("ALF serializer", function()
   end) -- add_entry()
 
   describe("serialize()", function()
+    -- FIXME: temporary double-loading of the cjson module
+    -- for the encoding JSON as empty array tests in the
+    -- serialize() suite.
+    -- remove once https://github.com/openresty/lua-cjson/pull/16
+    -- is included in a formal OpenResty release.
+    reload_alf_serializer()
+
     local cjson = require "cjson.safe"
     it("returns a JSON encoded ALF object", function()
       local alf = alf_serializer.new()

--- a/spec/03-plugins/99-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/99-oauth2/03-access_spec.lua
@@ -1456,6 +1456,18 @@ describe("#ci Plugin: oauth2 (access)", function()
   end)
 
   describe("Making a request", function()
+    it("fails when no access_token is being sent in an application/json body", function()
+      local res = assert(proxy_ssl_client:send {
+        method = "POST",
+        path = "/request",
+        headers = {
+          ["Host"] = "oauth2.com",
+          ["Content-Type"] = "application/json"
+        }
+      })
+      local body = assert.res_status(401, res)
+      assert.equal([[{"error_description":"The access token is missing","error":"invalid_request"}]], body)
+    end)
     it("works when a correct access_token is being sent in the querystring", function()
       local token = provision_token()
 

--- a/spec/fixtures/kong/plugins/metadata-transitory-store/handler.lua
+++ b/spec/fixtures/kong/plugins/metadata-transitory-store/handler.lua
@@ -15,21 +15,21 @@ end
 function MetadataTransitoryStoreHandler:access(conf)
   MetadataTransitoryStoreHandler.super.access(self)
 
-    -- add data in metadata transitory store
-    ngx.ctx.metadata_transitory_store = {
-        {
-          key = "location",
-          value = "location-from-transitory"
-        },
-        {
-          key = "third_party_api_key",
-          value = "api-key-from-transitory"
-        },
-        {
-            key = "field_only_available_in_transitory_store",
-            value = "field_only_available_in_transitory_store"
-        },
-    }
+  -- add data in metadata transitory store
+  ngx.ctx.metadata_transitory_store = {
+    {
+      key = "location",
+      value = "location-from-transitory"
+    },
+    {
+      key = "third_party_api_key",
+      value = "api-key-from-transitory"
+    },
+    {
+      key = "field_only_available_in_transitory_store",
+      value = "field_only_available_in_transitory_store"
+    },
+  }
 end
 
 return MetadataTransitoryStoreHandler

--- a/spec/fixtures/kong/plugins/metadata-transitory-store/handler.lua
+++ b/spec/fixtures/kong/plugins/metadata-transitory-store/handler.lua
@@ -1,0 +1,35 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local debug = require "kong.plugins.metadata-insertion.tool.debug"
+local MetadataTransitoryStoreHandler = BasePlugin:extend()
+
+MetadataTransitoryStoreHandler.PRIORITY = 100
+
+function MetadataTransitoryStoreHandler:new()
+  MetadataTransitoryStoreHandler.super.new(self, "metadata-transitory-store")
+end
+
+function MetadataTransitoryStoreHandler:init_worker()
+  MetadataTransitoryStoreHandler.super.init_worker(self)
+end
+
+function MetadataTransitoryStoreHandler:access(conf)
+  MetadataTransitoryStoreHandler.super.access(self)
+
+    -- add data in metadata transitory store
+    ngx.ctx.metadata_transitory_store = {
+        {
+          key = "location",
+          value = "location-from-transitory"
+        },
+        {
+          key = "third_party_api_key",
+          value = "api-key-from-transitory"
+        },
+        {
+            key = "field_only_available_in_transitory_store",
+            value = "field_only_available_in_transitory_store"
+        },
+    }
+end
+
+return MetadataTransitoryStoreHandler

--- a/spec/fixtures/kong/plugins/metadata-transitory-store/schema.lua
+++ b/spec/fixtures/kong/plugins/metadata-transitory-store/schema.lua
@@ -1,0 +1,3 @@
+return { 
+  fields = {}
+}

--- a/spec/fixtures/kong/plugins/metadata-transitory-store/schema.lua
+++ b/spec/fixtures/kong/plugins/metadata-transitory-store/schema.lua
@@ -1,3 +1,3 @@
-return { 
+return {
   fields = {}
 }

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -24,3 +24,5 @@ nginx_optimizations = off
 
 prefix = servroot
 log_level = debug
+
+custom_plugins = metadata-insertion


### PR DESCRIPTION
### Summary
Here's some metadata plugin that allows kong to modify Headers and Querystring based on two source of metadata, the persistent ones in database / redis and the ones in the transitory store.

Transitory store could allow other plugins to prepare metadata on the fly when kong receive a Request. (View Tieske suggestion here https://github.com/Mashape/kong/issues/550)
One of the test cover the use case by feeding the transitory store with fixtures.

I've added a debug.lua library for my POC, I should probably remove it if the pull request ever gets approved.

Also I believe my request_headers_factory and request_querystring_factory could be use in the request-transformer plugin, so it might be wise to move in /kong/tools or something like that ?

Comments are welcome, i've never done Lua / OpenResty before.

### Full changelog

* Implement metadata-insertion plugin

### Issues resolved

Fix https://github.com/Mashape/kong/issues/550
