### PR TITLE
fix(oauth2) dont try to hide credentials in a multipart req body

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -422,7 +422,11 @@ local function parse_access_token(conf)
       parameters[ACCESS_TOKEN] = nil
       ngx.req.set_uri_args(parameters)
 
-      if ngx.req.get_method() ~= "GET" then -- Remove from body
+      local content_type = req_get_headers()[CONTENT_TYPE]
+      local is_form_post = content_type and
+        string_find(content_type, "application/x-www-form-urlencoded", 1, true)
+
+      if ngx.req.get_method() ~= "GET" and is_form_post then -- Remove from body
         ngx.req.read_body()
         parameters = ngx.req.get_post_args()
         parameters[ACCESS_TOKEN] = nil

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -2027,5 +2027,21 @@ describe("#ci Plugin: oauth2 (access)", function()
       local body = cjson.decode(assert.res_status(200, res))
       assert.is_nil(body.headers.authorization)
     end)
+    it("does not abort when the request body is a multipart form upload", function()
+      local token = provision_token("oauth2_3.com")
+
+      local res = assert(proxy_client:send {
+        method = "POST",
+        path = "/request?access_token="..token.access_token,
+        body = {
+          foo = "bar"
+        },
+        headers = {
+          ["Host"] = "oauth2_3.com",
+          ["Content-Type"] = "multipart/form-data"
+        }
+      })
+      assert.res_status(200, res)
+    end)
   end)
 end)


### PR DESCRIPTION
### Summary

Don't try to remove credentials from request bodies when the request is a multipart upload. This prevents a thread abort when trying to index a non-existent table.

### Full changelog

* fix(oauth2) dont try to hide credentials in a multipart req body

### Issues resolved

Fix #1952 
