### PR TITLE
feat(init_worker): pass kong.conf to plugin's init_worker

### DIFF
--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -193,7 +193,7 @@ function Kong.init_worker()
   -- run plugins init_worker context
 
   for _, plugin in ipairs(singletons.loaded_plugins) do
-    plugin.handler:init_worker()
+    plugin.handler:init_worker(singletons.configuration)
   end
 end
 


### PR DESCRIPTION
For any plugins that require to open resources that have not already
been established by Kong itself, it would be best if the plugin
establishes the connection when an Nginx worker starts up,
instead on every request.

In order for a plugin to establish a connection to a resource,
it needs the ability to have access to Kong's main configuration
settings.
