### PR TITLE
test(lambda): add an initial request to prevent timeouts in testing

### DIFF
--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -58,6 +58,19 @@ describe("Plugin: AWS Lambda (access)", function()
     })
 
     assert(helpers.start_kong())
+
+    -- Improve test reliability here: warm up AWS lambda because the first
+    -- invocation will take the most time
+    client = helpers.proxy_client()
+    client:set_timeout(2 * 60 * 1000) -- 2 minute timeout for the warmup
+    local res = assert(client:send {
+      method = "GET",
+      path = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+      headers = {
+        ["Host"] = "lambda.com"
+      }
+    })
+    client:close()
   end)
 
   before_each(function()


### PR DESCRIPTION
The lambda environment needs to warm up, the initial request may be very
slow. This occasionally causes timeouts on the tests, which then fail.
