### PR TITLE
fix(proxy): host header including port

### DIFF
--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -237,7 +237,7 @@ end
 -- Main entry point when resolving
 --===========================================================
 
--- Resolves the target structure in-place (fields `ip` and `port`).
+-- Resolves the target structure in-place (fields `ip`, `port`, and `hostname`).
 --
 -- If the hostname matches an 'upstream' pool, then it must be balanced in that
 -- pool, in this case any port number provided will be ignored, as the pool provides it.
@@ -249,6 +249,7 @@ local function execute(target)
     -- it's an ip address (v4 or v6), so nothing we can do...
     target.ip = target.host
     target.port = target.port or 80 -- TODO: remove this fallback value
+    target.hostname = target.host
     return true
   end
 
@@ -309,6 +310,7 @@ local function execute(target)
 
   target.ip = ip
   target.port = port
+  target.hostname = target.host
   return true
 end
 

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -79,9 +79,8 @@ return {
 
       ctx.KONG_ACCESS_START = get_now()
 
-      local original_host_header = ngx.req.get_headers().host
-
-      local api, upstream_scheme, upstream_host, upstream_port = router.exec(ngx)
+      local api, upstream_scheme, upstream_host, 
+                 upstream_port, host_header = router.exec(ngx)
       if not api then
         return responses.send_HTTP_NOT_FOUND("no API found with those values")
       end
@@ -120,11 +119,10 @@ return {
           "' with: "..tostring(err))
       end
 
-      if api.preserve_host then
-        var.upstream_host = original_host_header
-      else
-        var.upstream_host = balancer_address.hostname..":"..balancer_address.port
-      end
+      -- if set `host_header` is the original header to be preserved
+      var.upstream_host = host_header or 
+          balancer_address.hostname..":"..balancer_address.port
+
     end,
     -- Only executed if the `router` module found an API and allows nginx to proxy it.
     after = function()

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -103,6 +103,7 @@ return {
         -- ip                = nil,            -- final target IP address
         -- failures          = nil,            -- for each failure an entry { name = "...", code = xx }
         -- balancer          = nil,            -- the balancer object, in case of a balancer
+        -- hostname          = nil,            -- the hostname belonging to the final target IP
       }
 
       var.upstream_scheme = upstream_scheme
@@ -119,9 +120,11 @@ return {
 
       if balancer_address.hostname and not api.preserve_host then
         var.upstream_host = balancer_address.hostname
+        var.upstream_port = balancer_address.port
 
       else
         var.upstream_host = upstream_host
+        var.upstream_port = upstream_port
       end
     end,
     -- Only executed if the `resolver` module found an API and allows nginx to proxy it.

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -634,7 +634,7 @@ function _M.new(apis)
       if not headers then
         headers = ngx.req.get_headers()
       end
-  
+
       host_header = headers["host"]
     end
 

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -493,6 +493,9 @@ function _M.new(apis)
 
 
     local host = headers["Host"] or headers["host"]
+    if host then
+      host = host:match("^([^:]+)") -- strip port number if given
+    end
     method = upper(method)
 
 
@@ -598,7 +601,6 @@ function _M.new(apis)
   function self.exec(ngx)
     local method = ngx.req.get_method()
     local uri = ngx.var.uri
-    local upstream_host
     local headers
 
 
@@ -619,21 +621,9 @@ function _M.new(apis)
     end
 
 
-    upstream_host = api_t.upstream_host
-
-
     if api_t.strip_uri_regex then
       local stripped_uri = re_sub(uri, api_t.strip_uri_regex, "/$1", "jo")
       ngx.req.set_uri(stripped_uri)
-    end
-
-
-    if api_t.preserve_host then
-      if not headers then
-        headers = ngx.req.get_headers()
-      end
-
-      upstream_host = headers["host"]
     end
 
 
@@ -642,7 +632,7 @@ function _M.new(apis)
     end
 
 
-    return api_t.api, api_t.upstream_scheme, upstream_host, api_t.upstream_port
+    return api_t.api, api_t.upstream_scheme, api_t.upstream_host, api_t.upstream_port
   end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -103,7 +103,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $upstream_host;
+        proxy_set_header Host $upstream_host:$upstream_port;
         proxy_set_header Upgrade $upstream_upgrade;
         proxy_set_header Connection $upstream_connection;
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -103,7 +103,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $upstream_host:$upstream_port;
+        proxy_set_header Host $upstream_host;
         proxy_set_header Upgrade $upstream_upgrade;
         proxy_set_header Connection $upstream_connection;
 


### PR DESCRIPTION
If the host header is updated to include the port, then what is the exact desired behaviour?

So if `preserve_host` is set on the api definition, we do not touch the header at all? or do we still inject a default port if it was not in the received host header?

If we don't preserve the header, we could simply insert the upstream host and port.