### PR TITLE
feat(tools): HTTP Response 503 Service unavailable

### DIFF
--- a/kong/tools/responses.lua
+++ b/kong/tools/responses.lua
@@ -70,7 +70,7 @@ local _M = {
 -- @field status_codes.HTTP_UNAUTHORIZED Default: Unauthorized
 -- @field status_codes.HTTP_INTERNAL_SERVER_ERROR Always "Internal Server Error"
 -- @field status_codes.HTTP_METHOD_NOT_ALLOWED Always "Method not allowed"
--- @field status_codes.HTTP_SERVICE_UNAVAILABLE Default: "Service Unavailable"
+-- @field status_codes.HTTP_SERVICE_UNAVAILABLE Default: "Service unavailable"
 local response_default_content = {
   [_M.status_codes.HTTP_UNAUTHORIZED] = function(content)
     return content or "Unauthorized"
@@ -88,8 +88,8 @@ local response_default_content = {
     return "Method not allowed"
   end,
   [_M.status_codes.HTTP_SERVICE_UNAVAILABLE] = function(content)
-    return content or "Service Unavailable"
-  end
+    return content or "Service unavailable"
+  end,
 }
 
 -- Return a closure which will be usable to respond with a certain status code.
@@ -97,7 +97,7 @@ local response_default_content = {
 -- @param[type=number] status_code The status for which to define a function
 local function send_response(status_code)
   -- Send a JSON response for the closure's status code with the given content.
-  -- If the content happens to be an error (>500), it will be logged by ngx.log as an ERR.
+  -- If the content happens to be an error (500), it will be logged by ngx.log as an ERR.
   -- @see https://github.com/openresty/lua-nginx-module
   -- @param content (Optional) The content to send as a response.
   -- @return ngx.exit (Exit current context)
@@ -147,7 +147,7 @@ local closure_cache = {}
 --- Send a response with any status code or body,
 -- Not all status codes are available as sugar methods, this function can be
 -- used to send any response.
--- If the `status_code` parameter is in the 5xx range, it is expectde that the `content` parameter be the error encountered. It will be logged and the response body will be empty. The user will just receive a 500 status code.
+-- If the `status_code` parameter is in the 5xx range, it is expected that the `content` parameter be the error encountered. For 500 errors it will be logged. The response body will be empty. The user will just receive a 500 status code.
 -- Will call `ngx.say` and `ngx.exit`, terminating the current context.
 -- @see ngx.say
 -- @see ngx.exit

--- a/kong/tools/responses.lua
+++ b/kong/tools/responses.lua
@@ -57,7 +57,7 @@ local _M = {
     HTTP_CONFLICT = 409,
     HTTP_UNSUPPORTED_MEDIA_TYPE = 415,
     HTTP_INTERNAL_SERVER_ERROR = 500,
-    HTTP_SERVICE_UNAVAILABLE = 503
+    HTTP_SERVICE_UNAVAILABLE = 503,
   }
 }
 
@@ -102,7 +102,7 @@ local function send_response(status_code)
   -- @param content (Optional) The content to send as a response.
   -- @return ngx.exit (Exit current context)
   return function(content, headers)
-    if status_code >= _M.status_codes.HTTP_INTERNAL_SERVER_ERROR and status_code ~= _M.status_codes.HTTP_SERVICE_UNAVAILABLE then
+    if status_code == _M.status_codes.HTTP_INTERNAL_SERVER_ERROR then
       if content then
         ngx.log(ngx.ERR, tostring(content))
       end

--- a/kong/tools/responses.lua
+++ b/kong/tools/responses.lua
@@ -39,6 +39,7 @@ local server_header = meta._NAME.."/"..meta._VERSION
 -- @field HTTP_CONFLICT 409 Conflict
 -- @field HTTP_UNSUPPORTED_MEDIA_TYPE 415 Unsupported Media Type
 -- @field HTTP_INTERNAL_SERVER_ERROR Internal Server Error
+-- @field HTTP_SERVICE_UNAVAILABLE 503 Service Unavailable
 -- @usage return responses.send_HTTP_OK()
 -- @usage return responses.HTTP_CREATED("Entity created")
 -- @usage return responses.HTTP_INTERNAL_SERVER_ERROR()
@@ -55,7 +56,8 @@ local _M = {
     HTTP_METHOD_NOT_ALLOWED = 405,
     HTTP_CONFLICT = 409,
     HTTP_UNSUPPORTED_MEDIA_TYPE = 415,
-    HTTP_INTERNAL_SERVER_ERROR = 500
+    HTTP_INTERNAL_SERVER_ERROR = 500,
+    HTTP_SERVICE_UNAVAILABLE = 503
   }
 }
 
@@ -68,6 +70,7 @@ local _M = {
 -- @field status_codes.HTTP_UNAUTHORIZED Default: Unauthorized
 -- @field status_codes.HTTP_INTERNAL_SERVER_ERROR Always "Internal Server Error"
 -- @field status_codes.HTTP_METHOD_NOT_ALLOWED Always "Method not allowed"
+-- @field status_codes.HTTP_SERVICE_UNAVAILABLE Default: "Service Unavailable"
 local response_default_content = {
   [_M.status_codes.HTTP_UNAUTHORIZED] = function(content)
     return content or "Unauthorized"
@@ -83,6 +86,9 @@ local response_default_content = {
   end,
   [_M.status_codes.HTTP_METHOD_NOT_ALLOWED] = function(content)
     return "Method not allowed"
+  end,
+  [_M.status_codes.HTTP_SERVICE_UNAVAILABLE] = function(content)
+    return content or "Service Unavailable"
   end
 }
 
@@ -96,7 +102,7 @@ local function send_response(status_code)
   -- @param content (Optional) The content to send as a response.
   -- @return ngx.exit (Exit current context)
   return function(content, headers)
-    if status_code >= _M.status_codes.HTTP_INTERNAL_SERVER_ERROR then
+    if status_code >= _M.status_codes.HTTP_INTERNAL_SERVER_ERROR and status_code ~= _M.status_codes.HTTP_SERVICE_UNAVAILABLE then
       if content then
         ngx.log(ngx.ERR, tostring(content))
       end

--- a/spec/01-unit/10-responses_spec.lua
+++ b/spec/01-unit/10-responses_spec.lua
@@ -58,8 +58,11 @@ describe("Response helpers", function()
       end)
     end
   end)
-  it("calls `ngx.log` if and only if a 500 status code range was given", function()
+  it("calls `ngx.log` if and only if a 500 status code was given", function()
     responses.send_HTTP_BAD_REQUEST()
+    assert.stub(ngx.log).was_not_called()
+    
+    responses.send_HTTP_BAD_REQUEST("error")
     assert.stub(ngx.log).was_not_called()
 
     responses.send_HTTP_INTERNAL_SERVER_ERROR()
@@ -67,6 +70,14 @@ describe("Response helpers", function()
 
     responses.send_HTTP_INTERNAL_SERVER_ERROR("error")
     assert.stub(ngx.log).was_called()
+  end)
+
+  it("don't call `ngx.log` if a 503 status code was given", function()
+    responses.send_HTTP_SERVICE_UNAVAILABLE()
+    assert.stub(ngx.log).was_not_called()
+
+    responses.send_HTTP_SERVICE_UNAVAILABLE()
+    assert.stub(ngx.log).was_not_called("error")
   end)
 
   describe("default content rules for some status codes", function()
@@ -85,6 +96,12 @@ describe("Response helpers", function()
       assert.stub(ngx.say).was.called_with("{\"message\":\"An unexpected error occurred\"}")
       responses.send_HTTP_INTERNAL_SERVER_ERROR("override")
       assert.stub(ngx.say).was.called_with("{\"message\":\"An unexpected error occurred\"}")
+    end)
+    it("should apply default content rules for some status codes", function()
+      responses.send_HTTP_SERVICE_UNAVAILABLE()
+      assert.stub(ngx.say).was.called_with("{\"message\":\"Service unavailable\"}")
+      responses.send_HTTP_SERVICE_UNAVAILABLE("override")
+      assert.stub(ngx.say).was.called_with("{\"message\":\"override\"}")
     end)
   end)
 


### PR DESCRIPTION
### Summary

Add HTTP response for 503 Service unavailable. This will be used for a
new api-unavailable plugin that will send a 503 error. See #1279.

### Full changelog

* Implement HTTP response for 503 Service unavailable.

### Issues resolved

N/A