### PR TITLE
fix(dao) enforce custom_id uniqueness

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -335,4 +335,13 @@ return {
       DROP TABLE targets;
     ]],
   },
+  {
+    name = "2016-01-25-103600_unique_custom_id",
+    up = [[
+      ALTER TABLE consumers ADD CONSTRAINT consumers_custom_id_key UNIQUE(custom_id);
+    ]],
+    down = [[
+      ALTER TABLE consumers DROP CONSTRAINT consumers_custom_id_key;
+    ]],
+  },
 }

--- a/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
@@ -67,13 +67,28 @@ describe("Admin API", function()
                        ..[[a 'username' must be specified"}]], body)
           end
         end)
-        it_content_types("returns 409 on conflict", function(content_type)
+        it_content_types("returns 409 on conflicting username", function(content_type)
           return function()
             local res = assert(client:send {
               method = "POST",
               path = "/consumers",
               body = {
                 username = "bob"
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            local body = assert.res_status(409, res)
+            assert.equal([[{"username":"already exists with value 'bob'"}]], body)
+          end
+        end)
+        it_content_types("returns 409 on conflicting custom_id", function(content_type)
+          return function()
+            local res = assert(client:send {
+              method = "POST",
+              path = "/consumers",
+              body = {
+                username = "tom",
+                custom_id = consumer.custom_id,
               },
               headers = {["Content-Type"] = content_type}
             })

--- a/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/03-consumers_routes_spec.lua
@@ -93,7 +93,7 @@ describe("Admin API", function()
               headers = {["Content-Type"] = content_type}
             })
             local body = assert.res_status(409, res)
-            assert.equal([[{"username":"already exists with value 'bob'"}]], body)
+            assert.equal([[{"custom_id":"already exists with value '1234'"}]], body)
           end
         end)
       end)


### PR DESCRIPTION
### Summary

On postgres the field `custom_id` for `consumers` was supposed to be unique, but this was not enforced. This updates the checks and enforces it.

__NOTE__: if data is not unique before starting Kong with this fix, it will fail the migrations! so duplicates must be removed before upgrading. Hence I do not think it should be backported to the 0.9.x version, but only be applied in 0.10.x

