### PR TITLE
Lambda support for us-west-2 #2257

### DIFF
--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -5,7 +5,7 @@ return {
     aws_key = {type = "string", required = true},
     aws_secret = {type = "string", required = true},
     aws_region = {type = "string", required = true, enum = {
-                  "us-east-1", "us-east-2", "ap-northeast-1", "ap-northeast-2", 
+                  "us-east-1", "us-east-2", "ap-northeast-1", "ap-northeast-2", "us-west-2",
                   "ap-southeast-1", "ap-southeast-2", "eu-central-1", "eu-west-1"}},
     function_name = {type="string", required = true},
     qualifier = {type = "string"},


### PR DESCRIPTION
Hello

Lambda plugin is not supported in us-west-2. Is there any specific reason for this limitation.
Will this region be supported in near future.

Thanks

Steps To Reproduce

Create a pi and attach a lambda plugin. In the configuration when i mention us-west-2 i get a error that region is not supported.
Additional Details & Logs

Kong version (0.10.0)
Operating System : Centos