### PR TITLE
hotfix(response-ratelimiting): handle header_value as table in parse_header

### DIFF
--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -14,6 +14,15 @@ local _M = {}
 local function parse_header(header_value, limits)
   local increments = {}
   if header_value then
+    if (type(header_value) == "table") then
+      -- multiple headers with same name: combine per RFC 2616 section 4.2
+      local hval_str = header_value[1]
+      local i
+      for i = 2,#header_value do
+        hval_str = hval_str .. "," .. header_value[i]
+      end
+      header_value = hval_str
+    end
     local parts = utils.split(header_value, ",")
     for _, v in ipairs(parts) do
       local increment_parts = utils.split(v, "=")

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -14,16 +14,12 @@ local _M = {}
 local function parse_header(header_value, limits)
   local increments = {}
   if header_value then
-    if (type(header_value) == "table") then
-      -- multiple headers with same name: combine per RFC 2616 section 4.2
-      local hval_str = header_value[1]
-      local i
-      for i = 2,#header_value do
-        hval_str = hval_str .. "," .. header_value[i]
-      end
-      header_value = hval_str
+    local parts
+    if type(header_value) == "table" then
+      parts = header_value
+    else
+      parts = utils.split(header_value, ",")
     end
-    local parts = utils.split(header_value, ",")
     for _, v in ipairs(parts) do
       local increment_parts = utils.split(v, "=")
       if #increment_parts == 2 then

--- a/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/98-response-rate-limiting/04-access_spec.lua
@@ -417,39 +417,11 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         assert.equal(4, tonumber(body.headers["X-Ratelimit-Remaining-Video"]))
       end)
 
-      it("has test case where upstream sends multiple x-kong-limit headers", function()
-        -- Multiple headers with same name is OK per RFC 2616 section 4.2.
-        -- Can't use proxy_client to validate upstream:
-        -- res.headers can't have multiple table keys with the same name
-        local sock = assert(ngx.socket.tcp())
-
-        sock:settimeout(3000)
-        assert(sock:connect("httpbin.org", 80))
-        sock:send("GET /response-headers?x-kong-limit=video=2&x-kong-limit=image=1 HTTP/1.1\r\nHost: httpbin.org\r\n\r\n")
-
-        -- Read content-length value from headers
-        local readline = sock:receiveuntil("\r\n\r\n")
-        local headers = assert(readline()):lower()
-        local content_length = string.match(headers, ".*content%-length:%s*(%d+).*")
-
-        -- Read body, should be expected length
-        assert(sock:receive(tonumber(content_length)))
-        sock:close()
-
-        -- Validate x-kong-limit headers
-        local limit_header_count = 0
-        for header_value in string.gmatch(headers, ".-x%-kong%-limit:%s*(%S+).-") do
-          limit_header_count = limit_header_count + 1
-          assert(header_value == "video=2" or header_value == "image=1")
-        end
-        assert.equal(2, limit_header_count)
-      end)
-
       it("combines multiple x-kong-limit headers from upstream", function()
         for i = 1, 3 do
           local res = assert(client:send {
             method = "GET",
-            path = "/response-headers?x-kong-limit=video=2&x-kong-limit=image=1",
+            path = "/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1",
             headers = {
               ["Host"] = "test4.com"
             }
@@ -466,13 +438,14 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
 
         local res = assert(client:send {
           method = "GET",
-          path = "/response-headers?x-kong-limit=video=2&x-kong-limit=image=1",
+          path = "/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1",
           headers = {
             ["Host"] = "test4.com"
           }
         })
+
         local body = assert.res_status(429, res)
-        assert.equal([[]], body)
+        assert.equal("", body)
         assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
         assert.equal(1, tonumber(res.headers["x-ratelimit-remaining-image-minute"]))
       end)


### PR DESCRIPTION
### Summary

For issue #2089: If upstream sends multiple headers with the same name, combine their values per RFC 2616.

### Full changelog

* When parsing upstream response headers, handle header_value as table in parse_header

### Issues resolved

Fix #2089
