### PR TITLE
chore(ssl) requiring upgrade to more secure TLS/1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ perform significantly better than any previous version.
   been added to Kong core, and are configurable via new properties on the API
   entity. See the related PR for a detailed explanation of this change.
   [#1970](https://github.com/Mashape/kong/pull/1970)
+- :warning: Dropping support for unsecure `TLS/1.0` and defaulting `Upgrade` 
+  responses to `TLS/1.2`.
+  [#2119](https://github.com/Mashape/kong/pull/2119)
 - Bump the compatible OpenResty version to `1.11.2.1` and `1.11.2.2`. Support
   for OpenResty `1.11.2.2` requires the `--without-luajit-lua52` compilation
   flag.

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -86,7 +86,7 @@ return {
 
       if api.https_only and not utils.check_https(api.http_if_terminated) then
         ngx.header["connection"] = "Upgrade"
-        ngx.header["upgrade"]    = "TLS/1.0, HTTP/1.1"
+        ngx.header["upgrade"]    = "TLS/1.2, HTTP/1.1"
 
         return responses.send(426, "Please use HTTPS protocol")
       end

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -86,7 +86,7 @@ server {
     listen ${{PROXY_LISTEN_SSL}} ssl;
     ssl_certificate ${{SSL_CERT}};
     ssl_certificate_key ${{SSL_CERT_KEY}};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.1 TLSv1.2;
     ssl_certificate_by_lua_block {
         kong.ssl_certificate()
     }

--- a/spec/02-integration/05-proxy/04-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/04-ssl_spec.lua
@@ -105,7 +105,7 @@ describe("SSL", function()
       local body = assert.res_status(426, res)
       assert.equal([[{"message":"Please use HTTPS protocol"}]], body)
       assert.contains("Upgrade", res.headers.connection)
-      assert.equal("TLS/1.0, HTTP/1.1", res.headers.upgrade)
+      assert.equal("TLS/1.2, HTTP/1.1", res.headers.upgrade)
     end)
 
     it("blocks request with HTTPS in x-forwarded-proto but no http_if_already_terminated", function()


### PR DESCRIPTION
### Full changelog

* Dropping support for unsecure `TLS/1.0` and defaulting `Upgrade` responses to `TLS/1.2`.
