### PR TITLE
fix the misinterpretation of the `%` character in a query string

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -155,16 +155,13 @@ do
   local url = require "socket.url"
 
   --- URL escape and format key and value
-  -- An obligatory url.unescape pass must be done to prevent double-encoding
-  -- already encoded values (which contain a '%' character that `url.escape` escapes)
+  -- values should be already decoded or the `raw` option should be passed to prevent double-encoding
   local function encode_args_value(key, value, raw)
     if not raw then
-      key = url.unescape(key)
       key = url.escape(key)
     end
     if value ~= nil then
       if not raw then
-        value = url.unescape(value)
         value = url.escape(value)
       end
       return fmt("%s=%s", key, value)

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -200,6 +200,12 @@ describe("Utils", function()
         }
         assert.equal("hello=world&multiple=hello%2c%20world&multiple%20values", str)
       end)
+      it("should not interpret the `%` character followed by 2 characters in the [0-9a-f] group as an hexadecimal value", function()
+        local str = utils.encode_args {
+          foo = "%bar%"
+        }
+        assert.equal("foo=%25bar%25", str)
+      end)
       it("should not percent-encode if given a `raw` option", function()
         -- this is useful for kong.tools.http_client
         local str = utils.encode_args({
@@ -229,6 +235,12 @@ describe("Utils", function()
             b = false
           }, true)
           assert.equal("a=true&b=false", str)
+        end)
+        it("should prevent double percent-encoding", function()
+          local str = utils.encode_args({
+            foo = "hello%20world"
+          }, true)
+          assert.equal("foo=hello%20world", str)
         end)
       end)
     end)


### PR DESCRIPTION
**Note: new features are to be opened against next, hotfixes against master.**

### Summary

We've observed that Kong doesn't handle the '%' character when it's not part of a percent-encoding value (e.g. "foo=%bar%"). Since [`encode_args`](https://github.com/Mashape/kong/blob/99206799cd033de2697789bfee92aa76e05b78a0/kong/core/handler.lua#L48) is only used in `kong/core/handler.lua` and that query params are already [decoded](https://github.com/Mashape/kong/blob/99206799cd033de2697789bfee92aa76e05b78a0/kong/core/handler.lua#L46) and moreover since we cannot at the same time deal with percent-encoded value and a decoded value containing the `%` character without misinterpret it, we've remove the uncesseray `unescape` call as we judged that `encode_args` should be called with the `raw` option in the presence of percent-encoded value.

### Full changelog

* [fix] remove the `unescape` call in `encode_args`
* [tests] handling of the `%` character with the `encode_args` method

### Issues resolved

Fix #1975
Link https://github.com/Mashape/kong/issues/1480#issuecomment-238654446
