### PR TITLE
fix(ldap-plugin) cannot be applied on a consumer

### DIFF
--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -9,6 +9,7 @@ local function check_user(anonymous)
 end
 
 return {
+  no_consumer = true,
   fields = {
     ldap_host = {required = true, type = "string"},
     ldap_port = {required = true, type = "number"},


### PR DESCRIPTION
### Full changelog

* LDAP Plugin cannot be applied to a specific consumer.

### Issues resolved

Fix #2235
