### PR TITLE
fix(proxy) prevent misinterpretation of '%' character in proxied URL encoding

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -155,16 +155,13 @@ do
   local url = require "socket.url"
 
   --- URL escape and format key and value
-  -- An obligatory url.unescape pass must be done to prevent double-encoding
-  -- already encoded values (which contain a '%' character that `url.escape` escapes)
+  -- values should be already decoded or the `raw` option should be passed to prevent double-encoding
   local function encode_args_value(key, value, raw)
     if not raw then
-      key = url.unescape(key)
       key = url.escape(key)
     end
     if value ~= nil then
       if not raw then
-        value = url.unescape(value)
         value = url.escape(value)
       end
       return fmt("%s=%s", key, value)

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -200,6 +200,12 @@ describe("Utils", function()
         }
         assert.equal("hello=world&multiple=hello%2c%20world&multiple%20values", str)
       end)
+      it("should not interpret the `%` character followed by 2 characters in the [0-9a-f] group as an hexadecimal value", function()
+        local str = utils.encode_args {
+          foo = "%bar%"
+        }
+        assert.equal("foo=%25bar%25", str)
+      end)
       it("should not percent-encode if given a `raw` option", function()
         -- this is useful for kong.tools.http_client
         local str = utils.encode_args({
@@ -229,6 +235,12 @@ describe("Utils", function()
             b = false
           }, true)
           assert.equal("a=true&b=false", str)
+        end)
+        it("should prevent double percent-encoding", function()
+          local str = utils.encode_args({
+            foo = "hello%20world"
+          }, true)
+          assert.equal("foo=hello%20world", str)
         end)
       end)
     end)

--- a/spec/02-integration/05-proxy/04-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/04-uri_encoding_spec.lua
@@ -1,0 +1,105 @@
+local cjson = require "cjson"
+local helpers = require "spec.helpers"
+
+describe("URI encoding", function()
+  local client
+
+  setup(function()
+    assert(helpers.start_kong())
+    client = helpers.proxy_client()
+
+    assert(helpers.dao.apis:insert {
+      name = "api-1",
+      request_host = "httpbin.com",
+      upstream_url = "http://httpbin.org",
+    })
+
+    assert(helpers.dao.apis:insert {
+      name = "api-2",
+      request_host = "mockbin.com",
+      upstream_url = "http://mockbin.com",
+    })
+  end)
+
+  teardown(function()
+    helpers.stop_kong()
+  end)
+
+  it("issue #1975 does not double percent-encode proxied args", function()
+    -- https://github.com/Mashape/kong/pull/1975
+
+    local res = assert(client:send {
+      method = "GET",
+      path = "/get?limit=25&where=%7B%22or%22:%5B%7B%22name%22:%7B%22like%22:%22%25bac%25%22%7D%7D%5D%7D",
+      headers = {
+        ["Host"] = "httpbin.com"
+      }
+    })
+
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    assert.equal("25", json.args.limit)
+    assert.equal([[{"or":[{"name":{"like":"%bac%"}}]}]], json.args.where)
+  end)
+
+  it("issue #1480 does percent-encode args unecessarily", function()
+    -- behavior might not be correct, but we assert it anyways until
+    -- a change is planned and documented.
+    -- https://github.com/Mashape/kong/issues/1480
+
+    -- we use mockbin because httpbin.org/get performs URL decode
+    -- on `url` and `args` fields.
+    local res = assert(client:send {
+      method = "GET",
+      path = "/request?param=1.2.3",
+      headers = {
+        ["Host"] = "mockbin.com"
+      }
+    })
+
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    assert.equal("http://mockbin.com/request?param=1%2e2%2e3", json.url)
+  end)
+
+  it("issue #749 does not decode percent-encoded args", function()
+    -- https://github.com/Mashape/kong/issues/749
+
+    -- we use mockbin because httpbin.org/get performs URL decode
+    -- on `url` and `args` fields.
+    local res = assert(client:send {
+      method = "GET",
+      path = "/request?param=abc%7Cdef",
+      headers = {
+        ["Host"] = "mockbin.com"
+      }
+    })
+
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    -- TODO: %7C is apparently decoded/re-encoded to %7c
+    assert.equal("http://mockbin.com/request?param=abc%7cdef", json.url)
+  end)
+
+  it("issue #688 does not percent-decode proxied URLs", function()
+    -- https://github.com/Mashape/kong/issues/688
+
+    -- we use mockbin because httpbin.org/get performs URL decode
+    -- on `url` and `args` fields.
+    local res = assert(client:send {
+      method = "GET",
+      path = "/request/foo%2Fbar",
+      headers = {
+        ["Host"] = "mockbin.com",
+      }
+    })
+
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    assert.equal("http://mockbin.com/request/foo%2Fbar", json.url)
+  end)
+end)


### PR DESCRIPTION
### Summary

This is a patch that includes #1998 as well as a new integration test suite to ensure percent-encoding behavior of proxied URLs. The expected behavior is asserted in there as a source of truth.

### Full changelog

* fix(utils) remove unescape from encode_args_value
* tests(proxy) assert URI encoding behavior in tests

### Issues resolved

Fix #1975
Ensure #749 behavior
Ensure #688 behavior
Ensure #1480 behavior

Replaces #1998