### PR TITLE
feat(c*) run migrations from a single coordinator

### DIFF
--- a/kong-0.10.0rc4-0.rockspec
+++ b/kong-0.10.0rc4-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.4",
   "version == 0.2",
   "lapis == 1.5.1",
-  "lua-cassandra == 1.1.0",
+  "lua-cassandra == 1.1.1",
   "pgmoon-mashape == 2.0.1",
   "luatz == 0.3",
   "lua_system_constants == 0.1.1",

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -245,7 +245,7 @@ local function migrate(self, identifier, migrations_modules, cur_migrations, on_
     if on_success then
       on_success(identifier, migration.name, self.db:infos())
     end
-end
+  end
 
   return true, nil, #to_run
 end
@@ -270,6 +270,14 @@ function _M:run_migrations(on_migrate, on_success)
 
   log.verbose("running datastore migrations")
 
+  if self.db.name == "cassandra" then
+    local ok, err = self.db:first_coordinator()
+    if not ok then
+      return nil, ret_error_string(self.db.name, nil,
+                    "could not find coordinator: " .. err)
+    end
+  end
+
   local migrations_modules = self:migrations_modules()
   local cur_migrations, err = self:current_migrations()
   if err then return nil, err end
@@ -284,6 +292,23 @@ function _M:run_migrations(on_migrate, on_success)
       else
         migrations_ran = migrations_ran + n_ran
       end
+    end
+  end
+
+  if self.db.name == "cassandra" then
+    log.verbose("now waiting for schema consensus (%dms) timeout",
+                self.db.cluster.max_schema_consensus_wait)
+
+    local ok, err = self.db:wait_for_schema_consensus()
+    if not ok then
+      return nil, ret_error_string(self.db.name, nil,
+                    "could not wait for schema consensus: " .. err)
+    end
+
+    ok, err = self.db:close_coordinator()
+    if not ok then
+      return nil, ret_error_string(self.db.name, nil,
+                    "could not close coordinator: " .. err)
     end
   end
 

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -37,6 +37,11 @@ return {
         return err
       end
 
+      local ok, err = db:coordinator_change_keyspace(keyspace_name)
+      if not ok then
+        return err
+      end
+
       local res, err = db:query [[
         CREATE TABLE IF NOT EXISTS schema_migrations(
           id text PRIMARY KEY,


### PR DESCRIPTION
### Summary

Run DDL queries from a single coordinator and only check for the schema consensus at the very end of this process. This allows for faster and more reliable migrations

### Full changelog

* bump lua-cassandra to 1.1.1
* implement a "single coordinator" mode in the cassandra DB module

### Issues

Possible fix #2063