### PR TITLE
fix(dao): drop `hosts` instead of `headers` in postgresql migration

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -235,7 +235,7 @@ return {
       END$$;
     ]],
     down = [[
-      ALTER TABLE apis DROP COLUMN IF EXISTS headers;
+      ALTER TABLE apis DROP COLUMN IF EXISTS hosts;
       ALTER TABLE apis DROP COLUMN IF EXISTS uris;
       ALTER TABLE apis DROP COLUMN IF EXISTS methods;
       ALTER TABLE apis DROP COLUMN IF EXISTS strip_uri;


### PR DESCRIPTION
Signed-off-by: Wei.ZHAO <zhaowei@qiyi.com>