### PR TITLE
fix(migrations) avoid performing full updates

### DIFF
--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -159,9 +159,11 @@ end
 local function deserialize_rows(rows, schema)
   for i, row in ipairs(rows) do
     for col, value in pairs(row) do
-      local t = schema.fields[col].type
-      if t == "table" or t == "array" then
-        rows[i][col] = cjson.decode(value)
+      if schema.fields[col] then
+        local t = schema.fields[col].type
+        if t == "table" or t == "array" then
+          rows[i][col] = cjson.decode(value)
+        end
       end
     end
   end

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -200,12 +200,10 @@ local function get_where(tbl)
 end
 
 local function get_select_fields(schema)
-  local fields = {}
+  local fields = { "*" }
   for k, v in pairs(schema.fields) do
     if v.type == "timestamp" then
       fields[#fields+1] = fmt("(extract(epoch from %s)*1000)::bigint as %s", k, k)
-    else
-      fields[#fields+1] = '"' .. k .. '"'
     end
   end
   return concat(fields, ", ")

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -167,10 +167,13 @@ return {
       end
 
       for _, row in ipairs(rows) do
-        if not row.retries then  -- only if retries is not set already
-          -- we do not specify default values explicitly, as they will be
-          -- taken from the schema automatically by the dao.
-          local _, err = dao.apis:update(row, { id = row.id }, {full = true})
+        if not row.retries then
+
+          local _, err = dao.apis:update({
+            retries = 5
+          }, {
+            id = row.id
+          })
           if err then
             return err
           end
@@ -272,11 +275,22 @@ return {
       end
 
       for _, row in ipairs(rows) do
-        row.hosts = { row.request_host }
-        row.uris = { row.request_path }
-        row.strip_uri = row.strip_request_path
+        local hosts
+        local uris
 
-        local _, err = dao.apis:update(row, { id = row.id }, { full = true })
+        if row.request_host then
+          hosts = { row.request_host }
+        end
+
+        if row.request_path then
+          uris = { row.request_path }
+        end
+
+        local _, err = dao.apis:update({
+          hosts = hosts,
+          uris = uris,
+          strip_uri = row.strip_request_path,
+        }, { id = row.id })
         if err then
           return err
         end
@@ -336,9 +350,11 @@ return {
           or not row.upstream_read_timeout
           or not row.upstream_send_timeout then
 
-          -- update row, getting default values for upstream timeouts
-          -- from schema file
-          local _, err = dao.apis:update(row, { id = row.id })
+          local _, err = dao.apis:update({
+            upstream_connect_timeout = 60000,
+            upstream_send_timeout = 60000,
+            upstream_read_timeout = 60000,
+          }, { id = row.id })
           if err then
             return err
           end

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -259,15 +259,22 @@ return {
       end
 
       for _, row in ipairs(rows) do
-        if row.request_host == "" then row.request_host = nil end
-        if row.request_path == "" then row.request_path = nil end
-        local fields_to_update = {
-          hosts = { row.request_host },
-          uris = { row.request_path },
-          strip_uri = row.strip_request_path,
-        }
+        local hosts
+        local uris
 
-        local _, err = dao.apis:update(fields_to_update, { id = row.id })
+        if row.request_host and row.request_host ~= "" then
+          hosts = { row.request_host }
+        end
+
+        if row.request_path and row.request_path ~= "" then
+          uris = { row.request_path }
+        end
+
+        local _, err = dao.apis:update({
+          hosts     = hosts,
+          uris      = uris,
+          strip_uri = row.strip_request_path,
+        }, { id = row.id })
         if err then
           return err
         end
@@ -336,9 +343,11 @@ return {
           or not row.upstream_read_timeout
           or not row.upstream_send_timeout then
 
-          -- update row, getting default values for upstream timeouts
-          -- from schema file
-          local _, err = dao.apis:update(row, { id = row.id })
+          local _, err = dao.apis:update({
+            upstream_connect_timeout = 60000,
+            upstream_send_timeout = 60000,
+            upstream_read_timeout = 60000,
+          }, { id = row.id })
           if err then
             return err
           end


### PR DESCRIPTION
### Summary

The previous intent was to rely on a schema's default field to insert
default values for new fields. However, a `full` update means we pass a
complete row to the DAO, and that row might contain older fields. Those
fields come from the row in the DB, but **disappeared** from the schema
definition. Hence, the DAO errors on the update and complains that
fields (such as `strip_request_path`) do not exist anymore, which is
correct, according to the current API schema.

Hence, we prefer not performing full updates, and only pass a subset of
hard-coded entities' fields to `dao:update()`.

### Full changelog

* avoid performing full updates with now non-existing fields in 
`dao:update()` from migrations