### PR TITLE
Correct the length of a year

### DIFF
--- a/kong/plugins/response-ratelimiting/policies.lua
+++ b/kong/plugins/response-ratelimiting/policies.lua
@@ -17,7 +17,7 @@ local EXPIRATIONS = {
   hour = 3600,
   day = 86400,
   month = 2592000,
-  year = 31104000
+  year = 31536000
 }
 
 return {


### PR DESCRIPTION
A year was incorrectly assumed to have 360 days. This change assumes a year has 365 days.

**Note: new features are to be opened against next, hotfixes against master.**

### Issues resolved

Fix #2021 
