### PR TITLE
chore(cli) removing sensitive PRNG seed log

### DIFF
--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -1,6 +1,6 @@
 require("kong.core.globalpatches")({cli = true})
 
-local prng_seed = math.randomseed()
+math.randomseed() -- Generate PRNG seed
 
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
@@ -84,7 +84,6 @@ return function(args)
   log.debug("ngx_lua: %s", ngx.config.ngx_lua_version)
   log.debug("nginx: %s", ngx.config.nginx_version)
   log.debug("Lua: %s", jit and jit.version or _VERSION)
-  log.debug("PRNG seed: %d", prng_seed)
 
   xpcall(function() cmd_exec(args) end, function(err)
     if not (args.v or args.vv) then


### PR DESCRIPTION
The `prng_seed` is used explicitly for the generation of UUID creation for setting the consumer ids. The consumer identifier is further used as salt value to hash the passwords in the database.

### Full changelog

* Hides the PRNG seed from the debug logs.