### PR TITLE
fix(cli): fixes bad error message on missing serf

### DIFF
--- a/kong/cmd/utils/serf_signals.lua
+++ b/kong/cmd/utils/serf_signals.lua
@@ -56,7 +56,8 @@ local function check_serf_bin(kong_config)
 
   if not found then
     return nil, "could not find 'serf' executable. Kong requires version " ..
-                serf_compatible .. " (you can tweak 'serf_path' to your needs)"
+                tostring(serf_compatible) ..
+                " (you can tweak 'serf_path' to your needs)"
   end
 
   return found


### PR DESCRIPTION
generating the error message concatenated a table by omitting a `tostring()` call.

### Issues resolved

Fix #2217  
