### PR TITLE
make serf_event admin ip to synchronize with kong.conf's admin_listen

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -223,7 +223,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   if not resty_bin then return nil, err end
 
   log.verbose("saving serf shell script handler to %s", kong_config.serf_event)
-  local script = fmt(script_template, "127.0.0.1", kong_config.admin_port, resty_bin)
+  local script = fmt(script_template, kong_config.admin_ip, kong_config.admin_port, resty_bin)
   pl_file.write(kong_config.serf_event, script)
   local ok, _, _, stderr = pl_utils.executeex("chmod +x "..kong_config.serf_event)
   if not ok then return nil, stderr end


### PR DESCRIPTION
**Note: new features are to be opened against next, hotfixes against master.**

### Summary
chaned kong/cmd/utils/prefix_handler.lua  to  fix serf_event.sh connect admin ip error bug

### Issues resolved

Fix #1687 
