### PR TITLE
Failed to connect PostgreSQL with numbers password

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -66,11 +66,13 @@ local CONF_INFERENCES = {
 
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},
+  pg_password = {typ = "string"},
   pg_ssl = {typ = "boolean"},
   pg_ssl_verify = {typ = "boolean"},
 
   cassandra_contact_points = {typ = "array"},
   cassandra_port = {typ = "number"},
+  cassandra_password = {typ = "string"},
   cassandra_timeout = {typ = "number"},
   cassandra_ssl = {typ = "boolean"},
   cassandra_ssl_verify = {typ = "boolean"},

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -444,4 +444,16 @@ describe("Configuration loader", function()
       assert.is_nil(purged_conf.cluster_encrypt_key)
     end)
   end)
+
+  describe("number as string", function()
+    it("force the numeric pg_password/cassandra_password to a string", function()
+      local conf = assert(conf_loader(nil, {
+        pg_password = 123456,
+        cassandra_password = 123456
+      }))
+
+      assert.equal("123456", conf.pg_password)
+      assert.equal("123456", conf.cassandra_password)
+    end)
+  end)
 end)


### PR DESCRIPTION
If the PostgreSQL database password is a string of numbers, we can not connect to the database, regardless of the form(such as using double quotes) of value setting to the conf file.

Lua pl.config automatically converts the string option with numbers into a number, so I try to add double quotes to the `pg_password` option, but kong regard the quotes as a part of the option; then I try to add the trim_quotes parameter to call `pl_config.read(`) for parsing, at this point, the command line is working properly, but the worker still fails with error ‘pg_password is not a string’(because the generated prefix kong.conf is still no quotes).

There are three methods to solve it:
   ● Add double quotes in conf, and remove the double quotes when reading `pg_password` at `/kong/kong/dao/db/postgres.lua `(this method can only solve the problem itself, and it is ugly)
   ● Add the double quotes and using the `trim_quotes` for `pl_config.read()`, when the prefix_handler generates the configuration file, if the type of the value is a string, add double quotes for it (this method is more general but the effect is large)
   ● Specify the `pg_password` schema type as a string in `CONF_INFERENCES`, then it will be forced to a string (see `check_and_infer()`) (this method changes the least code, and other options encountered this problem can also take a similar approach)

This patch we use the third method to solve it.

### Issues resolved

Fix #2082
