### PR TITLE
fix(core) set SNI server name for upstream SSL connections

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -118,6 +118,7 @@ server {
         proxy_pass_header  Server;
         proxy_pass_header  Date;
         proxy_pass         $upstream_scheme://kong_upstream;
+        proxy_ssl_name     $upstream_host;
 
         header_filter_by_lua_block {
             kong.header_filter()


### PR DESCRIPTION
Made sure server name for upstream SSL connections match Host header.

### Summary

Fixes problem when having configured upstream server using https://... where Kong initiates upstream SSL connection using SNI with server name "kong_upstream".
This does not match the "Host: " header forwarded from the incoming request and is seen by most web servers as an error and they won't process such request.

### Full changelog

* Added NGINX [proxy_ssl_name](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_name) directive to nginx-kong.conf template

### Issues resolved

Fix #2129
