### PR TITLE
Can't access upstream_url with path

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -79,7 +79,7 @@ return {
 
       ctx.KONG_ACCESS_START = get_now()
 
-      local api, upstream_scheme, upstream_host, upstream_port = router.exec(ngx)
+      local api, upstream_scheme, upstream_host, upstream_port, upstream_uri = router.exec(ngx)
       if not api then
         return responses.send_HTTP_NOT_FOUND("no API found with those values")
       end
@@ -104,6 +104,7 @@ return {
 
       var.upstream_scheme = upstream_scheme
       var.upstream_host = upstream_host
+      var.upstream_uri = upstream_uri
 
       ctx.api = api
       ctx.balancer_address = balancer_address

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -184,6 +184,7 @@ local function marshall_api(api)
     api_t.upstream_scheme = parsed.scheme
     api_t.upstream_host = parsed.host
     api_t.upstream_port = tonumber(parsed.port)
+    api_t.upstream_uri = parsed.path
 
     if not api_t.upstream_port then
       if parsed.scheme == "https" then
@@ -629,7 +630,7 @@ function _M.new(apis)
     end
 
 
-    return api_t.api, api_t.upstream_scheme, api_t.upstream_host, api_t.upstream_port
+    return api_t.api, api_t.upstream_scheme, api_t.upstream_host, api_t.upstream_port, api_t.upstream_uri
   end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -94,6 +94,7 @@ server {
     location / {
         set $upstream_host nil;
         set $upstream_scheme nil;
+        set $upstream_uri nil;
         set $upstream_connection nil;
 
         access_by_lua_block {
@@ -108,7 +109,7 @@ server {
         proxy_set_header Upgrade $upstream_upgrade;
         proxy_set_header Connection $upstream_connection;
         proxy_pass_header Server;
-        proxy_pass $upstream_scheme://kong_upstream;
+        proxy_pass $upstream_scheme://kong_upstream/$upstream_uri;
 
         header_filter_by_lua_block {
             kong.header_filter()


### PR DESCRIPTION
### Summary

When we create an API, and set its upstream_url with a path, then we request this API, we can't access the upstream_url with path, but only access the root url.
    
It should be able to proxy the entire upstream_url, this patch will fix the issue:
we append a var `$upstream_uri` to nginx `proxy_pass`, and set it with the path value parsed from API upstream_url.

### Issues resolved

Fix #2073 
