### PR TITLE
fix(router) fix trailing slash getting automatically appended

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -1,25 +1,25 @@
 local lrucache = require "resty.lrucache"
-local url = require "socket.url"
-local bit = require "bit"
+local url      = require "socket.url"
+local bit      = require "bit"
 
 
 local re_match = ngx.re.match
-local re_find = ngx.re.find
-local re_sub = ngx.re.sub
-local insert = table.insert
-local upper = string.upper
-local lower = string.lower
-local find = string.find
-local fmt = string.format
-local sub = string.sub
+local re_find  = ngx.re.find
+local re_sub   = ngx.re.sub
+local insert   = table.insert
+local upper    = string.upper
+local lower    = string.lower
+local find     = string.find
+local fmt      = string.format
+local sub      = string.sub
 local tonumber = tonumber
-local ipairs = ipairs
-local pairs = pairs
-local type = type
-local next = next
-local band = bit.band
-local bor = bit.bor
-local ERR = ngx.ERR
+local ipairs   = ipairs
+local pairs    = pairs
+local type     = type
+local next     = next
+local band     = bit.band
+local bor      = bit.bor
+local ERR      = ngx.ERR
 local new_tab
 local log
 
@@ -51,13 +51,13 @@ local MATCH_RULES = {
 }
 
 local CATEGORIES = {
-  bor(MATCH_RULES.HOST, MATCH_RULES.URI, MATCH_RULES.METHOD),
-  bor(MATCH_RULES.HOST, MATCH_RULES.URI),
-  bor(MATCH_RULES.HOST, MATCH_RULES.METHOD),
+  bor(MATCH_RULES.HOST,   MATCH_RULES.URI,     MATCH_RULES.METHOD),
+  bor(MATCH_RULES.HOST,   MATCH_RULES.URI),
+  bor(MATCH_RULES.HOST,   MATCH_RULES.METHOD),
   bor(MATCH_RULES.METHOD, MATCH_RULES.URI),
-  MATCH_RULES.HOST,
-  MATCH_RULES.URI,
-  MATCH_RULES.METHOD,
+      MATCH_RULES.HOST,
+      MATCH_RULES.URI,
+      MATCH_RULES.METHOD,
 }
 
 local categories_len = #CATEGORIES
@@ -116,8 +116,8 @@ local function marshall_api(api)
       for _, host_value in ipairs(host_values) do
         if find(host_value, "*", nil, true) then
           -- wildcard host matching
-          local wildcard_host_regex = "^" .. host_value:gsub("%.", "\\.")
-                                                       :gsub("%*", ".+") .. "$"
+          local wildcard_host_regex = host_value:gsub("%.", "\\.")
+                                                :gsub("%*", ".+") .. "$"
           insert(api_t.wildcard_hosts, {
             value = host_value,
             regex = wildcard_host_regex
@@ -144,15 +144,15 @@ local function marshall_api(api)
       api_t.uris_prefix_regexes = new_tab(#api.uris, 0)
 
       for i, uri in ipairs(api.uris) do
-        local escaped_uri = uri:gsub("/", "\\/")
-        local strip_regex = "^" .. escaped_uri .. "\\/?(.*)"
+        local escaped_uri = [[\Q]] .. uri .. [[\E]]
+        local strip_regex = escaped_uri .. [[\/?(.*)]]
 
         api_t.uris[uri] = {
           strip_regex = strip_regex,
         }
 
         api_t.uris_prefixes_regexes[i] = {
-          regex = "^" .. escaped_uri,
+          regex       = escaped_uri,
           strip_regex = strip_regex,
         }
       end
@@ -189,8 +189,13 @@ local function marshall_api(api)
       scheme       = parsed.scheme,
       host         = parsed.host,
       port         = tonumber(parsed.port),
-      path         = parsed.path,
     }
+
+    if parsed.path then
+      api_t.upstream.path = parsed.path
+      api_t.upstream.file = sub(parsed.path, -1) == "/" and parsed.path ~= "/" and
+                            sub(parsed.path,  1, -2)     or parsed.path
+    end
 
     if not api_t.upstream.port then
       if parsed.scheme == "https" then
@@ -467,7 +472,7 @@ function _M.new(apis)
 
     if host then
       -- strip port number if given
-      local m, err = re_match(host, "^([^:]+)", "jo")
+      local m, err = re_match(host, "([^:]+)", "ajo")
       if not m then
         log(ERR, "could not strip port from Host header: ", err)
       end
@@ -496,7 +501,7 @@ function _M.new(apis)
 
       elseif host then
         for i = 1, #wildcard_hosts do
-          local m, err = re_match(host, wildcard_hosts[i].regex, "jo")
+          local m, err = re_match(host, wildcard_hosts[i].regex, "ajo")
           if err then
             log(ERR, "could not match wildcard host: ", err)
             return
@@ -516,7 +521,7 @@ function _M.new(apis)
 
       else
         for i = 1, #uris_prefixes do
-          local from, _, err = re_find(uri, uris_prefixes[i].regex, "jo")
+          local from, _, err = re_find(uri, uris_prefixes[i].regex, "ajo")
           if err then
             log(ERR, "could not search for URI prefix: ", err)
             return
@@ -570,9 +575,10 @@ function _M.new(apis)
 
 
   function self.exec(ngx)
-    local method = ngx.req.get_method()
-    local uri = ngx.var.uri
-    local new_uri = uri
+    local method      = ngx.req.get_method()
+    local uri         = ngx.var.uri
+    local uri_root    = uri == "/"
+    local new_uri     = uri
     local host_header
     local req_host
 
@@ -591,9 +597,9 @@ function _M.new(apis)
     end
 
 
-    if api_t.strip_uri_regex then
+    if not uri_root and api_t.strip_uri_regex then
       local err
-      new_uri, err = re_sub(uri, api_t.strip_uri_regex, "/$1", "jo")
+      new_uri, err = re_sub(uri, api_t.strip_uri_regex, "/$1", "ajo")
       if not new_uri then
         log(ERR, "could not strip URI: ", err)
         return
@@ -601,25 +607,29 @@ function _M.new(apis)
     end
 
 
-    local upstream_path = api_t.upstream.path
-    if upstream_path then
-      if new_uri == "/" then
-        new_uri = upstream_path
+    local upstream = api_t.upstream
+    if upstream.path and upstream.path ~= "/" then
+      if new_uri ~= "/" then
+        new_uri = upstream.file .. new_uri
 
       else
-        new_uri = upstream_path .. (sub(upstream_path, -1) == "/" and sub(new_uri, 2) or new_uri)
+        if upstream.path ~= upstream.file then
+          if uri_root or sub(uri, -1) == "/" then
+            new_uri = upstream.path
+
+          else
+            new_uri = upstream.file
+          end
+
+        else
+          if uri_root or sub(uri, -1) ~= "/" then
+            new_uri = upstream.file
+
+          else
+            new_uri = upstream.file .. new_uri
+          end
+        end
       end
-    end
-
-
-    local req_uri_slash = sub(uri,     -1) == "/"
-    local new_uri_slash = sub(new_uri, -1) == "/"
-
-    if new_uri_slash and not req_uri_slash and new_uri ~= "/" then
-      new_uri = sub(new_uri, 1, -2)
-
-    elseif not new_uri_slash and req_uri_slash and uri ~= "/" then
-      new_uri = new_uri .. "/"
     end
 
 

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -11,6 +11,7 @@ local upper = string.upper
 local lower = string.lower
 local find = string.find
 local fmt = string.format
+local sub = string.sub
 local tonumber = tonumber
 local ipairs = ipairs
 local pairs = pairs
@@ -600,8 +601,25 @@ function _M.new(apis)
     end
 
 
-    if api_t.upstream.path then
-      new_uri = api_t.upstream.path .. new_uri
+    local upstream_path = api_t.upstream.path
+    if upstream_path then
+      if new_uri == "/" then
+        new_uri = upstream_path
+
+      else
+        new_uri = upstream_path .. (sub(upstream_path, -1) == "/" and sub(new_uri, 2) or new_uri)
+      end
+    end
+
+
+    local req_uri_slash = sub(uri,     -1) == "/"
+    local new_uri_slash = sub(new_uri, -1) == "/"
+
+    if new_uri_slash and not req_uri_slash and new_uri ~= "/" then
+      new_uri = sub(new_uri, 1, -2)
+
+    elseif not new_uri_slash and req_uri_slash and uri ~= "/" then
+      new_uri = new_uri .. "/"
     end
 
 

--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -14,10 +14,6 @@ local function validate_upstream_url(value)
     end
   end
 
-  if parsed_url.path and string.sub(value, #value) == "/" then
-    return false, "Cannot end with a slash"
-  end
-
   return true
 end
 

--- a/spec/01-unit/07-entities_schemas_spec.lua
+++ b/spec/01-unit/07-entities_schemas_spec.lua
@@ -78,15 +78,14 @@ describe("Entities Schemas", function()
         assert.equal("Supported protocols are HTTP and HTTPS", errors.upstream_url)
       end)
 
-      it("should return error with final slash in upstream_url", function()
+      it("should not return error with final slash in upstream_url", function()
         local valid, errors = validate_entity({
           name = "mockbin",
           upstream_url = "http://mockbin.com/",
           hosts = { "mockbin.com" },
         }, api_schema)
-        assert.is_false(valid)
-        assert.equal("Cannot end with a slash", errors.upstream_url)
-
+        assert.is_nil(errors)
+        assert.is_true(valid)
       end)
 
       it("should validate with upper case protocol", function()

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -899,39 +899,52 @@ describe("Router", function()
 
     describe("trailing slash", function()
       local checks = {
-        -- upstream url    request path    expected path           strip uri
-        {  "/",            "/",            "/",                    true      },
-        {  "/",            "/foo/bar",     "/",                    true      },
-        {  "/",            "/foo/bar/",    "/",                    true      },
-        {  "/foo/bar",     "/",            "/foo/bar",             true      },
-        {  "/foo/bar/",    "/",            "/foo/bar/",            true      },
-        {  "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
-        {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             true      },
-        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            true      },
-        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
-        {  "/",            "/",            "/",                    false     },
-        {  "/",            "/foo/bar",     "/foo/bar",             false     },
-        {  "/",            "/foo/bar/",    "/foo/bar/",            false     },
-        {  "/foo/bar",     "/",            "/foo/bar",             false     },
-        {  "/foo/bar/",    "/",            "/foo/bar/",            false     },
-        {  "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
-        {  "/foo/bar/",    "/foo/bar",     "/foo/bar/foo/bar",     false     },
-        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
-        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+        -- upstream url    uris            request path    expected path           strip uri
+        {  "/",            "/",            "/",            "/",                    true      },
+        {  "/",            "/",            "/foo/bar",     "/foo/bar",             true      },
+        {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            true      },
+        {  "/",            "/foo/bar",     "/foo/bar",     "/",                    true      },
+        {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    true      },
+        {  "/foo/bar",     "/",            "/",            "/foo/bar",             true      },
+        {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
+        {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
+        {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+        {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            true      },
+        {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
+        {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
+        {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+        {  "/",            "/",            "/",            "/",                    false     },
+        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     },
+        {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
+        {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
+        {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
+        {  "/foo/bar",     "/",            "/",            "/foo/bar",             false     },
+        {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+        {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+        {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            false     },
+        {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+        {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
       }
 
       for i, args in ipairs(checks) do
 
-        local config = args[4] == true and "(strip_uri = on) " or "(strip_uri = off)"
-        local space  = string.sub(args[1], -1) == "/" and "" or " "
+        local config = args[5] == true and "(strip_uri = on)" or "(strip_uri = off)"
 
-        it(config .. " is not appended to upstream uri " .. args[1] ..
-            space .. " when requesting "                 .. args[2], function()
+        it(config .. " is not appended to upstream url " .. args[1] ..
+                     " (with uri "                       .. args[2] .. ")" ..
+                     " when requesting "                 .. args[3], function()
+
 
           local use_case_apis = {
             {
               name         = "api-1",
-              strip_uri    = args[4],
+              strip_uri    = args[5],
               upstream_url = "http://httpbin.org" .. args[1],
               uris         = {
                 args[2],
@@ -941,11 +954,11 @@ describe("Router", function()
 
           local router = assert(Router.new(use_case_apis) )
 
-          local _ngx = mock_ngx("GET", args[2], {})
+          local _ngx = mock_ngx("GET", args[3], {})
           local api, upstream = router.exec(_ngx)
           assert.same(use_case_apis[1], api)
           assert.equal(args[1], upstream.path)
-          assert.equal(args[3], _ngx.var.uri)
+          assert.equal(args[4], _ngx.var.uri)
         end)
       end
     end)

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -896,5 +896,58 @@ describe("Router", function()
         end)
       end)
     end)
+
+    describe("trailing slash", function()
+      local checks = {
+        -- upstream url    request path    expected path           strip uri
+        {  "/",            "/",            "/",                    true      },
+        {  "/",            "/foo/bar",     "/",                    true      },
+        {  "/",            "/foo/bar/",    "/",                    true      },
+        {  "/foo/bar",     "/",            "/foo/bar",             true      },
+        {  "/foo/bar/",    "/",            "/foo/bar/",            true      },
+        {  "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+        {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             true      },
+        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            true      },
+        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+        {  "/",            "/",            "/",                    false     },
+        {  "/",            "/foo/bar",     "/foo/bar",             false     },
+        {  "/",            "/foo/bar/",    "/foo/bar/",            false     },
+        {  "/foo/bar",     "/",            "/foo/bar",             false     },
+        {  "/foo/bar/",    "/",            "/foo/bar/",            false     },
+        {  "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar/",    "/foo/bar",     "/foo/bar/foo/bar",     false     },
+        {  "/foo/bar",     "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+        {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      }
+
+      for i, args in ipairs(checks) do
+
+        local config = args[4] == true and "(strip_uri = on) " or "(strip_uri = off)"
+        local space  = string.sub(args[1], -1) == "/" and "" or " "
+
+        it(config .. " is not appended to upstream uri " .. args[1] ..
+            space .. " when requesting "                 .. args[2], function()
+
+          local use_case_apis = {
+            {
+              name         = "api-1",
+              strip_uri    = args[4],
+              upstream_url = "http://httpbin.org" .. args[1],
+              uris         = {
+                args[2],
+              },
+            }
+          }
+
+          local router = assert(Router.new(use_case_apis) )
+
+          local _ngx = mock_ngx("GET", args[2], {})
+          local api, upstream = router.exec(_ngx)
+          assert.same(use_case_apis[1], api)
+          assert.equal(args[1], upstream.path)
+          assert.equal(args[3], _ngx.var.uri)
+        end)
+      end
+    end)
   end)
 end)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -387,4 +387,98 @@ describe("Router", function()
       assert.equal("fixture-api", res.headers["kong-api-name"])
     end)
   end)
+
+  describe("trailing slash", function()
+    local checks = {
+      -- upstream url    request path    expected path           strip uri
+      {  "/",            "/",            "/",                    nil       },
+      {  "/",            "/foo/bar",     "/",                    nil       },
+      {  "/",            "/foo/bar/",    "/",                    nil       },
+      {  "/foo/bar",     "/",            "/foo/bar",             nil       },
+      {  "/foo/bar/",    "/",            "/foo/bar/",            nil       },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             nil       },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/",            "/",            "/",                    true      },
+      {  "/",            "/foo/bar",     "/",                    true      },
+      {  "/",            "/foo/bar/",    "/",                    true      },
+      {  "/foo/bar",     "/",            "/foo/bar",             true      },
+      {  "/foo/bar/",    "/",            "/foo/bar/",            true      },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             true      },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/",            "/",            "/",                    false     },
+      {  "/",            "/foo/bar",     "/foo/bar",             false     },
+      {  "/",            "/foo/bar/",    "/foo/bar/",            false     },
+      {  "/foo/bar",     "/",            "/foo/bar",             false     },
+      {  "/foo/bar/",    "/",            "/foo/bar/",            false     },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+    }
+
+    setup(function()
+      helpers.dao:truncate_tables()
+
+      for i, args in ipairs(checks) do
+        assert(helpers.dao.apis:insert {
+            name         = "localbin-" .. i,
+            strip_uri    = args[4],
+            upstream_url = "http://localhost:9999" .. args[1],
+            hosts        = {
+              "localbin-" .. i .. ".com",
+            },
+            uris         = {
+              args[2],
+            }
+        })
+      end
+
+      assert(helpers.start_kong {
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      })
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    local function check(i, request_uri, expected_uri)
+      return function()
+        local res = assert(client:send {
+          method  = "GET",
+          path    = request_uri,
+          headers = {
+            ["Host"] = "localbin-" .. i .. ".com",
+          }
+        })
+
+        local json = assert.res_status(200, res)
+        local data = cjson.decode(json)
+
+        assert.equal(expected_uri, data.vars.request_uri)
+      end
+    end
+
+    for i, args in ipairs(checks) do
+
+      local config = "(strip_uri = n/a)"
+
+      if args[4] == true then
+        config = "(strip_uri = on) "
+
+      elseif args[4] == false then
+        config = "(strip_uri = off)"
+      end
+
+      local space = string.sub(args[1], -1) == "/" and "" or " "
+
+      it(config .. " is not appended to upstream uri " .. args[1] ..
+          space .. " when requesting "                 .. args[2],
+        check(i, args[2], args[3]))
+    end
+  end)
 end)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -390,34 +390,52 @@ describe("Router", function()
 
   describe("trailing slash", function()
     local checks = {
-      -- upstream url    request path    expected path           strip uri
-      {  "/",            "/",            "/",                    nil       },
-      {  "/",            "/foo/bar",     "/",                    nil       },
-      {  "/",            "/foo/bar/",    "/",                    nil       },
-      {  "/foo/bar",     "/",            "/foo/bar",             nil       },
-      {  "/foo/bar/",    "/",            "/foo/bar/",            nil       },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             nil       },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            nil       },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
-      {  "/",            "/",            "/",                    true      },
-      {  "/",            "/foo/bar",     "/",                    true      },
-      {  "/",            "/foo/bar/",    "/",                    true      },
-      {  "/foo/bar",     "/",            "/foo/bar",             true      },
-      {  "/foo/bar/",    "/",            "/foo/bar/",            true      },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",             true      },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",            true      },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
-      {  "/",            "/",            "/",                    false     },
-      {  "/",            "/foo/bar",     "/foo/bar",             false     },
-      {  "/",            "/foo/bar/",    "/foo/bar/",            false     },
-      {  "/foo/bar",     "/",            "/foo/bar",             false     },
-      {  "/foo/bar/",    "/",            "/foo/bar/",            false     },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      -- upstream url    uris            request path    expected path           strip uri
+      {  "/",            "/",            "/",            "/",                    nil       },
+      {  "/",            "/",            "/foo/bar",     "/foo/bar",             nil       },
+      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/",            "/foo/bar",     "/foo/bar",     "/",                    nil       },
+      {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    nil       },
+      {  "/foo/bar",     "/",            "/",            "/foo/bar",             nil       },
+      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     nil       },
+      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    nil       },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            nil       },
+      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     nil       },
+      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    nil       },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/",            "/",            "/",            "/",                    true      },
+      {  "/",            "/",            "/foo/bar",     "/foo/bar",             true      },
+      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/",            "/foo/bar",     "/foo/bar",     "/",                    true      },
+      {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    true      },
+      {  "/foo/bar",     "/",            "/",            "/foo/bar",             true      },
+      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
+      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            true      },
+      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
+      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/",            "/",            "/",            "/",                    false     },
+      {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     },
+      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
+      {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
+      {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
+      {  "/foo/bar",     "/",            "/",            "/foo/bar",             false     },
+      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            false     },
+      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
+      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
     }
 
     setup(function()
@@ -426,14 +444,14 @@ describe("Router", function()
       for i, args in ipairs(checks) do
         assert(helpers.dao.apis:insert {
             name         = "localbin-" .. i,
-            strip_uri    = args[4],
+            strip_uri    = args[5],
             upstream_url = "http://localhost:9999" .. args[1],
+            uris         = {
+              args[2],
+            },
             hosts        = {
               "localbin-" .. i .. ".com",
             },
-            uris         = {
-              args[2],
-            }
         })
       end
 
@@ -467,18 +485,17 @@ describe("Router", function()
 
       local config = "(strip_uri = n/a)"
 
-      if args[4] == true then
+      if args[5] == true then
         config = "(strip_uri = on) "
 
-      elseif args[4] == false then
+      elseif args[5] == false then
         config = "(strip_uri = off)"
       end
 
-      local space = string.sub(args[1], -1) == "/" and "" or " "
-
-      it(config .. " is not appended to upstream uri " .. args[1] ..
-          space .. " when requesting "                 .. args[2],
-        check(i, args[2], args[3]))
+      it(config .. " is not appended to upstream url " .. args[1] ..
+                   " (with uri "                       .. args[2] .. ")" ..
+                   " when requesting "                 .. args[3],
+        check(i, args[3], args[4]))
     end
   end)
 end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -193,6 +193,51 @@ http {
             return 200;
         }
 
+        location / {
+            content_by_lua_block {
+                local cjson = require "cjson"
+                local var   = ngx.var
+                local req   = ngx.req
+
+                req.read_body()
+
+                local json = cjson.encode {
+                    vars = {
+                        uri                = var.uri,
+                        host               = var.host,
+                        hostname           = var.hostname,
+                        https              = var.https,
+                        scheme             = var.scheme,
+                        is_args            = var.is_args,
+                        server_addr        = var.server_addr,
+                        server_port        = var.server_port,
+                        server_name        = var.server_name,
+                        server_protocol    = var.server_protocol,
+                        remote_addr        = var.remote_addr,
+                        remote_port        = var.remote_port,
+                        realip_remote_addr = var.realip_remote_addr,
+                        realip_remote_port = var.realip_remote_port,
+                        binary_remote_addr = var.binary_remote_addr,
+                        request            = var.request,
+                        request_uri        = var.request_uri,
+                        request_time       = var.request_time,
+                        request_length     = var.request_length,
+                        request_method     = var.request_method,
+                        bytes_received     = var.bytes_received,
+                    },
+                    method       = req.get_method(),
+                    headers      = req.get_headers(0),
+                    uri_args     = req.get_uri_args(0),
+                    post_args    = req.get_post_args(0),
+                    http_version = req.http_version(),
+                }
+
+                ngx.status = 200
+                ngx.say(json)
+                ngx.exit(200)
+            }
+        }
+
         location /headers-inspect {
             content_by_lua_block {
                 local cjson = require "cjson"


### PR DESCRIPTION
### Summary

Trailing slashes get automatically appended to proxied uris and sometimes double (`//`) slashes. This PR is meant to follow the original request uri semantics regarding the trailing slash, and forward it as is the proxied service. Making the proxying more transparent.

Revert some of the changes introduced in #2115.

### Issues resolved

Fix: #2211
