### PR TITLE
fix(hmac-auth) generate a credential secret if none provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased][unreleased]
 
-## [0.10.0] - 2017/03/07
+### Fixed
+
+- Plugins:
+  - hmac: generate an HMAC secret value if none is provided.
+    [#2158](https://github.com/Mashape/kong/pull/2158)
+
+
+## [0.10.0] - 2016/03/07
 
 Kong 0.10 is one of most significant releases to this day. It ships with
 exciting new features that have been havily requested for the last few months,

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -1,3 +1,5 @@
+local utils = require "kong.tools.utils"
+
 local SCHEMA = {
   primary_key = {"id"},
   table = "hmacauth_credentials",
@@ -6,7 +8,7 @@ local SCHEMA = {
     created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
     consumer_id = {type = "id", required = true, foreign = "consumers:id"},
     username = {type = "string", required = true, unique = true},
-    secret = {type = "string"}
+    secret = {type = "string", default = utils.random_string}
   },
   marshall_event = function(self, t)
     return {id = t.id, consumer_id = t.consumer_id, username = t.username}

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -39,6 +39,20 @@ describe("Plugin: hmac-auth (API)", function()
         credential = cjson.decode(body)
         assert.equal(consumer.id, credential.consumer_id)
       end)
+      it("[SUCCESS] should create a hmac-auth credential with a random secret", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/consumers/bob/hmac-auth/",
+          body = {
+            username = "bob",
+          },
+          headers = {["Content-Type"] = "application/json"}
+        })
+
+        local body = assert.res_status(201, res)
+        credential = cjson.decode(body)
+        assert.is.not_nil(credential.secret)
+      end)
       it("[FAILURE] should return proper errors", function()
         local res = assert(client:send {
           method = "POST",


### PR DESCRIPTION
### Summary

Since the credential secret is required to compute the signature, create a random secret which will be  displayed back to the user as part of the response body.

### Full changelog

* generate a credential secret if none provided

### Issues resolved

Fix #2143 
