### PR TITLE
fix(config): align template config file with actual defaults

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -133,7 +133,7 @@
 #pg_host = 127.0.0.1             # The PostgreSQL host to connect to.
 #pg_port = 5432                  # The port to connect to.
 #pg_user = kong                  # The username to authenticate if required.
-#pg_password = kong              # The password to authenticate if required.
+#pg_password =                   # The password to authenticate if required.
 #pg_database = kong              # The database name to connect to.
 
 #pg_ssl = off                    # Toggles client-server TLS connections
@@ -167,7 +167,7 @@
 #cassandra_username = kong       # Username when using the
                                  # `PasswordAuthenticator` scheme.
 
-#cassandra_password = kong       # Password when using the
+#cassandra_password =            # Password when using the
                                  # `PasswordAuthenticator` scheme.
 
 #cassandra_consistency = ONE     # Consistency setting to use when reading/


### PR DESCRIPTION
the actual defaults had no passwords set for neither Cassandra nor Postgres,
yet the template config file had them both set to `kong`.

fixes #2254
