### PR TITLE
fix(test) fetch user by escaped username #1968

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -61,7 +61,7 @@ end
 
 function _M.paginated_set(self, dao_collection)
   local size = self.params.size and tonumber(self.params.size) or 100
-  local offset = self.params.offset and ngx.decode_base64(self.params.offset) or nil
+  local offset = self.params.offset and ngx.decode_base64(self.params.offset)
 
   self.params.size = nil
   self.params.offset = nil

--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -17,6 +17,7 @@ return {
 
   ["/consumers/:username_or_id"] = {
     before = function(self, dao_factory, helpers)
+      self.params.username_or_id = ngx.unescape_uri(self.params.username_or_id)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
     end,
 

--- a/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
@@ -23,7 +23,7 @@ describe("Admin API", function()
   before_each(function()
     helpers.dao:truncate_tables()
     consumer = assert(helpers.dao.consumers:insert {
-      username = "bob",
+      username = "bob pop",
       custom_id = "1234"
     })
   end)
@@ -68,12 +68,12 @@ describe("Admin API", function()
               method = "POST",
               path = "/consumers",
               body = {
-                username = "bob"
+                username = "bob pop"
               },
               headers = {["Content-Type"] = content_type}
             })
             local body = assert.res_status(409, res)
-            assert.equal([[{"username":"already exists with value 'bob'"}]], body)
+            assert.equal([[{"username":"already exists with value 'bob pop'"}]], body)
           end
         end)
       end)

--- a/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local escape = require("socket.url").escape
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
@@ -264,7 +265,7 @@ describe("Admin API", function()
         it("retrieves by username", function()
           local res = assert(client:send {
             method = "GET",
-            path = "/consumers/"..consumer.username
+            path = "/consumers/"..escape(consumer.username)
           })
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)


### PR DESCRIPTION
Fix for issue #1968 allowing username with spaces in url

Initial commit with only a test, but oddly the test passes...

on the command line I can reproduce the erroneous behaviour:
```
mashapes-mbp-2:kong thijs$ http post :8001/consumers username="bob pop"
HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Mon, 16 Jan 2017 13:32:58 GMT
Server: kong/0.10.0rc2
Transfer-Encoding: chunked

{
    "created_at": 1484573579000,
    "id": "9fbe2f9e-42bb-4e08-87bf-e63e40151227",
    "username": "bob pop"
}

mashapes-mbp-2:kong thijs$ http get :8001/consumers/bob%20pop
HTTP/1.1 404 Not Found
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Mon, 16 Jan 2017 13:33:16 GMT
Server: kong/0.10.0rc2
Transfer-Encoding: chunked

{
    "message": "Not found"
}

mashapes-mbp-2:kong thijs$
```