### PR TITLE
add a policy to the rate limiting to scale the limit per node

### DIFF
--- a/kong/plugins/rate-limiting/dao/cassandra.lua
+++ b/kong/plugins/rate-limiting/dao/cassandra.lua
@@ -42,6 +42,39 @@ function _M:increment(api_id, identifier, current_timestamp, value)
   return ok
 end
 
+function _M:update(api_id, identifier, current_timestamp, period, value)
+  local periods = timestamp.get_timestamps(current_timestamp)
+  local options = self:_get_conn_options()
+  local session, err = cassandra.spawn_session(options)
+  if err then
+    ngx.log(ngx.ERR, "[rate-limiting] could not spawn session to Cassandra: "..tostring(err))
+    return nil, err
+  end
+
+  local ok = true
+  local res, err = session:execute([[
+    UPDATE ratelimiting_metrics SET value = value + ? WHERE
+      api_id = ? AND
+      identifier = ? AND
+      period_date = ? AND
+      period = ?
+  ]], {
+    cassandra.counter(value),
+    cassandra.uuid(api_id),
+    identifier,
+    cassandra.timestamp(periods[period]),
+    period
+  })
+  if not res then
+    ok = false
+    ngx.log(ngx.ERR, "[rate-limiting] could not increment counter for period '"..period.."': "..tostring(err))
+  end
+
+  session:set_keep_alive()
+
+  return ok
+end
+
 function _M:find(api_id, identifier, current_timestamp, period)
   local periods = timestamp.get_timestamps(current_timestamp)
   local rows, err = self:query([[

--- a/kong/plugins/rate-limiting/dao/postgres.lua
+++ b/kong/plugins/rate-limiting/dao/postgres.lua
@@ -25,6 +25,18 @@ function _M:increment(api_id, identifier, current_timestamp, value)
   return true
 end
 
+function _M:update(api_id, identifier, current_timestamp, period, value)
+  local periods = timestamp.get_timestamps(current_timestamp)
+  local buf = fmt("SELECT increment_rate_limits('%s', '%s', '%s', to_timestamp('%s') at time zone 'UTC', %d)",
+                        api_id, identifier, period, periods[period]/1000, value)
+
+  local res, err = self:query(queries)
+  if not res then
+    return false, err
+  end
+  return true
+end
+
 function _M:find(api_id, identifier, current_timestamp, period)
   local periods = timestamp.get_timestamps(current_timestamp)
 

--- a/kong/plugins/rate-limiting/policies.lua
+++ b/kong/plugins/rate-limiting/policies.lua
@@ -140,5 +140,116 @@ return {
 
       return current_metric and current_metric or 0
     end
+  },
+  ["distributed"] = {
+    increment = function(conf, api_id, identifier, current_timestamp, increment)
+      local periods = timestamp.get_timestamps(current_timestamp)
+      -- increment in cache
+      for period, period_date in pairs(periods) do
+        local cache_key = get_local_key(api_id, identifier, period_date, period)
+        local counter_key = cache_key.."counter"
+        -- TODO: fix race condition with cache.rawget_or_rawset() from
+        -- https://github.com/Mashape/kong/pull/2100
+        if not cache.rawget(cache_key) then
+          cache.rawset(cache_key, 0, EXPIRATIONS[period])
+          cache.rawset(counter_key, 0, EXPIRATIONS[period])
+        end
+
+        local _, err = cache.incr(cache_key, increment)
+        if err then
+          ngx_log("[rate-limiting] could not increment counter for period '"
+          ..period.."': "..tostring(err))
+          return nil, err
+        end
+      end
+
+      -- when was last resync ?
+      local resync_key = "last_resync:"..api_id..":"..identifier
+      local last_resync = cache.rawget(resync_key)
+      -- first init
+      if not last_resync then
+        last_resync = current_timestamp
+        cache.rawset(resync_key, last_resync)
+      end
+
+      -- check expiration
+      local diff = current_timestamp - last_resync
+      -- TODO : make db usage sync frequency a parameter
+      if diff > 30000 then
+        for period, period_date in pairs(periods) do
+          local cache_key = get_local_key(api_id, identifier, period_date, period)
+          local counter_key = cache_key.."counter"
+          local m = cache.rawget(cache_key)
+          if m then
+            local c = cache.rawget(counter_key)
+            -- calculate difference
+            local d = m - c
+            local _, stmt_err = singletons.dao.ratelimiting_metrics:update(api_id, identifier, period_date, period, d)
+            if stmt_err then
+              ngx.log(ngx.ERR, "failed to increment: ", tostring(stmt_err))
+            end
+          end
+        end
+        cache.rawset(resync_key, current_timestamp)
+      end
+    end,
+
+    usage = function(conf, api_id, identifier, current_timestamp, period)
+      -- Refresh the number of members in the cluster
+      local function refresh_members(current_timestamp)
+          -- Is the cluster size (in cache) to be refreshed ?
+          local members_resync = cache.rawget("members_resync")
+          -- first init
+          if not members_resync then
+              members_resync = current_timestamp
+              cache.rawset("members_resync", members_resync)
+          end
+
+          local diff = current_timestamp - members_resync
+
+          local nb_members = cache.rawget("nb_members")
+          -- first init or resync
+          if (not nb_members or diff > 30000) then
+              local members, serf_err = singletons.serf:members()
+              if serf_err then
+                  ngx.log(ngx.ERR, "failed to get members: ", tostring(err))
+                  return responses.send(500, "Could not determine cluster size")
+              end
+              nb_members = 0
+              local member_names = {}
+              for k,v in pairs(members) do
+                  if (v.status=="alive") then
+                      nb_members = nb_members + 1
+                  end
+              end
+              cache.rawset("nb_members", nb_members)
+              cache.rawset("members_resync", current_timestamp)
+          end
+          return nb_members
+      end
+
+      local nb_members = refresh_members(current_timestamp)
+      local periods = timestamp.get_timestamps(current_timestamp)
+      local cache_key = get_local_key(api_id, identifier, periods[period], period)
+      local counter_key = cache_key.."counter"
+      local current_metric = cache.rawget(cache_key)
+
+      -- first init or after db resync
+      if not current_metric then
+          local cm, err = singletons.dao.ratelimiting_metrics:find(api_id, identifier, periods[period], period)
+          if err then
+              return nil, err
+          end
+          current_metric = cm and cm.value or 0
+          current_metric = current_metric / nb_members
+          cache.rawset(cache_key, current_metric, EXPIRATIONS[period])
+          cache.rawset(counter_key, current_metric, EXPIRATIONS[period])
+      end
+
+      local current_usage = current_metric and current_metric or 0
+      local cluster_usage = current_usage * nb_members
+
+      return cluster_usage
+    end
   }
 }

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -11,7 +11,7 @@ return {
     month = { type = "number" },
     year = { type = "number" },
     limit_by = { type = "string", enum = {"consumer", "credential", "ip"}, default = "consumer" },
-    policy = { type = "string", enum = {"local", "cluster", REDIS}, default = "cluster" },
+    policy = { type = "string", enum = {"local", "cluster", REDIS, "distributed"}, default = "cluster" },
     fault_tolerant = { type = "boolean", default = true },
     redis_host = { type = "string" },
     redis_port = { type = "number", default = 6379 },


### PR DESCRIPTION
When the LB is a rr, it may be interested to have a global limit
regardless of the number of Kong instances. Each kong instance
will keep a local limit as a chunk of the global one. If the
number of instances varies, this local limit will adapt.