### PR TITLE
test(ip-restriction) properly checking "X-Forwarded-For" header

### DIFF
--- a/spec/03-plugins/07-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/07-ip-restriction/02-access_spec.lua
@@ -71,6 +71,32 @@ describe("Plugin: ip-restriction (access)", function()
       }
     })
 
+    local api6 = assert(helpers.dao.apis:insert {
+      name = "api-6",
+      hosts = { "ip-restriction6.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "ip-restriction",
+      api_id = api6.id,
+      config = {
+        whitelist = {"127.0.0.4"}
+      }
+    })
+
+    local api7 = assert(helpers.dao.apis:insert {
+      name = "api-7",
+      hosts = { "ip-restriction7.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "ip-restriction",
+      api_id = api7.id,
+      config = {
+        blacklist = {"127.0.0.4"}
+      }
+    })
+
     assert(helpers.start_kong())
     client = helpers.proxy_client()
     admin_client = helpers.admin_client()
@@ -119,6 +145,46 @@ describe("Plugin: ip-restriction (access)", function()
       local body = assert.res_status(403, res)
       assert.equal([[{"message":"Your IP address is not allowed"}]], body)
     end)
+
+    describe("X-Forwarded-For", function()
+      it("allows without any X-Forwarded-For and allowed IP", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "ip-restriction7.com"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("127.0.0.1", json.clientIPAddress)
+      end)
+      it("allows with allowed X-Forwarded-For header", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "ip-restriction7.com",
+            ["X-Forwarded-For"] = "127.0.0.3"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("127.0.0.3", json.clientIPAddress)
+      end)
+      it("blocks with not allowed X-Forwarded-For header", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction7.com",
+            ["X-Forwarded-For"] = "127.0.0.4"
+          }
+        })
+        local body = assert.res_status(403, res)
+        assert.equal([[{"message":"Your IP address is not allowed"}]], body)
+      end)
+    end)
   end)
 
   describe("whitelist", function()
@@ -142,6 +208,54 @@ describe("Plugin: ip-restriction (access)", function()
         }
       })
       assert.res_status(200, res)
+    end)
+
+    describe("X-Forwarded-For", function()
+      it("blocks without any X-Forwarded-For and not allowed IP", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction6.com"
+          }
+        })
+        local body = assert.res_status(403, res)
+        assert.equal([[{"message":"Your IP address is not allowed"}]], body)
+      end)
+      it("block with not allowed X-Forwarded-For header", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction6.com",
+            ["X-Forwarded-For"] = "127.0.0.3"
+          }
+        })
+        local body = assert.res_status(403, res)
+        assert.equal([[{"message":"Your IP address is not allowed"}]], body)
+      end)
+      it("allows with allowed X-Forwarded-For header", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction6.com",
+            ["X-Forwarded-For"] = "127.0.0.4"
+          }
+        })
+        assert.res_status(200, res)
+      end)
+      it("allows with allowed complex X-Forwarded-For header", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction6.com",
+            ["X-Forwarded-For"] = "127.0.0.4, 127.0.0.3"
+          }
+        })
+        assert.res_status(200, res)
+      end)
     end)
   end)
 


### PR DESCRIPTION
Some additional tests on IP Restriction plugin trying to replicate #1995, unsuccessfully. 

Everything seems to be working fine with a `X-Forwarded-For` header.
