### PR TITLE
fix(sni) stricter detection and handling of duplicate snis

### DIFF
--- a/kong/dao/schemas/ssl_servers_names.lua
+++ b/kong/dao/schemas/ssl_servers_names.lua
@@ -2,7 +2,7 @@ return {
   table = "ssl_servers_names",
   primary_key = { "name" },
   fields = {
-    name = { type = "text", required = true },
+    name = { type = "text", required = true, unique = true },
     ssl_certificate_id = { type = "id", foreign = "ssl_certificates:id" },
     created_at = {
       type = "timestamp",


### PR DESCRIPTION
Previously, if a duplicate sni was detected as part of the 'snis'
sugar param, we still created the certificate object, as well as
any previously non-existant sni encountered before the conflicting
element. This commit prevents creation of orphan entries by checking
for the existence all posted snis before creating the certificate
and sni objects.

This commit also cleans up the naming schemes for admin API certificate
routes integration tests (no functional change).

Fixes issue #2275, among other behavioral inconsistencies.