### PR TITLE
feat(proxy) implement upstream timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ perform significantly better than any previous version.
   the configuration file: `admin_listen_ssl`, `admin_ssl`, `admin_ssl_cert` and
   `admin_ssl_cert_key`.
   [#1706](https://github.com/Mashape/kong/pull/1706)
+- Support for upstream connection timeouts. APIs now have 3 new fields:
+  `upstream_connect_timeout`, `upstream_send_timeout`, `upstream_read_timeout`
+  to specify, in milliseconds, a timeout value for requests between Kong and
+  your APIs.
+  [#2036](https://github.com/Mashape/kong/pull/2036)
 - Plugins:
   - :fireworks: **New AWS Lambda plugin**. Thanks Tim Erickson for his
     collaboration on this new addition.

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -97,14 +97,17 @@ return {
         port                 = upstream_port,  -- final target port
         tries                = 0,              -- retry counter
         retries              = api.retries,    -- number of retries for the balancer
-        --  ip               = nil,            -- final target IP address
+        connect_timeout      = api.upstream_connect_timeout or 60000,
+        send_timeout         = api.upstream_send_timeout or 60000,
+        read_timeout         = api.upstream_read_timeout or 60000,
+        -- ip                = nil,            -- final target IP address
         -- failures          = nil,            -- for each failure an entry { name = "...", code = xx }
         -- balancer          = nil,            -- the balancer object, in case of a balancer
       }
 
       var.upstream_scheme = upstream_scheme
 
-      ctx.api = api
+      ctx.api              = api
       ctx.balancer_address = balancer_address
 
       local ok, err = balancer_execute(balancer_address)
@@ -124,9 +127,9 @@ return {
     -- Only executed if the `resolver` module found an API and allows nginx to proxy it.
     after = function()
       local ctx = ngx.ctx
-
       local now = get_now()
-      ctx.KONG_ACCESS_TIME = now - ngx.ctx.KONG_ACCESS_START -- time spent in Kong's access_by_lua
+
+      ctx.KONG_ACCESS_TIME = now - ctx.KONG_ACCESS_START -- time spent in Kong's access_by_lua
       ctx.KONG_ACCESS_ENDED_AT = now
       -- time spent in Kong before sending the reqeust to upstream
       ctx.KONG_PROXY_LATENCY = now - ngx.req.start_time() * 1000 -- ngx.req.start_time() is kept in seconds with millisecond resolution.

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -308,4 +308,43 @@ return {
       ALTER TABLE consumers DROP CONSTRAINT consumers_custom_id_key;
     ]],
   },
+  {
+    name = "2017-01-24-132600_upstream_timeouts",
+    up = [[
+      ALTER TABLE apis ADD upstream_connect_timeout integer;
+      ALTER TABLE apis ADD upstream_send_timeout integer;
+      ALTER TABLE apis ADD upstream_read_timeout integer;
+    ]],
+    down = [[
+      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_connect_timeout;
+      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_send_timeout;
+      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_read_timeout;
+    ]]
+  },
+  {
+    name = "2017-01-24-132600_upstream_timeouts_2",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM apis;
+      ]])
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        if not row.upstream_connect_timeout
+          or not row.upstream_read_timeout
+          or not row.upstream_send_timeout then
+
+          -- update row, getting default values for upstream timeouts
+          -- from schema file
+          local _, err = dao.apis:update(row, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end
+  },
 }

--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -168,11 +168,20 @@ local function check_name(name)
 end
 
 -- check that retries is a valid number
-local function check_retries(retries)
+local function check_smallint(i)
   -- Postgres 'smallint' size, 2 bytes
-  if (retries < 0) or (math.floor(retries) ~= retries) or (retries > 32767) then
-    return false, "retries must be an integer, from 0 to 32767"
+  if i < 0 or math.floor(i) ~= i or i > 32767 then
+    return false, "must be an integer between 0 and 32767"
   end
+
+  return true
+end
+
+local function check_u_int(t)
+  if t < 1 or t > 2^31 - 1 or math.floor(t) ~= t then
+    return false, "must be an integer between 1 and " .. 2^31 - 1
+  end
+
   return true
 end
 
@@ -183,17 +192,18 @@ return {
     id = {type = "id", dao_insert_value = true, required = true},
     created_at = {type = "timestamp", immutable = true, dao_insert_value = true, required = true},
     name = {type = "string", unique = true, required = true, func = check_name},
-
     hosts = {type = "array", func = check_hosts},
     uris = {type = "array", func = check_uris},
     methods = {type = "array", func = check_methods},
     strip_uri = {type = "boolean", default = true},
     https_only = {type = "boolean", default = false},
     http_if_terminated = {type = "boolean", default = true},
-
     upstream_url = {type = "url", required = true, func = validate_upstream_url_protocol},
     preserve_host = {type = "boolean", default = false},
-    retries = {type = "number", default = 5, func = check_retries},
+    retries = {type = "number", default = 5, func = check_smallint},
+    upstream_connect_timeout = {type = "number", default = 60000, func = check_u_int},
+    upstream_send_timeout = {type = "number", default = 60000, func = check_u_int},
+    upstream_read_timeout = {type = "number", default = 60000, func = check_u_int},
   },
   marshall_event = function(self, t)
     return { id = t.id }

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -106,6 +106,7 @@ server {
         proxy_set_header Host $upstream_host;
         proxy_set_header Upgrade $upstream_upgrade;
         proxy_set_header Connection $upstream_connection;
+
         proxy_pass_header Server;
         proxy_pass $upstream_scheme://kong_upstream;
 

--- a/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -1,0 +1,110 @@
+local helpers = require "spec.helpers"
+local Factory = require "kong.dao.factory"
+local dao_helpers = require "spec.02-integration.02-dao.helpers"
+
+
+local factory
+
+
+local function insert_apis(arr)
+  if type(arr) ~= "table" then
+    return error("expected arg #1 to be a table", 2)
+  end
+
+  factory:truncate_tables()
+
+  for i = 1, #arr do
+    assert(factory.apis:insert(arr[i]))
+  end
+end
+
+
+dao_helpers.for_each_dao(function(kong_config)
+
+  describe("upstream timeouts", function()
+    local client
+
+    setup(function()
+      factory = assert(Factory.new(kong_config))
+      assert(factory:run_migrations())
+      factory:truncate_tables()
+
+      insert_apis {
+        {
+          name = "api-1",
+          methods = "HEAD",
+          upstream_url = "http://httpbin.org",
+          upstream_connect_timeout = 1, -- ms
+        },
+        {
+          name = "api-2",
+          methods = "POST",
+          upstream_url = "http://httpbin.org",
+          upstream_send_timeout = 100, -- ms
+        },
+        {
+          name = "api-3",
+          methods = "GET",
+          upstream_url = "http://httpbin.org",
+          upstream_read_timeout = 100, -- ms
+        }
+      }
+
+      assert(helpers.start_kong({
+        database = kong_config.database
+      }))
+    end)
+
+    teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
+      end
+    end)
+
+    describe("upstream_connect_timeout", function()
+      it("sets upstream connect timeout value", function()
+        local res = assert(client:send {
+          method = "HEAD",
+          path = "/",
+        })
+
+        assert.res_status(504, res)
+      end)
+    end)
+
+    describe("upstream_read_timeout", function()
+      it("sets upstream read timeout value", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/delay/2",
+        })
+
+        assert.res_status(504, res)
+      end)
+    end)
+
+    describe("upstream_send_timeout", function()
+      it("sets upstream send timeout value", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/post",
+          body = {
+            huge = string.rep("a", 2^20)
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.res_status(504, res)
+      end)
+    end)
+  end)
+
+end) -- for_each_dao


### PR DESCRIPTION
### Summary

This implements timeout options between Kong and the upstream services/APIs. It adds 3 new fields to the API definition: `upstream_connect_timeout`, `upstream_send_timeout`, and `upstream_read_timeout`.

Those fields use a ms precision, and this take an integer value between 1 and 2^31 - 1.

When not specified, the default value is `60000` (60 seconds) for all 3 fields.

### Full changelog

* add new fields to APIs for connect/send/read timeouts
* fields are in ms precision, and must be greater than 0