### PR TITLE
fix(hmac) handle invalid Base64-encoded signatures

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -83,10 +83,6 @@ local function create_hash(request, hmac_params, headers)
 end
 
 local function is_digest_equal(digest_1, digest_2)
-  if #digest_1 ~= #digest_1 then
-    return false
-  end
-
   local result = true
   for i=1, #digest_1 do
     if digest_1:sub(i, i) ~= digest_2:sub(i, i) then
@@ -98,8 +94,15 @@ end
 
 local function validate_signature(request, hmac_params, headers)
   local digest = create_hash(request, hmac_params, headers)
+  local sig = ngx_decode_base64(hmac_params.signature)
+
+  -- we didnt receive a well-formed base64 encoding
+  if not sig then
+    return false
+  end
+
   if digest then
-   return is_digest_equal(digest, ngx_decode_base64(hmac_params.signature))
+   return is_digest_equal(digest, sig)
   end
 end
 

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -108,6 +108,23 @@ describe("Plugin: hmac-auth (access)", function()
       assert.equal(SIGNATURE_NOT_VALID, body.message)
     end)
 
+    it("should not be authorized when the HMAC signature is not properly base64 encoded", function()
+      local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+      local hmacAuth = [["hmac username="bob",algorithm="hmac-sha1",]]
+        ..[[headers="date",signature="not really a base64 encoded value!!!"]]
+      local res  = assert(client:send {
+        method          = "POST",
+        headers         = {
+          ["HOST"]      = "hmacauth.com",
+          date          = date,
+          authorization = hmacAuth
+        }
+      })
+      local body = assert.res_status(403, res)
+      body = cjson.decode(body)
+      assert.equal("HMAC signature does not match", body.message)
+    end)
+
     it("should not be authorized when date header is missing", function()
       local res = assert(client:send {
         method = "POST",


### PR DESCRIPTION
We don't need to try to compare against an empty string.

Additionally, remove the needless length comparison. This was bugged
to begin with, but the length comparison is needless, and doing so
removes the constant time factor from this function.