### PR TITLE
fix(ssl) fallback on global SSL certificate

### DIFF
--- a/kong/core/certificate.lua
+++ b/kong/core/certificate.lua
@@ -81,8 +81,14 @@ function _M.execute()
   -- retrieve SNI or raw server IP
 
   local sni, err = ssl.server_name()
+  if err then
+    log(ERR, "could not retrieve Server Name Indication: ", err)
+    return ngx.exit(ngx.ERROR)
+  end
   if not sni then
-    log(DEBUG, "could not retrieve Server Name Indication from client and using global SSL configuration: ", err)
+    log(DEBUG, "no Server Name Indication provided by client, serving ".. 
+               "default proxy SSL certificate")
+    -- use fallback certificate
     return
   end
 

--- a/kong/core/certificate.lua
+++ b/kong/core/certificate.lua
@@ -82,8 +82,8 @@ function _M.execute()
 
   local sni, err = ssl.server_name()
   if not sni then
-    log(ERR, "could not retrieve Server Name Indication from client: ", err)
-    return ngx.exit(ngx.ERROR)
+    log(DEBUG, "could not retrieve Server Name Indication from client and using global SSL configuration: ", err)
+    return
   end
 
   local cert_and_key, err

--- a/kong/core/certificate.lua
+++ b/kong/core/certificate.lua
@@ -86,7 +86,7 @@ function _M.execute()
     return ngx.exit(ngx.ERROR)
   end
   if not sni then
-    log(DEBUG, "no Server Name Indication provided by client, serving ".. 
+    log(DEBUG, "no Server Name Indication provided by client, serving ", 
                "default proxy SSL certificate")
     -- use fallback certificate
     return

--- a/spec/02-integration/05-proxy/04-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/04-ssl_spec.lua
@@ -64,7 +64,7 @@ describe("SSL", function()
   end)
 
   describe("global SSL", function()
-    it("fallbakcs on the global SSL certificate", function()
+    it("fallbacks on the default proxy SSL certificate when SNI is not provided by client", function()
       local res = assert(https_client:send {
         method = "GET",
         path = "/status/200",

--- a/spec/02-integration/05-proxy/04-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/04-ssl_spec.lua
@@ -14,10 +14,16 @@ end
 
 
 describe("SSL", function()
-  local admin_client, client
+  local admin_client, client, https_client
 
   setup(function()
     helpers.dao:truncate_tables()
+
+    assert(helpers.dao.apis:insert {
+      name = "global-cert",
+      hosts = { "global.com" },
+      upstream_url = "http://httpbin.org"
+    })
 
     assert(helpers.dao.apis:insert {
       name = "api-1",
@@ -39,6 +45,7 @@ describe("SSL", function()
 
     admin_client = helpers.admin_client()
     client = helpers.proxy_client()
+    https_client = helpers.proxy_ssl_client()
 
     assert(admin_client:send {
       method = "POST",
@@ -54,6 +61,19 @@ describe("SSL", function()
 
   teardown(function()
     helpers.stop_kong()
+  end)
+
+  describe("global SSL", function()
+    it("fallbakcs on the global SSL certificate", function()
+      local res = assert(https_client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          Host = "global.com"
+        }
+      })
+      assert.res_status(200, res)
+    end)
   end)
 
   describe("handshake", function()


### PR DESCRIPTION
When Kong starts it auto-generates global SSL certificates to be used on the `proxy_listen_ssl` port. 

0.10.0 introduced a bug where the global certificate was not used anymore if an API doesn't have a specific SSL certificate configured. This PR fixes the bug.