### PR TITLE
tests(rock) ensure all required Kong modules are declared

### DIFF
--- a/spec/01-unit/01-rockspec_meta_spec.lua
+++ b/spec/01-unit/01-rockspec_meta_spec.lua
@@ -1,5 +1,6 @@
-local pl_dir = require "pl.dir"
+local pl_utils = require "pl.utils"
 local pl_path = require "pl.path"
+local pl_dir = require "pl.dir"
 local meta = require "kong.meta"
 
 describe("rockspec/meta", function()
@@ -9,11 +10,15 @@ describe("rockspec/meta", function()
   setup(function()
     lua_srcs = pl_dir.getallfiles("./kong", "*.lua")
     assert.True(#lua_srcs > 0)
+
     local res = pl_dir.getfiles(".", "*.rockspec")
-    assert.equal(1, #res)
+    assert(#res == 1, "more than 1 rockspec file")
+
     rock_filename = res[1]
+
     local f = assert(loadfile(res[1]))
     setfenv(f, rock)
+
     f()
   end)
 
@@ -21,10 +26,12 @@ describe("rockspec/meta", function()
     it("has a _NAME field", function()
       assert.is_string(meta._NAME)
     end)
+
     it("has a _VERSION field", function()
       assert.is_string(meta._VERSION)
       assert.matches("%d+%.%d+%.%d+", meta._VERSION)
     end)
+
     it("has a _VERSION_TABLE field", function()
       assert.is_table(meta._VERSION_TABLE)
       assert.is_number(meta._VERSION_TABLE.major)
@@ -32,6 +39,7 @@ describe("rockspec/meta", function()
       assert.is_number(meta._VERSION_TABLE.patch)
       -- pre_release optional
     end)
+
     it("has a _DEPENDENCIES field", function()
       assert.is_table(meta._DEPENDENCIES)
       assert.is_table(meta._DEPENDENCIES.nginx)
@@ -42,9 +50,11 @@ describe("rockspec/meta", function()
   it("has same version as meta", function()
     assert.matches(meta._VERSION, rock.version:match("(.-)%-.*$"))
   end)
+
   it("has same name as meta", function()
     assert.equal(meta._NAME, rock.package)
   end)
+
   it("has correct version in filename", function()
     local pattern = meta._VERSION:gsub("%.", "%%."):gsub("-", "%%-")
     assert.matches(pattern, rock_filename)
@@ -53,28 +63,50 @@ describe("rockspec/meta", function()
   describe("modules", function()
     it("are all included in rockspec", function()
       for _, src in ipairs(lua_srcs) do
-        src = src:sub(3) -- strip './'
+        local rel_src = src:sub(3) -- strip './'
         local found
         for mod_name, mod_path in pairs(rock.build.modules) do
-          if mod_path == src then
+          if mod_path == rel_src then
             found = true
             break
           end
         end
-        assert(found, "could not find module entry for Lua file: "..src)
+        assert(found, "could not find module entry for Lua file: " .. src)
       end
     end)
+
     it("all modules named as their path", function()
       for mod_name, mod_path in pairs(rock.build.modules) do
         if mod_name ~= "kong" then
           mod_path = mod_path:gsub("%.lua", ""):gsub("/", '.'):gsub("%.init", "")
-          assert(mod_name == mod_path, mod_path.." has different name ("..mod_name..")")
+          assert(mod_name == mod_path,
+                 mod_path .. " has different name (" .. mod_name .. ")")
         end
       end
     end)
+
     it("all rockspec files do exist", function()
       for mod_name, mod_path in pairs(rock.build.modules) do
-        assert(pl_path.exists(mod_path), mod_path.." does not exist ("..mod_name..")")
+        assert(pl_path.exists(mod_path),
+               mod_path .. " does not exist (" .. mod_name .. ")")
+      end
+    end)
+  end)
+
+  describe("requires", function()
+    it("requires in the codebase are defined modules in the rockspec", function()
+      for _, src in ipairs(lua_srcs) do
+        local str = pl_utils.readfile(src)
+
+        for _, mod in string.gmatch(str, "require%s*([\"'])(kong%..-)%1") do
+          if not rock.build.modules[mod] then
+            assert(rock.build.modules[mod] ~= nil,
+                   "Invalid module require: \n"                      ..
+                   "requiring module '" .. mod .. "' in Lua source " ..
+                   "'" .. src .. "' that is not declared in "        ..
+                   rock_filename)
+          end
+        end
       end
     end)
   end)


### PR DESCRIPTION
This test ensures that all `kong.*` modules required in all of the Kong
sources are valid Kong modules, declared in the rockspec. This will help
a lot with the file structure revamp.