### PR TITLE
feat(admin) targets can be deleted by their ID

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -59,6 +59,25 @@ function _M.find_upstream_by_name_or_id(self, dao_factory, helpers)
   end
 end
 
+function _M.find_target_by_target_or_id(self, dao_factory, helpers)
+  local filter_keys = {
+    upstream_id = self.upstream.id,
+    [utils.is_valid_uuid(self.params.target_or_id) and "id" or "target"] = self.params.target_or_id
+  }
+  self.params.target_or_id = nil
+
+  local rows, err = dao_factory.targets:find_all(filter_keys)
+  if err then
+    return helpers.yield_error(err)
+  end
+
+  -- We know target and id are unique, so if we have a row, it must be the only one
+  self.target = rows[1]
+  if not self.target then
+    return helpers.responses.send_HTTP_NOT_FOUND()
+  end
+end
+
 function _M.paginated_set(self, dao_collection)
   local size = self.params.size and tonumber(self.params.size) or 100
   local offset = self.params.offset and ngx.decode_base64(self.params.offset)

--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -59,6 +59,8 @@ function _M.find_upstream_by_name_or_id(self, dao_factory, helpers)
   end
 end
 
+-- this function will return the exact target if specified by `id`, or just
+-- 'any target entry' if specified by target (= 'hostname:port')
 function _M.find_target_by_target_or_id(self, dao_factory, helpers)
   local filter_keys = {
     upstream_id = self.upstream.id,
@@ -71,7 +73,9 @@ function _M.find_target_by_target_or_id(self, dao_factory, helpers)
     return helpers.yield_error(err)
   end
 
-  -- We know target and id are unique, so if we have a row, it must be the only one
+  -- if looked up by `target` property we can have multiple targets here, but
+  -- anyone will do as they all have the same 'target' field, so just pick
+  -- the first
   self.target = rows[1]
   if not self.target then
     return helpers.responses.send_HTTP_NOT_FOUND()

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -167,9 +167,10 @@ return {
     end
   },
 
-  ["/upstreams/:name_or_id/targets/:target"] = {
+  ["/upstreams/:name_or_id/targets/:target_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_upstream_by_name_or_id(self, dao_factory, helpers)
+      crud.find_target_by_target_or_id(self, dao_factory, helpers)
     end,
 
     DELETE = function(self, dao_factory)
@@ -177,7 +178,7 @@ return {
 
       -- this is just a wrapper around POSTing a new target with weight=0
       local data, err = dao_factory.targets:insert({
-        target      = self.params.target,
+        target      = self.target.target,
         upstream_id = self.upstream.id,
         weight      = 0,
       })

--- a/spec/02-integration/03-admin_api/09-targets_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/09-targets_routes_spec.lua
@@ -345,10 +345,37 @@ describe("Admin API", function()
         })
       end)
 
-      it("acts as a sugar method to POST a target with 0 weight", function()
+      it("acts as a sugar method to POST a target with 0 weight (by target)", function()
         local res = assert(client:send {
           method = "DELETE",
           path = "/upstreams/" .. upstream_name4 .. "/targets/" .. target.target
+        })
+        assert.response(res).has.status(204)
+
+        local targets = assert(client:send {
+          method = "GET",
+          path = "/upstreams/" .. upstream_name4 .. "/targets/",
+        })
+        assert.response(targets).has.status(200)
+        local json = assert.response(targets).has.jsonbody()
+        assert.equal(3, #json.data)
+        assert.equal(3, json.total)
+
+        local active = assert(client:send {
+          method = "GET",
+          path = "/upstreams/" .. upstream_name4 .. "/targets/active/",
+        })
+        assert.response(active).has.status(200)
+        json = assert.response(active).has.jsonbody()
+        assert.equal(1, #json.data)
+        assert.equal(1, json.total)
+        assert.equal("api-1:80", json.data[1].target)
+      end)
+
+      it("acts as a sugar method to POST a target with 0 weight (by id)", function()
+        local res = assert(client:send {
+          method = "DELETE",
+          path = "/upstreams/" .. upstream_name4 .. "/targets/" .. target.id
         })
         assert.response(res).has.status(204)
 


### PR DESCRIPTION
### Full changelog

* Extends the sugar `DELETE` method for upstream targets, allowing them to be deleted by `id` as well.
