### PR TITLE
fix(test) websockets tests fixed, remnant of router merge

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -94,7 +94,6 @@ server {
     location / {
         set $upstream_host nil;
         set $upstream_scheme nil;
-        set $upstream_connection nil;
 
         access_by_lua_block {
             kong.access()


### PR DESCRIPTION
Not very good with the intimate details of the nginx configuration but the variable was overwritten with a bad value.

Question; are the other two values that are being set to `nil` of any value, or should they be removed to?
