### PR TITLE
fix(plugin): adds the 'no-consumer' flag to the ldap plugin schema

### DIFF
--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -9,6 +9,7 @@ local function check_user(anonymous)
 end
 
 return {
+  no_consumer = true,
   fields = {
     ldap_host = {required = true, type = "string"},
     ldap_port = {required = true, type = "number"},


### PR DESCRIPTION
Adds the `no_consumer` flag to the ldap plugin.

### Issues resolved

Fixes #2235 
