### PR TITLE
Feature/oauth2 consumer scopes (Issue #454)

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -117,13 +117,13 @@ local function retrieve_scopes(parameters, conf, client)
   if conf.scopes and scope then
     for v in scope:gmatch("%S+") do
       if not utils.table_contains(conf.scopes, v) then
-        return false, {[ERROR] = "invalid_scope", error_description = "\""..v.."\" is an invalid "..SCOPE}
+        return false, {[ERROR] = "invalid_scope", error_description = "\""..v.."\" is an invalid "..SCOPE}, false
       else
         table.insert(scopes, v)
       end
     end
   elseif not scope and conf.mandatory_scope then
-    return false, {[ERROR] = "invalid_scope", error_description = "You must specify a "..SCOPE}
+    return false, {[ERROR] = "invalid_scope", error_description = "You must specify a "..SCOPE}, false
   end
 
   -- Scopes have been established, now filter for allowed scopes in

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -138,13 +138,17 @@ local function retrieve_scopes(parameters, conf, client)
   local scope_required_in_response = false
   if client and client.allowed_scopes then
     local filtered_scopes = {}
-    local client_allowed_scopes = client.allowed_scopes:gmatch("%S+")
-    for v in scopes do
+    local client_allowed_scopes = {}
+    for allowed_scope in client.allowed_scopes:gmatch("%S+") do
+      table.insert(client_allowed_scopes, allowed_scope)
+    end
+    for idx,v in ipairs(scopes) do
       -- is scope in both tables?
       if utils.table_contains(client_allowed_scopes, v) then
         table.insert(filtered_scopes, v)
-      end -- else: omit, we need to communicate scope to client
+      else -- else: omit, we need to communicate scope to client
         scope_required_in_response = true
+      end
     end
     scopes = filtered_scopes
     -- Note: It may be that we filtered away all scopes here;

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -36,6 +36,7 @@ local OAUTH2_CREDENTIALS_SCHEMA = {
     client_id = { type = "string", required = false, unique = true, func = generate_if_missing },
     client_secret = { type = "string", required = false, unique = true, func = generate_if_missing },
     redirect_uri = { type = "array", required = true, func = validate_uris },
+    allowed_scopes = { type = "string", required = false },
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true }
   },
   marshall_event = function(self, t)
@@ -53,6 +54,7 @@ local OAUTH2_AUTHORIZATION_CODES_SCHEMA = {
     code = { type = "string", required = false, unique = true, immutable = true, func = generate_if_missing },
     authenticated_userid = { type = "string", required = false },
     scope = { type = "string" },
+    scope_required_in_response = { type = "boolean" },
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true }
   }
 }

--- a/kong/plugins/oauth2/migrations/cassandra.lua
+++ b/kong/plugins/oauth2/migrations/cassandra.lua
@@ -147,5 +147,16 @@ return {
         if err then return err end
       end
     end
+  },
+  {
+    name = "2017-01-27-oauth2_consumer_scopes",
+    up = [[
+      ALTER TABLE oauth2_credentials ADD allowed_scopes text;
+      ALTER TABLE oauth2_authorization_codes ADD scope_required_in_response boolean;
+    ]],
+    down = [[
+      ALTER TABLE oauth2_credentials DROP allowed_scopes;
+      ALTER TABLE oauth2_authorization_codes DROP scope_required_in_response;
+    ]]
   }
 }

--- a/spec/03-plugins/99-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/99-oauth2/02-api_spec.lua
@@ -65,6 +65,41 @@ describe("Plugin: oauth (API)", function()
         assert.equal("Test APP", body.name)
         assert.equal(2, #body.redirect_uri)
       end)
+      it("creates an oauth2 credential with allowed_scopes", function()
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/bob/oauth2",
+          body = {
+            name = "Test APP",
+            redirect_uri = "http://google.org/",
+            allowed_scopes = "foo bar code"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = cjson.decode(assert.res_status(201, res))
+        assert.equal(consumer.id, body.consumer_id)
+        assert.equal("Test APP", body.name)
+        assert.equal("foo bar code", body.allowed_scopes)
+      end)
+      it("creates an oauth2 credential without allowed_scopes", function()
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/bob/oauth2",
+          body = {
+            name = "Test APP",
+            redirect_uri = "http://google.org/"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = cjson.decode(assert.res_status(201, res))
+        assert.equal(consumer.id, body.consumer_id)
+        assert.equal("Test APP", body.name)
+        assert.is_nil(body.allowed_scopes)
+      end)
       describe("errors", function()
         it("returns bad request", function()
           local res = assert(admin_client:send {

--- a/spec/03-plugins/99-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/99-oauth2/03-access_spec.lua
@@ -29,6 +29,14 @@ describe("#ci Plugin: oauth2 (access)", function()
       name = "testapp3",
       consumer_id = consumer.id
     })
+    assert(helpers.dao.oauth2_credentials:insert {
+      client_id = "clientidabc",
+      client_secret = "secretabc",
+      redirect_uri = {"http://scope.com"},
+      name = "testapp4",
+      allowed_scopes = "foo bar",
+      consumer_id = consumer.id
+    })
 
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
@@ -213,6 +221,25 @@ describe("#ci Plugin: oauth2 (access)", function()
         token_expiration = 5,
         enable_implicit_grant = true,
         global_credentials = true
+      }
+    })
+
+    local api10 = assert(helpers.dao.apis:insert {
+      name = "oauth2_10.com",
+      hosts = { "oauth2_10.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "oauth2",
+      api_id = api10.id,
+      config = {
+        scopes = { "email", "profile", "user.email" },
+        enable_authorization_code = true,
+        mandatory_scope = true,
+        provision_key = "provision123",
+        token_expiration = 5,
+        enable_password_grant = true,
+        enable_client_credentials = true
       }
     })
 


### PR DESCRIPTION
**Note: new features are to be opened against next, hotfixes against master.**

Talked briefly to @Tieske about where to base this off; as there are lots of changes between release/0.10.0 and next, he proposed that it might be better/easier to base it on release/0.10.0 for now.

### Summary

See issue #454 for a full description:

* Add an `allowed_scopes` field to oauth2 consumers
* Filter resulting scopes after these scopes, if they are set
* If field is not set, regard consumer as "trusted" (default behavior, as before)

### Issues resolved

Implemented #454 
