### PR TITLE
fix(cors) returning correct Access-Control-Allow-Credentials

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -17,7 +17,9 @@ local function configure_origin(ngx, conf)
 end
 
 local function configure_credentials(ngx, conf)
-  if (conf.credentials) then
+  if conf.origin == nil or conf.origin == "*" then
+    ngx.header["Access-Control-Allow-Credentials"] = "false"
+  elseif conf.credentials then
     ngx.header["Access-Control-Allow-Credentials"] = "true"
   end
 end

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -151,6 +151,7 @@ server {
         default_type application/json;
         content_by_lua_block {
             ngx.header['Access-Control-Allow-Origin'] = '*'
+            ngx.header['Access-Control-Allow-Credentials'] = 'false'
             if ngx.req.get_method() == 'OPTIONS' then
                 ngx.header['Access-Control-Allow-Methods'] = 'GET,HEAD,PUT,PATCH,POST,DELETE'
                 ngx.header['Access-Control-Allow-Headers'] = 'Content-Type'

--- a/spec/03-plugins/04-cors/01-access_spec.lua
+++ b/spec/03-plugins/04-cors/01-access_spec.lua
@@ -25,6 +25,11 @@ describe("Plugin: cors (access)", function()
       hosts = { "cors4.com" },
       upstream_url = "http://mockbin.com"
     })
+    local api5 = assert(helpers.dao.apis:insert {
+      name = "api-5",
+      hosts = { "cors5.com" },
+      upstream_url = "http://mockbin.com"
+    })
 
     assert(helpers.dao.plugins:insert {
       name = "cors",
@@ -64,6 +69,14 @@ describe("Plugin: cors (access)", function()
       api_id = api4.id
     })
 
+    assert(helpers.dao.plugins:insert {
+      name = "cors",
+      api_id = api5.id,
+      config = {
+        origin = "*"
+      }
+    })
+
     assert(helpers.start_kong())
     client = helpers.proxy_client()
   end)
@@ -86,7 +99,22 @@ describe("Plugin: cors (access)", function()
       assert.equal("*", res.headers["Access-Control-Allow-Origin"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
       assert.is_nil(res.headers["Access-Control-Expose-Headers"])
-      assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+      assert.equal("false", res.headers["Access-Control-Allow-Credentials"])
+      assert.is_nil(res.headers["Access-Control-Max-Age"])
+    end)
+    it("gives appropriate defaults when origin is explicitly set to *", function()
+      local res = assert(client:send {
+        method = "OPTIONS",
+        headers = {
+          ["Host"] = "cors5.com"
+        }
+      })
+      assert.res_status(204, res)
+      assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
+      assert.equal("*", res.headers["Access-Control-Allow-Origin"])
+      assert.is_nil(res.headers["Access-Control-Allow-Headers"])
+      assert.is_nil(res.headers["Access-Control-Expose-Headers"])
+      assert.equal("false", res.headers["Access-Control-Allow-Credentials"])
       assert.is_nil(res.headers["Access-Control-Max-Age"])
     end)
     it("accepts config options", function()
@@ -132,7 +160,7 @@ describe("Plugin: cors (access)", function()
       assert.is_nil(res.headers["Access-Control-Allow-Methods"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
       assert.is_nil(res.headers["Access-Control-Expose-Headers"])
-      assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+      assert.equal("false", res.headers["Access-Control-Allow-Credentials"])
       assert.is_nil(res.headers["Access-Control-Max-Age"])
     end)
     it("accepts config options", function()
@@ -163,7 +191,7 @@ describe("Plugin: cors (access)", function()
       assert.is_nil(res.headers["Access-Control-Allow-Methods"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
       assert.is_nil(res.headers["Access-Control-Expose-Headers"])
-      assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+      assert.equal("false", res.headers["Access-Control-Allow-Credentials"])
       assert.is_nil(res.headers["Access-Control-Max-Age"])
     end)
     it("works with 40x responses returned by another plugin", function()
@@ -178,7 +206,7 @@ describe("Plugin: cors (access)", function()
       assert.is_nil(res.headers["Access-Control-Allow-Methods"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
       assert.is_nil(res.headers["Access-Control-Expose-Headers"])
-      assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+      assert.equal("false", res.headers["Access-Control-Allow-Credentials"])
       assert.is_nil(res.headers["Access-Control-Max-Age"])
     end)
   end)


### PR DESCRIPTION
### Full changelog

* Properly follow the CORS specification and return `Access-Control-Allow-Credentials: false` if `Access-Control-Allow-Origin: *`
