### PR TITLE
hotfix(admin-api) disable TLS/1.0

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -145,7 +145,7 @@ server {
     listen ${{ADMIN_LISTEN_SSL}} ssl;
     ssl_certificate ${{ADMIN_SSL_CERT}};
     ssl_certificate_key ${{ADMIN_SSL_CERT_KEY}};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.1 TLSv1.2;
 > end
 
     location / {


### PR DESCRIPTION
### Full changelog

* Also disables `TLS/1.0` on the Admin API
