### PR TITLE
Fix DAOFactory usage in the migration command

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -28,7 +28,7 @@ end
 
 local function execute(args)
   local conf = assert(conf_loader(args.conf))
-  local dao = assert(DAOFactory.new(conf, conf.plugins))
+  local dao = assert(DAOFactory.new(conf))
 
   if args.command == "up" then
     assert(dao:run_migrations())


### PR DESCRIPTION
**Note: new features are to be opened against next, hotfixes against master.**

### Summary

Migrations will fail during the upgrade process to 0.10.0 with the following error:

```
Error: 
/usr/local/share/lua/5.1/kong/dao/dao.lua:80: attempt to index field 'TYPES' (a nil value)
stack traceback:
        /usr/local/share/lua/5.1/kong/dao/dao.lua:80: in function 'event'
        /usr/local/share/lua/5.1/kong/dao/dao.lua:302: in function 'update'
        /usr/local/share/lua/5.1/kong/dao/migrations/postgres.lua:359: in function 'up'
        /usr/local/share/lua/5.1/kong/dao/factory.lua:232: in function 'migrate'
        /usr/local/share/lua/5.1/kong/dao/factory.lua:288: in function 'run_migrations'
        /usr/local/share/lua/5.1/kong/cmd/migrations.lua:34: in function 'cmd_exec'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:88>
        [C]: in function 'xpcall'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:45>
        /usr/local/bin/kong:5: in function 'file_gen'
        init_worker_by_lua:41: in function <init_worker_by_lua:39>
        [C]: in function 'pcall'
        init_worker_by_lua:48: in function <init_worker_by_lua:46>
```

This is due to the plugins config being passed in as the second argument to the factory instantiation causing it to think there is an event_handler. The DAOFactory parameters were changed a year ago.

### Full changelog

* Removed the old parameter which allowed the migration command to succeed.

### Issues resolved

Fix #XXX