### PR TITLE
fix(*) replace os.execute calls with Penlight execute / ngx.sleep

### DIFF
--- a/kong/cmd/utils/kill.lua
+++ b/kong/cmd/utils/kill.lua
@@ -1,4 +1,5 @@
 local pl_path = require "pl.path"
+local pl_utils = require "pl.utils"
 local log = require "kong.cmd.utils.log"
 
 local cmd_tmpl = [[kill %s `cat %s` >/dev/null 2>&1]]
@@ -8,7 +9,8 @@ local function kill(pid_file, args)
   local cmd = string.format(cmd_tmpl, args or "-0", pid_file)
   if pl_path.exists(pid_file) then
     log.debug(cmd)
-    return os.execute(cmd)
+    local _, code = pl_utils.execute(cmd)
+    return code
   else
     log.debug("no pid file at: %s", pid_file)
     return 0

--- a/spec/02-integration/03-admin_api/06-cluster_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/06-cluster_routes_spec.lua
@@ -21,7 +21,7 @@ describe("Admin API", function()
     describe("GET", function()
       it("retrieves the members list", function()
         -- old test converted
-        --os.execute("sleep 2") -- Let's wait for serf to register the node
+        --ngx.sleep(2) -- Let's wait for serf to register the node
         local res = assert(client:send {
           method = "GET",
           path = "/cluster"

--- a/spec/02-integration/04-core/02-hooks_spec.lua
+++ b/spec/02-integration/04-core/02-hooks_spec.lua
@@ -106,7 +106,7 @@ describe("Core Hooks", function()
         })
         local entry = cjson.decode(assert.res_status(200, res))
         assert.same(DB_MISS_SENTINEL, entry)  -- db-miss sentinel value
-        
+
         -- Add plugin
         local res = assert(api_client:send {
           method = "POST",
@@ -732,7 +732,10 @@ describe("Core Hooks", function()
 
       local function kill(pid_file, args)
         local cmd = string.format([[kill %s `cat %s` >/dev/null 2>&1]], args or "-0", pid_file)
-        return os.execute(cmd)
+        local ok, code = pl_utils.execute(cmd)
+        if ok then
+          return code
+        end
       end
 
       local function is_running(pid_path)
@@ -782,7 +785,7 @@ describe("Core Hooks", function()
       end
 
       local function stop_serf()
-        os.execute(string.format("kill `cat %s` >/dev/null 2>&1", PID_FILE))
+        pl_utils.execute(string.format("kill `cat %s` >/dev/null 2>&1", PID_FILE))
       end
 
       it("should synchronize nodes on members events", function()

--- a/spec/03-plugins/09-galileo/ngx.lua
+++ b/spec/03-plugins/09-galileo/ngx.lua
@@ -1,3 +1,6 @@
+local pl_utils = require "pl.utils"
+
+
 -- test fixtures. we have to load them before requiring the
 -- ALF serializer, since it caches those functions at the
 -- module chunk level.
@@ -50,7 +53,7 @@ Accept: application/json\r
     return t
   end,
   sleep = function(t)
-    os.execute("sleep " .. t/1000)
+    pl_utils.execute("sleep " .. t/1000)
   end,
   timer = {
     at = function() end

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -14,7 +14,7 @@ local function wait(second_offset)
   -- of the current minute is > 30, then we wait till the new minute kicks in
   local current_second = timestamp.get_timetable().sec
   if current_second > (second_offset or 0) then
-    os.execute("sleep "..tostring(60 - current_second))
+    ngx.sleep(60 - current_second)
   end
 end
 

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -15,7 +15,7 @@ local function wait(second_offset)
   -- of the current minute is > 30, then we wait till the new minute kicks in
   local current_second = timestamp.get_timetable().sec
   if current_second > (second_offset or 0) then
-    os.execute("sleep "..tostring(60 - current_second))
+    ngx.sleep(60 - current_second)
   end
 end
 


### PR DESCRIPTION
### Summary

Right now we suggest compiling OpenResty with `--without-luajit-lua52` (or LuaJIT without `-DLUAJIT_ENABLE_LUA52COMPAT`). All the official OpenResty packages compile LuaJIT with Lua 5.2 compatibility, and we should follow the suit.

Also it looks like some of the tests were using `os.execute("sleep ...")` instead of `ngx.sleep(...)`. This pull-request fixes that as well.
