### PR TITLE
Proxying more than once fails

### DIFF
--- a/spec/02-integration/05-proxy/02-http_spec.lua
+++ b/spec/02-integration/05-proxy/02-http_spec.lua
@@ -1,0 +1,42 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+describe("HTTP proxying", function()
+  local client
+  setup(function()
+    assert(helpers.dao.apis:insert {
+      name = "mockbin",
+      uris = { "/mockbin" },
+      strip_uri = true,
+      upstream_url = "http://mockbin.com"
+    })
+
+    assert(helpers.start_kong())
+    client = helpers.proxy_client()
+  end)
+
+  teardown(function()
+    if client then client:close() end
+    helpers.stop_kong()
+  end)
+
+  local function make_request()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/mockbin/request?hello=world",
+    })
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+    assert.equal("world", json.queryString.hello)
+  end
+
+  it("proxies on HTTP port", function()
+    make_request()
+  end)
+
+  it("proxies on HTTP port multiple times", function()
+    for i = 1, 10 do 
+      make_request()
+    end
+  end)
+end)


### PR DESCRIPTION
This is a **significant** bug introduced in 0.10.0 - proxying more than once on a worker doesn't work.

So far the test case replicates the problem, but a fix needs to be implemented.