### PR TITLE
feat(configuration): add ability to allow redis entires in kong.conf

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -63,7 +63,8 @@ local CONF_INFERENCES = {
   cluster_advertise = {typ = "string"},
   nginx_worker_processes = {typ = "string"},
   upstream_keepalive = {typ = "number"},
-
+  redis_host = {typ = "string"},
+  redis_port = {typ = "number"},
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},
   pg_ssl = {typ = "boolean"},

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -59,4 +59,7 @@ lua_ssl_verify_depth = 1
 lua_package_path = ?/init.lua;./kong/?.lua
 lua_package_cpath = NONE
 serf_path = serf
+
+redis_host = 127.0.0.1
+redis_port = 6379
 ]]


### PR DESCRIPTION
Allow the user to define redis connection details defined by kong.conf keys:

  * redis_host
  * redis_port

For my use case, this will be used in conjunction with feature/pass-conf-plugin-init_worker.  The user should have a means to define redis connection details in kong.conf and have the information propagated to a plugin's init_worker.