### PR TITLE
fix(tests) fixed oauth2 tests failing due to merge issues

### DIFF
--- a/spec/03-plugins/99-oauth2/04-hooks_spec.lua
+++ b/spec/03-plugins/99-oauth2/04-hooks_spec.lua
@@ -37,14 +37,6 @@ describe("#ci Plugin: oauth2 (hooks)", function()
       consumer_id = consumer.id
     })
 
-    -- Invalidate cache
-    local res = assert(admin_client:send {
-      method = "DELETE",
-      path = "/cache/",
-      headers = {}
-    })
-    assert.res_status(204, res)
-
     assert(helpers.start_kong())
     admin_client = helpers.admin_client()
     proxy_ssl_client = helpers.proxy_ssl_client()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -222,7 +222,7 @@ end
 -- @name proxy_ssl_client
 local function proxy_ssl_client(timeout)
   local client = http_client(conf.proxy_ip, conf.proxy_ssl_port, timeout)
-  client:ssl_handshake()
+  assert(client:ssl_handshake())
   return client
 end
 


### PR DESCRIPTION
Most errors are fixed, but still getting;

```
[----------] Running tests from ./spec/03-plugins/99-oauth2/03-access_spec.lua
2017/01/16 11:09:51 [error] 28023#0: *2 SSL_do_handshake() failed (SSL: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error), context: ngx.timer
./spec/helpers.lua:225: handshake failed

stack traceback:
	./spec/helpers.lua:225: in function 'proxy_ssl_client'
	./spec/03-plugins/99-oauth2/03-access_spec.lua:204: in function <./spec/03-plugins/99-oauth2/03-access_spec.lua:7>

[----------] 0 tests from ./spec/03-plugins/99-oauth2/03-access_spec.lua (2069.44 ms total)
```

Suspecting this due to the changes in ssl/tls from the new router.

@thibaultcha any hints?