### PR TITLE
hotfix(cache): removes deadlocks when cache callbacks error

### DIFF
--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -14,7 +14,7 @@ local function load_plugin_into_memory(api_id, consumer_id, plugin_name)
     name = plugin_name
   }
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err
   end
 
   if #rows > 0 then
@@ -37,8 +37,11 @@ end
 -- @treturn table Plugin retrieved from the cache or database.
 local function load_plugin_configuration(api_id, consumer_id, plugin_name)
   local cache_key = cache.plugin_key(plugin_name, api_id, consumer_id)
-  local plugin = cache.get_or_set(cache_key, nil, load_plugin_into_memory,
+  local plugin, err = cache.get_or_set(cache_key, nil, load_plugin_into_memory,
                                   api_id, consumer_id, plugin_name)
+  if err then
+    responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
   if plugin ~= nil and plugin.enabled then
     return plugin.config or {}
   end

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -21,7 +21,7 @@ end
 local function load_acls_into_memory(consumer_id)
   local results, err = singletons.dao.acls:find_all {consumer_id = consumer_id}
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err
   end
   return results
 end
@@ -37,9 +37,11 @@ function ACLHandler:access(conf)
   end
 
   -- Retrieve ACL
-  local acls = cache.get_or_set(cache.acls_key(consumer_id), nil,
+  local acls, err = cache.get_or_set(cache.acls_key(consumer_id), nil,
                                 load_acls_into_memory, consumer_id)
-
+  if err then
+    responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
   if not acls then acls = {} end
 
   local block

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -132,8 +132,11 @@ function KeyAuthHandler:access(conf)
   if not ok then
     if conf.anonymous ~= "" then
       -- get anonymous user
-      local consumer = cache.get_or_set(cache.consumer_key(conf.anonymous),
-                       nil, load_consumer, conf.anonymous, true)
+      local consumer, err = cache.get_or_set(cache.consumer_key(conf.anonymous),
+                            nil, load_consumer, conf.anonymous, true)
+      if err then
+        responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      end
       set_consumer(consumer, nil)
     else
       return responses.send(err.status, err.message)

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -26,7 +26,7 @@ local function load_credential(key)
     key = key
   }
   if not creds then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err
   end
   return creds[1]
 end
@@ -37,7 +37,7 @@ local function load_consumer(consumer_id, anonymous)
     if anonymous and not err then
       err = 'anonymous consumer "'..consumer_id..'" not found'
     end
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err
   end
   return result
 end
@@ -98,8 +98,11 @@ local function do_authentication(conf)
   end
 
   -- retrieve our consumer linked to this API key
-  local credential = cache.get_or_set(cache.keyauth_credential_key(key),
+  local credential, err = cache.get_or_set(cache.keyauth_credential_key(key),
                                       nil, load_credential, key)
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
 
   -- no credential in DB, for this key, it is invalid, HTTP 403
   if not credential then
@@ -111,8 +114,11 @@ local function do_authentication(conf)
   -----------------------------------------
 
   -- retrieve the consumer linked to this API key, to set appropriate headers
-  local consumer = cache.get_or_set(cache.consumer_key(credential.consumer_id),
+  local consumer, err = cache.get_or_set(cache.consumer_key(credential.consumer_id),
                                     nil, load_consumer, credential.consumer_id)
+  if err then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
 
   set_consumer(consumer, credential)
 

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -42,7 +42,7 @@ local function ldap_authenticate(given_username, given_password, conf)
   ok, err = sock:connect(conf.ldap_host, conf.ldap_port)
   if not ok then
     ngx_log(ngx_error, "[ldap-auth] failed to connect to "..conf.ldap_host..":"..tostring(conf.ldap_port)..": ", err)
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err, responses.status_codes.HTTP_INTERNAL_SERVER_ERROR
   end
 
   if conf.start_tls then
@@ -68,7 +68,8 @@ end
 local function load_credential(given_username, given_password, conf)
   ngx_log(ngx_debug, "[ldap-auth] authenticating user against LDAP server: "..conf.ldap_host..":"..conf.ldap_port)
 
-  local ok, err = ldap_authenticate(given_username, given_password, conf)
+  local ok, err, status = ldap_authenticate(given_username, given_password, conf)
+  if status ~= nil then return nil, err, status end
   if err ~= nil then ngx_log(ngx_error, err) end
   if not ok then
     return nil
@@ -82,8 +83,9 @@ local function authenticate(conf, given_credentials)
     return false
   end
 
-  local credential = cache.get_or_set(cache.ldap_credential_key(ngx.ctx.api.id, given_username), 
+  local credential, err, status = cache.get_or_set(cache.ldap_credential_key(ngx.ctx.api.id, given_username), 
       conf.cache_ttl, load_credential, given_username, given_password, conf)
+  if status then responses.send(status, err) end
 
   return credential and credential.password == given_password, credential
 end
@@ -94,7 +96,7 @@ local function load_consumer(consumer_id, anonymous)
     if anonymous and not err then
       err = 'anonymous consumer "'..consumer_id..'" not found'
     end
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return nil, err
   end
   return result
 end
@@ -151,8 +153,11 @@ function _M.execute(conf)
   if not ok then
     if conf.anonymous ~= "" then
       -- get anonymous user
-      local consumer = cache.get_or_set(cache.consumer_key(conf.anonymous),
+      local consumer, err = cache.get_or_set(cache.consumer_key(conf.anonymous),
                        nil, load_consumer, conf.anonymous, true)
+      if err then
+        responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      end
       set_consumer(consumer, nil)
     else
       return responses.send(err.status, err.message)

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -57,6 +57,13 @@ _M.split = split
 -- @function strip
 _M.strip = strip
 
+--- packs a set of arguments in a table.
+-- Explicitly sets field `n` to the number of arguments, so it is `nil` safe
+_M.pack = function(...) return {n = select("#", ...), ...} end
+
+--- unpacks a table to a list of arguments.
+-- Explicitly honors the `n` field if given in the table, so it is `nil` safe
+_M.unpack = function(t, i, j) return unpack(t, i or 1, j or t.n or #t) end
 
 --- Retrieves the hostname of the local machine
 -- @return string  The hostname

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -486,4 +486,32 @@ describe("Utils", function()
       end
     end
   end)
+  it("pack() stores results, including nils, properly", function()
+    assert.same({ n = 0 }, utils.pack())
+    assert.same({ n = 1 }, utils.pack(nil))
+    assert.same({ n = 3, "1", "2", "3" }, utils.pack("1", "2", "3"))
+    assert.same({ n = 3, [1] = "1", [3] = "3" }, utils.pack("1", nil, "3"))
+  end)
+  it("unpack() unwraps results, including nils, properly", function()
+    local a,b,c
+    a,b,c = utils.unpack({})
+    assert.is_nil(a)
+    assert.is_nil(b)
+    assert.is_nil(c)
+
+    a,b,c = unpack({ n = 1 })
+    assert.is_nil(a)
+    assert.is_nil(b)
+    assert.is_nil(c)
+
+    a,b,c = utils.unpack({ n = 3, "1", "2", "3" })
+    assert.equal("1", a)
+    assert.equal("2", b)
+    assert.equal("3", c)
+
+    a,b,c = utils.unpack({ n = 3, [1] = "1", [3] = "3" })
+    assert.equal("1", a)
+    assert.is_nil(b)
+    assert.equal("3", c)
+  end)
 end)

--- a/spec/01-unit/11-database_cache_spec.lua
+++ b/spec/01-unit/11-database_cache_spec.lua
@@ -107,5 +107,32 @@ describe("Database cache", function()
       -- verify
       assert.is.Nil(cache.get(key))
     end)
+
+    it("get_or_set only returns a single value on success", function()
+      local cb = function() return 1,2,3,4 end
+      local a,b,c,d = cache.get_or_set("just some key", nil, cb)
+      assert.equal(1, a)
+      assert.is_nil(b)
+      assert.is_nil(c)
+      assert.is_nil(d)
+
+      -- try again, while retrieving the cached value
+      local cb = function() return "result",2,3,4 end
+      local a,b,c,d = cache.get_or_set("just some key", nil, cb)
+      assert.equal(1, a)  -- still 1, cached value
+      assert.is_nil(b)
+      assert.is_nil(c)
+      assert.is_nil(d)
+    end)
+
+    it("get_or_set returns all values on failure", function()
+      local cb = function() return nil,2,3,4 end
+      local a,b,c,d = cache.get_or_set("just some other key", nil, cb)
+      assert.is_nil(a)
+      assert.equal(2, b)
+      assert.equal(3, c)
+      assert.equal(4, d)
+    end)
+
   end)
 end)


### PR DESCRIPTION
Main cause is exiting early on error conditions, when the lock has not
yet been released. It occurs both in the `get_or_set` method itself as
well as in the callbacks all over the code base.

### Issues resolved

Fix #2186 
