### PR TITLE
fix(key-auth): validate the configured headernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ perform significantly better than any previous version.
   - CORS: Properly return `Access-Control-Allow-Credentials: false` if 
     `Access-Control-Allow-Origin: *`.
     [#2104](https://github.com/Mashape/kong/pull/2104)
+  - key-auth: validate the `key_names` to be proper header names
+    [#2142](https://github.com/Mashape/kong/pull/2142)
 
 ## [0.9.7] - 2016/12/21
 

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -1,6 +1,8 @@
 local utils = require "kong.tools.utils"
 
+
 local function check_user(anonymous)
+
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
     return true
   end
@@ -8,24 +10,34 @@ local function check_user(anonymous)
   return false, "the anonymous user must be empty or a valid uuid"
 end
 
+
 local function check_keys(keys)
+
   for _, key in ipairs(keys) do
     local res, err = utils.validate_header_name(key, false)
+
     if not res then
       return false, "key_name '"..key.."' is illegal, "..tostring(err)
     end
   end
+
   return true
 end
 
+
 local function default_key_names(t)
+
   if not t.key_names then
     return {"apikey"}
   end
+
 end
 
+
 return {
+
   no_consumer = true,
+
   fields = {
     key_names = {
       required = true,
@@ -33,14 +45,17 @@ return {
       default = default_key_names,
       func = check_keys,
     },
+
     hide_credentials = {
       type = "boolean",
       default = false,
     },
+
     anonymous = {
       type = "string",
       default = "",
       func = check_user,
     },
   }
+
 }

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -8,6 +8,16 @@ local function check_user(anonymous)
   return false, "the anonymous user must be empty or a valid uuid"
 end
 
+local function check_keys(keys)
+  for _, key in ipairs(keys) do
+    local res, err = utils.validate_header_name(key, false)
+    if not res then
+      return false, "key_name '"..key.."' is illegal, "..tostring(err)
+    end
+  end
+  return true
+end
+
 local function default_key_names(t)
   if not t.key_names then
     return {"apikey"}
@@ -17,8 +27,20 @@ end
 return {
   no_consumer = true,
   fields = {
-    key_names = {required = true, type = "array", default = default_key_names},
-    hide_credentials = {type = "boolean", default = false},
-    anonymous = {type = "string", default = "", func = check_user},
+    key_names = {
+      required = true,
+      type = "array",
+      default = default_key_names,
+      func = check_keys,
+    },
+    hide_credentials = {
+      type = "boolean",
+      default = false,
+    },
+    anonymous = {
+      type = "string",
+      default = "",
+      func = check_user,
+    },
   }
 }

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -24,6 +24,7 @@ local concat     = table.concat
 local insert     = table.insert
 local lower      = string.lower
 local fmt        = string.format
+local match      = string.match
 local find       = string.find
 local gsub       = string.gsub
 local split      = pl_stringx.split
@@ -581,6 +582,29 @@ _M.format_host = function(p1, p2)
   else
     return host ..  (port and ":"..port or "")
   end
+end
+
+-- patterns for allowed header characters
+local header_chars = [[!#$%%&'%*%+%-%.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~]]
+local header_allowed = "^["..header_chars.."]+$"
+local header_allowed_u = "^["..header_chars.."_]+$"  -- adds underscore
+
+--- Validates a header name.
+-- Checks characters used in a header name to be valid.
+-- @param name (string) the header name to verify
+-- @param allow_underscore (boolean, optional) if thruthy and `_` (underscore) is
+-- accepted, otherwise it will fail.
+-- @return the valid header name, or `nil+error`
+_M.validate_header_name = function(name, allow_underscore)
+  -- allow_underscore is used because openresty by default changes "_" into "-"
+  if name == nil or name == "" then
+    return nil, "no header name provided"
+  end
+  if match(name, allow_underscore and header_allowed_u or header_allowed) then
+    return name
+  end
+  return nil, "only the following characters are allowed for header names: "..
+              (allow_underscore and header_allowed_u or header_allowed)
 end
 
 return _M

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -458,5 +458,29 @@ describe("Utils", function()
       end)
     end)
   end)
-  
+
+  describe("validate_header_name()", function()
+    it("validates header names without underscore", function()
+      local header_chars = [[%!#$&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~]]
+      for i = 1, 255 do
+        local c = string.char(i)
+        if string.find(header_chars, c, nil, true) then
+          assert(utils.validate_header_name(c) == c, "ascii character '"..c.."' ("..i..") should have been allowed")
+        else
+          assert(utils.validate_header_name(c) == nil, "ascii character "..i.." should not have been allowed")
+        end
+      end
+    end)
+    it("validates header names with underscore", function()
+      local header_chars = [[%!#$&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~_]]
+      for i = 1, 255 do
+        local c = string.char(i)
+        if string.find(header_chars, c, nil, true) then
+          assert(utils.validate_header_name(c, true) == c, "ascii character '"..c.."' ("..i..") should have been allowed")
+        else
+          assert(utils.validate_header_name(c, true) == nil, "ascii character "..i.." should not have been allowed")
+        end
+      end
+    end)
+  end)
 end)

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -459,28 +459,15 @@ describe("Utils", function()
     end)
   end)
 
-  describe("validate_header_name()", function()
-    it("validates header names without underscore", function()
-      local header_chars = [[%!#$&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~]]
-      for i = 1, 255 do
-        local c = string.char(i)
-        if string.find(header_chars, c, nil, true) then
-          assert(utils.validate_header_name(c) == c, "ascii character '"..c.."' ("..i..") should have been allowed")
-        else
-          assert(utils.validate_header_name(c) == nil, "ascii character "..i.." should not have been allowed")
-        end
+  it("validate_header_name() validates header names", function()
+    local header_chars = [[-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
+    for i = 1, 255 do
+      local c = string.char(i)
+      if string.find(header_chars, c, nil, true) then
+        assert(utils.validate_header_name(c) == c, "ascii character '"..c.."' ("..i..") should have been allowed")
+      else
+        assert(utils.validate_header_name(c) == nil, "ascii character "..i.." should not have been allowed")
       end
-    end)
-    it("validates header names with underscore", function()
-      local header_chars = [[%!#$&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~_]]
-      for i = 1, 255 do
-        local c = string.char(i)
-        if string.find(header_chars, c, nil, true) then
-          assert(utils.validate_header_name(c, true) == c, "ascii character '"..c.."' ("..i..") should have been allowed")
-        else
-          assert(utils.validate_header_name(c, true) == nil, "ascii character "..i.." should not have been allowed")
-        end
-      end
-    end)
+    end
   end)
 end)

--- a/spec/03-plugins/02-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/02-key-auth/01-api_spec.lua
@@ -5,12 +5,21 @@ describe("Plugin: key-auth (API)", function()
   local consumer
   local admin_client
   setup(function()
-    assert(helpers.start_kong())
-    admin_client = helpers.admin_client()
-
+    assert(helpers.dao.apis:insert {
+      name = "keyauth1",
+      upstream_url = "http://mockbin.com",
+      hosts = { "keyauth1.test" },
+    })
+    assert(helpers.dao.apis:insert {
+      name = "keyauth2",
+      upstream_url = "http://mockbin.com",
+      hosts = { "keyauth2.test" },
+    })
     consumer = assert(helpers.dao.consumers:insert {
       username = "bob"
     })
+    assert(helpers.start_kong())
+    admin_client = helpers.admin_client()
   end)
   teardown(function()
     if admin_client then admin_client:close() end
@@ -252,6 +261,46 @@ describe("Plugin: key-auth (API)", function()
           assert.res_status(404, res)
         end)
       end)
+    end)
+  end)
+  describe("/apis/:api/plugins", function()
+    it("fails with invalid key_names", function()
+      local key_name = "hello\\world"
+      local res = assert(admin_client:send {
+        method = "POST",
+        path = "/apis/keyauth1/plugins",
+        body = {
+          name = "key-auth",
+          config = {
+            key_names = {key_name},
+          },
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+      assert.response(res).has.status(400)
+      local body = assert.response(res).has.jsonbody()
+      assert.equal("key_name 'hello\\world' is illegal, only the following characters are allowed for header names: ^[!#$%%&'%*%+%-%.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~]+$", body["config.key_names"])
+    end)
+    it("succeeds with valid key_names", function()
+      local key_name = "hello-world"
+      local res = assert(admin_client:send {
+        method = "POST",
+        path = "/apis/keyauth2/plugins",
+        body = {
+          name = "key-auth",
+          config = {
+            key_names = {key_name},
+          },
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+      assert.response(res).has.status(201)
+      local body = assert.response(res).has.jsonbody()
+      assert.equal(key_name, body.config.key_names[1])
     end)
   end)
 end)

--- a/spec/03-plugins/02-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/02-key-auth/01-api_spec.lua
@@ -281,7 +281,7 @@ describe("Plugin: key-auth (API)", function()
       })
       assert.response(res).has.status(400)
       local body = assert.response(res).has.jsonbody()
-      assert.equal("key_name 'hello\\world' is illegal, only the following characters are allowed for header names: ^[!#$%%&'%*%+%-%.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^`abcdefghijklmnopqrstuvwxyz|~]+$", body["config.key_names"])
+      assert.equal("key_name 'hello\\world' is illegal, bad header name 'hello\\world', allowed characters are A-Z, a-z, 0-9 and '-'", body["config.key_names"])
     end)
     it("succeeds with valid key_names", function()
       local key_name = "hello-world"


### PR DESCRIPTION
adds validation of header names (was completely absent)
due to nginx/openresty config the '_' is also considered an invalid
character.

### Issues resolved

Fixes #2013 
