### PR TITLE
chore(luacheck) use .luacheckrc + update settings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,39 @@
+std             = "ngx_lua"
+unused          = false
+redefined       = false
+max_line_length = false
+
+
+globals = {
+    "_KONG",
+}
+
+
+not_globals = {
+    "string.len",
+    "table.getn",
+}
+
+
+ignore = {
+    "6.", -- ignore whitespace warnings
+}
+
+
+exclude_files = {
+    "spec/fixtures/invalid-module.lua",
+}
+
+
+files["kong/plugins/ldap-auth/*.lua"] = {
+    read_globals = {
+        "bit.mod",
+        "string.pack",
+        "string.unpack",
+    },
+}
+
+
+files["spec/**/*.lua"] = {
+    std = "ngx_lua+busted",
+}

--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,7 @@ dev: install
 	done;
 
 lint:
-	@luacheck -q . \
-						--exclude-files 'kong/vendor/**/*.lua' \
-						--exclude-files 'spec/fixtures/invalid-module.lua' \
-						--std 'ngx_lua+busted' \
-						--globals '_KONG' \
-						--globals 'ngx' \
-						--globals 'assert' \
-						--globals 'string.pack' \
-						--globals 'string.unpack' \
-						--globals 'bit.mod' \
-						--no-redefined \
-						--no-unused-args \
-						--ignore 6..
+	@luacheck -q .
 
 test:
 	@$(TEST_CMD) spec/01-unit

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -200,7 +200,6 @@ return function(options)
     --
     -- This patched method will create a unique seed per worker process,
     -- using a combination of both time and the worker's pid.
-    -- luacheck: globals math
     local util = require "kong.tools.utils"
     local seeds = {}
     local randomseed = math.randomseed


### PR DESCRIPTION
### Summary

This allows users who would rather use `luacheck .` than the `make lint`
command to do so. It also makes the linting options more obvious.

Note: In the future, re-enable white-spaces warnings.

### Full changelog

* use `.luacheckrc` for Luacheck config options
* update Luacheck settings
