### PR TITLE
Allow multiple origin domains for CORS

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -8,7 +8,7 @@ CorsHandler.PRIORITY = 2000
 local OPTIONS = "OPTIONS"
 
 local function host_in_domain(domain, conf)
-  for i, d in ipairs(conf.origin_domains) do
+  for i, d in ipairs(conf.origin) do
     if string.match(domain, '[%.|//]'..d..'$') then
       return true
     end
@@ -18,16 +18,13 @@ end
 
 local function configure_origin(ngx, conf)
   local origin = ngx.req.get_headers()["origin"] or nil
-  if conf.origin_domains ~= nil then
-   if origin ~= nil and host_in_domain(origin, conf) then
+  if conf.origin == nil then
+    ngx.header["Access-Control-Allow-Origin"] = "*"
+  else
+    if origin ~= nil and host_in_domain(origin, conf) then
       ngx.header["Access-Control-Allow-Origin"] = origin
       ngx.header["Vary"] = "Origin"
     end
-  elseif conf.origin == nil then
-    ngx.header["Access-Control-Allow-Origin"] = "*"
-  else
-    ngx.header["Access-Control-Allow-Origin"] = conf.origin
-    ngx.header["Vary"] = "Origin"
   end
 end
 

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -7,8 +7,23 @@ CorsHandler.PRIORITY = 2000
 
 local OPTIONS = "OPTIONS"
 
+local function host_in_domain(domain, conf)
+  for i, d in ipairs(conf.origin_domains) do
+    if string.match(domain, '[%.|//]'..d..'$') then
+      return true
+    end
+  end
+  return false
+end
+
 local function configure_origin(ngx, conf)
-  if conf.origin == nil then
+  local origin = ngx.req.get_headers()["origin"] or nil
+  if conf.origin_domains ~= nil then
+   if origin ~= nil and host_in_domain(origin, conf) then
+      ngx.header["Access-Control-Allow-Origin"] = origin
+      ngx.header["Vary"] = "Origin"
+    end
+  elseif conf.origin == nil then
     ngx.header["Access-Control-Allow-Origin"] = "*"
   else
     ngx.header["Access-Control-Allow-Origin"] = conf.origin

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -7,6 +7,7 @@ return {
     methods = { type = "array", enum = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE" } },
     max_age = { type = "number" },
     credentials = { type = "boolean", default = false },
-    preflight_continue = { type = "boolean", default = false }
+    preflight_continue = { type = "boolean", default = false },
+    origin_domains = { type = "array" }
   }
 }

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -1,13 +1,12 @@
 return {
   no_consumer = true,
   fields = {
-    origin = { type = "string" },
+    origin = { type = "array" },
     headers = { type = "array" },
     exposed_headers = { type = "array" },
     methods = { type = "array", enum = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE" } },
     max_age = { type = "number" },
     credentials = { type = "boolean", default = false },
-    preflight_continue = { type = "boolean", default = false },
-    origin_domains = { type = "array" }
+    preflight_continue = { type = "boolean", default = false }
   }
 }

--- a/spec/03-plugins/04-cors/01-access_spec.lua
+++ b/spec/03-plugins/04-cors/01-access_spec.lua
@@ -26,7 +26,8 @@ describe("Plugin: cors (access)", function()
       upstream_url = "http://mockbin.com"
     })
     local api5 = assert(helpers.dao.apis:insert {
-      request_host = "cors5.com",
+      name = "api-5"
+      request_host = { "cors5.com" },
       upstream_url = "http://mockbin.com"
     })
 
@@ -38,7 +39,7 @@ describe("Plugin: cors (access)", function()
       name = "cors",
       api_id = api2.id,
       config = {
-        origin = "example.com",
+        origin = {"example.com"},
         methods = {"GET"},
         headers = {"origin", "type", "accepts"},
         exposed_headers = {"x-auth-token"},
@@ -50,7 +51,7 @@ describe("Plugin: cors (access)", function()
       name = "cors",
       api_id = api3.id,
       config = {
-        origin = "example.com",
+        origin = {"example.com"},
         methods = {"GET"},
         headers = {"origin", "type", "accepts"},
         exposed_headers = {"x-auth-token"},
@@ -72,13 +73,12 @@ describe("Plugin: cors (access)", function()
       name = "cors",
       api_id = api5.id,
       config = {
-        origin = "example.com",
+        origin = {"example.com", "example.org"},
         methods = {"GET"},
         headers = {"origin", "type", "accepts"},
         exposed_headers = {"x-auth-token"},
         max_age = 23,
-        preflight_continue = true,
-        origin_domains = 'example.com, example.org'
+        preflight_continue = true
       }
     })
 

--- a/spec/03-plugins/04-cors/01-access_spec.lua
+++ b/spec/03-plugins/04-cors/01-access_spec.lua
@@ -25,6 +25,10 @@ describe("Plugin: cors (access)", function()
       hosts = { "cors4.com" },
       upstream_url = "http://mockbin.com"
     })
+    local api5 = assert(helpers.dao.apis:insert {
+      request_host = "cors5.com",
+      upstream_url = "http://mockbin.com"
+    })
 
     assert(helpers.dao.plugins:insert {
       name = "cors",
@@ -62,6 +66,20 @@ describe("Plugin: cors (access)", function()
     assert(helpers.dao.plugins:insert {
       name = "key-auth",
       api_id = api4.id
+    })
+    
+    assert(helpers.dao.plugins:insert {
+      name = "cors",
+      api_id = api5.id,
+      config = {
+        origin = "example.com",
+        methods = {"GET"},
+        headers = {"origin", "type", "accepts"},
+        exposed_headers = {"x-auth-token"},
+        max_age = 23,
+        preflight_continue = true,
+        origin_domains = 'example.com, example.org'
+      }
     })
 
     assert(helpers.start_kong())
@@ -180,6 +198,28 @@ describe("Plugin: cors (access)", function()
       assert.is_nil(res.headers["Access-Control-Expose-Headers"])
       assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
       assert.is_nil(res.headers["Access-Control-Max-Age"])
+    end)
+    it("sets CORS orgin based on origin host", function()
+      local res = assert(client:send {
+        method = "GET",
+        headers = {
+          ["Host"] = "cors5.com",
+          ["Origin"] = "http://www.example.com"
+        }
+      })
+      assert.res_status(200, res)
+      assert.equal("http://www.example.com", res.headers["Access-Control-Allow-Origin"])
+    end)
+    it("does not sets CORS orgin if origin host is not in origin_domains list", function()
+      local res = assert(client:send {
+        method = "GET",
+        headers = {
+          ["Host"] = "cors5.com",
+          ["Origin"] = "http://www.example.net"
+        }
+      })
+      assert.res_status(200, res)
+      assert.is_nil(res.headers["Access-Control-Allow-Origin"])
     end)
   end)
 end)

--- a/spec/03-plugins/04-cors/01-access_spec.lua
+++ b/spec/03-plugins/04-cors/01-access_spec.lua
@@ -26,7 +26,7 @@ describe("Plugin: cors (access)", function()
       upstream_url = "http://mockbin.com"
     })
     local api5 = assert(helpers.dao.apis:insert {
-      name = "api-5"
+      name = "api-5",
       request_host = { "cors5.com" },
       upstream_url = "http://mockbin.com"
     })


### PR DESCRIPTION
**This PR references 1774 contributed by @danielvijge and has been rebased on top of next.**

## Summary

When several domains consume an API, the CORS header Access-Control-Allow-Origin is not as useful, because it only allows one domain, or all domains (with "*"). The specs do not allow for a list of domains. This change works around this by comparing the Origin header to a list of configured domain in the array 'origin_domains'. It tests if the end of the domain matches either ".{domain}" or "//{domain}". Thus, if origins_domain="example.com, example.net", a request from Origin="http://www.example.com" would be allowed, as does a request from Origin="http://example.com". But Origin="http://my-example.com" is not allowed. In this case, no Access-Control-Allow-Origin header is set.
If both origin and origin_domains are configured, origin_domains take precedence over origin.

## Full changelog

- Changes to CORS plugin schema to have extra configuration for origin_domains[]
- Changes to CORS plugin handler to test for multiple domain and set correct header
- Changes to test script to test if the correct header is set when the origin domain matches
- Changes to test script to test if the header remains empty when the origin domain does not match

## Issues resolved
Fix #1043
