### PR TITLE
Fix/anonymous to accept a consumer

### DIFF
--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -1,7 +1,17 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 return {
   no_consumer = true,
   fields = {
-    anonymous = {type = "boolean", default = false},
+    anonymous = {type = "string", default = "", func = check_user},
     hide_credentials = {type = "boolean", default = false}
   }
 }

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -138,12 +138,30 @@ local function validate_clock_skew(headers, date_header_name, allowed_clock_skew
   return true
 end
 
-local function load_consumer_into_memory(credential)
-  local result, err = singletons.dao.consumers:find {id = credential.consumer_id}
-  if err then
+local function load_consumer_into_memory(consumer_id, anonymous)
+  local result, err = singletons.dao.consumers:find { id = consumer_id }
+  if not result then
+    if anonymous and not err then
+      err = 'anonymous consumer "'..consumer_id..'" not found'
+    end
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
   return result
+end
+
+local function set_consumer(consumer, credential)
+  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  ngx.ctx.authenticated_consumer = consumer
+  if credential then
+    ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+    ngx.ctx.authenticated_credential = credential
+    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
+  else
+    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+  end
+  
 end
 
 local function do_authentication(conf)
@@ -180,15 +198,9 @@ local function do_authentication(conf)
 
   -- Retrieve consumer
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id),
-                                    nil, load_consumer_into_memory, credential)
+                   nil, load_consumer_into_memory, credential.consumer_id)
 
-  ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- In case of auth plugins concatenation
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
-  ngx.ctx.authenticated_credential = credential
-  ngx.ctx.authenticated_consumer = consumer
+  set_consumer(consumer, credential)
 
   return true
 end
@@ -196,8 +208,11 @@ end
 function _M.execute(conf)
   local ok, err = do_authentication(conf)
   if not ok then
-    if conf.anonymous then
-      ngx.req.set_header(constants.HEADERS.ANONYMOUS, true)
+    if conf.anonymous ~= "" then
+      -- get anonymous user
+      local consumer = cache.get_or_set(cache.consumer_key(conf.anonymous),
+                       nil, load_consumer_into_memory, conf.anonymous, true)
+      set_consumer(consumer, nil)
     else
       return responses.send(err.status, err.message, err.headers)
     end

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -1,3 +1,13 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 local function check_clock_skew_positive(v)
   if v and v < 0 then
     return false, "Clock Skew should be positive"
@@ -10,6 +20,6 @@ return {
   fields = {
     hide_credentials = { type = "boolean", default = false },
     clock_skew = { type = "number", default = 300, func = check_clock_skew_positive },
-    anonymous = {type = "boolean", default = false}
+    anonymous = {type = "string", default = "", func = check_user},
   }
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -1,3 +1,13 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 return {
   no_consumer = true,
   fields = {
@@ -5,6 +15,6 @@ return {
     key_claim_name = {type = "string", default = "iss"},
     secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}},
-    anonymous = {type = "boolean", default = false}
+    anonymous = {type = "string", default = "", func = check_user},
   }
 }

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -31,12 +31,30 @@ local function load_credential(key)
   return creds[1]
 end
 
-local function load_consumer(credential)
-  local row, err = singletons.dao.consumers:find { id = credential.consumer_id }
-  if not row then
+local function load_consumer(consumer_id, anonymous)
+  local result, err = singletons.dao.consumers:find { id = consumer_id }
+  if not result then
+    if anonymous and not err then
+      err = 'anonymous consumer "'..consumer_id..'" not found'
+    end
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
-  return row
+  return result
+end
+
+local function set_consumer(consumer, credential)
+  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  ngx.ctx.authenticated_consumer = consumer
+  if credential then
+    ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+    ngx.ctx.authenticated_credential = credential
+    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
+  else
+    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+  end
+  
 end
 
 local function do_authentication(conf)
@@ -94,14 +112,9 @@ local function do_authentication(conf)
 
   -- retrieve the consumer linked to this API key, to set appropriate headers
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id),
-                                    nil, load_consumer, credential)
+                                    nil, load_consumer, credential.consumer_id)
 
-  ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- In case of auth plugins concatenation
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx.ctx.authenticated_credential = credential
-  ngx.ctx.authenticated_consumer = consumer
+  set_consumer(consumer, credential)
 
   return true
 end
@@ -111,8 +124,11 @@ function KeyAuthHandler:access(conf)
 
   local ok, err = do_authentication(conf)
   if not ok then
-    if conf.anonymous then
-      ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+    if conf.anonymous ~= "" then
+      -- get anonymous user
+      local consumer = cache.get_or_set(cache.consumer_key(conf.anonymous),
+                       nil, load_consumer, conf.anonymous, true)
+      set_consumer(consumer, nil)
     else
       return responses.send(err.status, err.message, err.headers)
     end

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -1,3 +1,13 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 local function default_key_names(t)
   if not t.key_names then
     return {"apikey"}
@@ -9,6 +19,6 @@ return {
   fields = {
     key_names = {required = true, type = "array", default = default_key_names},
     hide_credentials = {type = "boolean", default = false},
-    anonymous = {type = "boolean", default = false}
+    anonymous = {type = "string", default = "", func = check_user},
   }
 }

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -1,5 +1,15 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 return {
-fields = {
+  fields = {
     ldap_host = {required = true, type = "string"},
     ldap_port = {required = true, type = "number"},
     start_tls = {required = true, type = "boolean", default = false},
@@ -10,6 +20,6 @@ fields = {
     hide_credentials = {type = "boolean", default = false},
     timeout = {type = "number", default = 10000},
     keepalive = {type = "number", default = 60000},
-    anonymous = {type = "boolean", default = false}
+    anonymous = {type = "string", default = "", func = check_user},
   }
 }

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -449,12 +449,31 @@ local function load_oauth2_credential_into_memory(credential_id)
   return result
 end
 
-local function load_consumer_into_memory(consumer_id)
-  local result, err = singletons.dao.consumers:find {id = consumer_id}
-  if err then
+local function load_consumer_into_memory(consumer_id, anonymous)
+  local result, err = singletons.dao.consumers:find { id = consumer_id }
+  if not result then
+    if anonymous and not err then
+      err = 'anonymous consumer "'..consumer_id..'" not found'
+    end
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
   return result
+end
+  
+local function set_consumer(consumer, credential, token)
+  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  ngx.ctx.authenticated_consumer = consumer
+  if credential then
+    ngx_set_header("x-authenticated-scope", token.scope)
+    ngx_set_header("x-authenticated-userid", token.authenticated_userid)
+    ngx.ctx.authenticated_credential = credential
+    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
+  else
+    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+  end
+  
 end
 
 local function do_authentication(conf)
@@ -488,14 +507,7 @@ local function do_authentication(conf)
   local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id),
     nil, load_consumer_into_memory, credential.consumer_id)
 
-  ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- In case of auth plugins concatenation
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx_set_header("x-authenticated-scope", token.scope)
-  ngx_set_header("x-authenticated-userid", token.authenticated_userid)
-  ngx.ctx.authenticated_credential = credential
-  ngx.ctx.authenticated_consumer = consumer
+  set_consumer(consumer, credential, token)
 
   return true
 end
@@ -517,8 +529,11 @@ function _M.execute(conf)
 
   local ok, err = do_authentication(conf)
   if not ok then
-    if conf.anonymous then
-      ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+    if conf.anonymous ~= "" then
+      -- get anonymous user
+      local consumer = cache.get_or_set(cache.consumer_key(conf.anonymous),
+                       nil, load_consumer_into_memory, conf.anonymous, true)
+      set_consumer(consumer, nil, nil)
     else
       return responses.send(err.status, err.message, err.headers)
     end

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -1,6 +1,14 @@
 local utils = require "kong.tools.utils"
 local Errors = require "kong.dao.errors"
 
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+  
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 local function generate_if_missing(v, t, column)
   if not v or utils.strip(v) == "" then
     return true, nil, { [column] = utils.random_string()}
@@ -28,8 +36,8 @@ return {
     enable_password_grant = { required = true, type = "boolean", default = false },
     hide_credentials = { type = "boolean", default = false },
     accept_http_if_already_terminated = { required = false, type = "boolean", default = false },
-    anonymous = {type = "boolean", default = false},
-    global_credentials = {type = "boolean", default = false}
+    anonymous = {type = "string", default = "", func = check_user},
+    global_credentials = {type = "boolean", default = false},
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if not plugin_t.enable_authorization_code and not plugin_t.enable_implicit_grant

--- a/spec/03-plugins/08-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/08-ldap-auth/01-access_spec.lua
@@ -1,5 +1,6 @@
 local cache = require "kong.tools.database_cache"
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 
 describe("Plugin: ldap-auth (access)", function()
   local client, client_admin, api2, plugin2
@@ -19,6 +20,15 @@ describe("Plugin: ldap-auth (access)", function()
       name = "test-ldap3",
       hosts = { "ldap3.com" },
       upstream_url = "http://mockbin.com"
+    })
+    local api4 = assert(helpers.dao.apis:insert {
+      name = "test-ldap4",
+      hosts = { "ldap4.com" },
+      upstream_url = "http://mockbin.com"
+    })
+
+    local anonymous_user = assert(helpers.dao.consumers:insert {
+      username = "no-body"
     })
 
     assert(helpers.dao.plugins:insert {
@@ -54,7 +64,20 @@ describe("Plugin: ldap-auth (access)", function()
         start_tls = false,
         base_dn = "ou=scientists,dc=ldap,dc=mashape,dc=com",
         attribute = "uid",
-        anonymous = true
+        anonymous = anonymous_user.id,
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api4.id,
+      name = "ldap-auth",
+      config = {
+        ldap_host = "ec2-54-210-29-167.compute-1.amazonaws.com",
+        ldap_port = "389",
+        start_tls = false,
+        base_dn = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+        attribute = "uid",
+        cache_ttl = 2,
+        anonymous = utils.uuid(), -- non existing consumer
       }
     })
 
@@ -297,7 +320,18 @@ describe("Plugin: ldap-auth (access)", function()
       assert.response(r).has.status(200)
       local value = assert.request(r).has.header("x-anonymous-consumer")
       assert.are.equal("true", value)
-      assert.request(r).has_not.header("x-consumer-username")
+      value = assert.request(r).has.header("x-consumer-username")
+      assert.equal('no-body', value)
+    end)
+    it("errors when anonymous user doesn't exist", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "ldap4.com"
+        }
+      })
+      assert.response(res).has.status(500)
     end)
   end)
 end)

--- a/spec/03-plugins/99-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/99-oauth2/03-access_spec.lua
@@ -1,5 +1,6 @@
 local cjson = require "cjson"
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 
 describe("#ci Plugin: oauth2 (access)", function()
   local proxy_ssl_client, proxy_client
@@ -7,6 +8,9 @@ describe("#ci Plugin: oauth2 (access)", function()
   setup(function()
     local consumer = assert(helpers.dao.consumers:insert {
       username = "bob"
+    })
+    local anonymous_user = assert(helpers.dao.consumers:insert {
+      username = "no-body"
     })
     client1 = assert(helpers.dao.oauth2_credentials:insert {
       client_id = "clientid123",
@@ -156,7 +160,7 @@ describe("#ci Plugin: oauth2 (access)", function()
         provision_key = "provision123",
         token_expiration = 5,
         enable_implicit_grant = true,
-        anonymous = true,
+        anonymous = anonymous_user.id,
         global_credentials = false
       }
     })
@@ -196,6 +200,26 @@ describe("#ci Plugin: oauth2 (access)", function()
         token_expiration = 5,
         enable_implicit_grant = true,
         global_credentials = true
+      }
+    })
+
+    local api10 = assert(helpers.dao.apis:insert {
+      name = "oauth2_10.com",
+      hosts = { "oauth2_10.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "oauth2",
+      api_id = api10.id,
+      config = {
+        scopes = { "email", "profile", "user.email" },
+        enable_authorization_code = true,
+        mandatory_scope = true,
+        provision_key = "provision123",
+        token_expiration = 5,
+        enable_implicit_grant = true,
+        global_credentials = true,
+        anonymous = utils.uuid(), -- a non existing consumer
       }
     })
 
@@ -1659,8 +1683,18 @@ describe("#ci Plugin: oauth2 (access)", function()
         }
       })
       local body = cjson.decode(assert.res_status(200, res))
-      assert.is_nil(body.headers["x-consumer-username"])
       assert.are.equal("true", body.headers["x-anonymous-consumer"])
+      assert.equal('no-body', body.headers["x-consumer-username"])
+    end)
+    it("errors when anonymous user doesn't exist", function()
+      local res = assert(proxy_ssl_client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "oauth2_10.com"
+        }
+      })
+      assert.response(res).has.status(500)
     end)
     describe("Global Credentials", function()
       it("does not access two different APIs that are not sharing global credentials", function()


### PR DESCRIPTION
### Summary

current implementation for anonymous access does not allow to run plugins on anonymous consumers. This change changes the `boolean` setting to accept anonymous access into a `uuid` setting which can hold the uuid of the consumer to associate with the anonymous access.

When this user is set, the credentials will not be set, and the header `X-Anonymous-Consumer: true` will still be set.

### Full changelog

Updated plugins:

- [x] basic-auth
- [x] key-auth
- [x] oauth2
- [x] hmac-auth
- [x] jwt
- [x] ldap-auth
