### PR TITLE
fix(balancer): update dependency to fix issue #2131

### DIFF
--- a/kong-0.10.0rc4-0.rockspec
+++ b/kong-0.10.0rc4-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.3.1",
+  "lua-resty-dns-client == 0.3.2",
   "lua-resty-worker-events == 0.3.0",
 }
 build = {


### PR DESCRIPTION
### Summary

Updates dependency to fix an issue with the balancer.

Before merging:

- [x] verify issue #2131 has been fixed
- [x] release version 0.3.2 of https://github.com/Mashape/lua-resty-dns-client

### Issues resolved

Fix #2131 
