### PR TITLE
fix(plugins) use a sane wrapper around ngx.get_post_args

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -7,11 +7,11 @@ local utils = require "kong.tools.utils"
 local Multipart = require "multipart"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
+local public_utils = require "kong.utils.public"
 
 local string_find = string.find
 local ngx_req_get_headers = ngx.req.get_headers
 local ngx_req_read_body = ngx.req.read_body
-local ngx_req_get_post_args = ngx.req.get_post_args
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_req_get_body_data = ngx.req.get_body_data
 
@@ -35,7 +35,7 @@ local function retrieve_parameters()
       body_parameters = {}
     end
   else
-    body_parameters = ngx_req_get_post_args()
+    body_parameters = public_utils.get_post_args()
   end
 
   return utils.table_merge(ngx_req_get_uri_args(), body_parameters)

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -7,6 +7,7 @@ local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local timestamp = require "kong.tools.timestamp"
 local singletons = require "kong.singletons"
+local public_utils = require "kong.utils.public"
 
 local string_find = string.find
 local req_get_headers = ngx.req.get_headers
@@ -99,7 +100,7 @@ local function retrieve_parameters()
     body_parameters, err = cjson.decode(ngx.req.get_body_data())
     if err then body_parameters = {} end
   else
-    body_parameters = ngx.req.get_post_args()
+    body_parameters = public_utils.get_post_args()
   end
 
   return utils.table_merge(ngx.req.get_uri_args(), body_parameters)
@@ -424,7 +425,7 @@ local function parse_access_token(conf)
 
       if ngx.req.get_method() ~= "GET" then -- Remove from body
         ngx.req.read_body()
-        parameters = ngx.req.get_post_args()
+        parameters = public_utils.get_post_args()
         parameters[ACCESS_TOKEN] = nil
         local encoded_args = ngx.encode_args(parameters)
         ngx.req.set_header(CONTENT_LENGTH, #encoded_args)

--- a/kong/plugins/runscope/handler.lua
+++ b/kong/plugins/runscope/handler.lua
@@ -1,6 +1,7 @@
 local runscope_serializer = require "kong.plugins.log-serializers.runscope"
 local BasePlugin = require "kong.plugins.base_plugin"
 local log = require "kong.plugins.runscope.log"
+local public_utils = require "kong.utils.public"
 
 local ngx_log = ngx.log
 local ngx_log_ERR = ngx.ERR
@@ -8,8 +9,6 @@ local string_find = string.find
 local req_read_body = ngx.req.read_body
 local req_get_headers = ngx.req.get_headers
 local req_get_body_data = ngx.req.get_body_data
-local req_get_post_args = ngx.req.get_post_args
-local pcall = pcall
 
 local RunscopeLogHandler = BasePlugin:extend()
 
@@ -30,16 +29,7 @@ function RunscopeLogHandler:access(conf)
     local headers = req_get_headers()
     local content_type = headers["content-type"]
     if content_type and string_find(content_type:lower(), "application/x-www-form-urlencoded", nil, true) then
-      local status, res = pcall(req_get_post_args)
-      if not status then
-        if res == "requesty body in temp file not supported" then
-          ngx_log(ngx_log_ERR, "[runscope] cannot read request body from temporary file. Try increasing the client_body_buffer_size directive.")
-        else
-          ngx_log(ngx_log_ERR, res)
-        end
-      else
-        req_post_args = res
-      end
+      req_post_args = public_utils.get_post_args()
     end
   end
 

--- a/kong/utils/public.lua
+++ b/kong/utils/public.lua
@@ -1,0 +1,26 @@
+local pcall = pcall
+local ngx_log = ngx.log
+local ERR = ngx.ERR
+
+
+local _M = {}
+
+
+do
+  local ngx_req_get_post_args = ngx.req.get_post_args
+
+  function _M.get_post_args()
+    local ok, res, err = pcall(ngx_req_get_post_args)
+
+    if not ok or err then
+      local msg = res and res or err
+      ngx_log(ERR, "could not get body args: ", msg)
+      return {} -- TODO return an immutable table here
+    end
+
+    return res
+  end
+end
+
+
+return _M


### PR DESCRIPTION
### Summary

This call can fail in multiple ways, most notibly when the request body size is greater than client_body_buffer_size. Until a refactored plugin api is in place, we should catch errors (either Lua errors, or a returned error message from ngx).

### Full changelog

* fix(plugins) user a sane wrapper around ngx.get_post_args

### Issues resolved

Fix #1241 
