### PR TITLE
fix(conf) strip/trim specified list values

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -151,6 +151,10 @@ local function check_and_infer(conf)
       -- separated strings to tables (but not when the arr has
       -- only one element)
       value = setmetatable(pl_stringx.split(value, ","), nil) -- remove List mt
+
+      for i = 1, #value do
+        value[i] = pl_stringx.strip(value[i])
+      end
     end
 
     if value == "" then

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -154,6 +154,10 @@ describe("Configuration loader", function()
       assert.is_nil(getmetatable(conf.cassandra_contact_points))
       assert.is_nil(getmetatable(conf.cassandra_data_centers))
     end)
+    it("trims array values", function()
+      local conf = assert(conf_loader("spec/fixtures/to-strip.conf"))
+      assert.same({"dc1:2", "dc2:3", "dc3:4"}, conf.cassandra_data_centers)
+    end)
     it("infer ngx_boolean", function()
       local conf = assert(conf_loader(nil, {
         lua_code_cache = true

--- a/spec/fixtures/to-strip.conf
+++ b/spec/fixtures/to-strip.conf
@@ -6,6 +6,8 @@ pg_ssl = off                     # Toggles client-server TLS connections
 
 dns_resolver = 8.8.8.8
 
+cassandra_data_centers = dc1:2,   dc2:3  , dc3:4
+
 custom_plugins = foobar,hello-world  # Comma-separated list of additional plugins
                                      # this node should load.
                                      # Use this property to load custom plugins


### PR DESCRIPTION
### Summary

Properties like:

    value = a,  b  , c

...used to yield non-trimed values in the resulting array. We now trim such
values when parsing the config file.