### PR TITLE
tests(ci): provide more time to start for background server, and collect closed sockets

### DIFF
--- a/spec/02-integration/05-proxy/05-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/05-balancer_spec.lua
@@ -68,7 +68,9 @@ local function http_server(timeout, count, port, ...)
     end
   }, timeout, count, port)
 
-  return thread:start(...)
+  local server = thread:start(...)
+  ngx.sleep(0.2)  -- attempt to make sure server is started for failing CI tests
+  return server
 end
 
 dao_helpers.for_each_dao(function(kong_config)
@@ -83,6 +85,11 @@ dao_helpers.for_each_dao(function(kong_config)
     teardown(function()
       helpers.test_conf.database = config_db
       config_db = nil
+    end)
+
+    before_each(function()
+      collectgarbage()
+      collectgarbage()
     end)
 
     describe("Balancing", function()


### PR DESCRIPTION
trial and error fix to see how CI responds and whether it now passes the failing balancer tests.