### PR TITLE
fix(conf) the "user" directive makes sense only if the master process runs with super-user privileges

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -383,6 +383,14 @@ local function load(path, custom_conf)
     setmetatable(conf.plugins, nil) -- remove Map mt
   end
 
+  -- nginx user directive
+  do
+    local user = conf.nginx_user:gsub("^%s*", ""):gsub("%s$", ""):gsub("%s+", " ")
+    if user == "nobody" or user == "nobody nobody" then
+      conf.nginx_user = nil
+    end
+  end
+
   -- extract ports/listen ips
   do
     local ip_port_pat = "(.+):([%d]+)$"

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -1,5 +1,7 @@
 return [[
+> if nginx_user then
 user ${{NGINX_USER}};
+> end
 worker_processes ${{NGINX_WORKER_PROCESSES}};
 daemon ${{NGINX_DAEMON}};
 

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -5,7 +5,7 @@ describe("Configuration loader", function()
   it("loads the defaults", function()
     local conf = assert(conf_loader())
     assert.is_string(conf.lua_package_path)
-    assert.equal("nobody nobody", conf.nginx_user)
+    assert.is_nil(conf.nginx_user)
     assert.equal("auto", conf.nginx_worker_processes)
     assert.equal("0.0.0.0:8001", conf.admin_listen)
     assert.equal("0.0.0.0:8000", conf.proxy_listen)
@@ -22,8 +22,8 @@ describe("Configuration loader", function()
     -- defaults
     assert.equal("on", conf.nginx_daemon)
     -- overrides
-    assert.equal("nobody nobody", conf.nginx_user)
-    assert.equal("1", conf.nginx_worker_processes)
+    assert.is_nil(conf.nginx_user)
+    assert.equal("1",            conf.nginx_worker_processes)
     assert.equal("0.0.0.0:9001", conf.admin_listen)
     assert.equal("0.0.0.0:9000", conf.proxy_listen)
     assert.equal("0.0.0.0:9443", conf.proxy_listen_ssl)
@@ -41,11 +41,11 @@ describe("Configuration loader", function()
     -- defaults
     assert.equal("on", conf.nginx_daemon)
     -- overrides
-    assert.equal("nobody nobody", conf.nginx_user)
-    assert.equal("auto", conf.nginx_worker_processes)
+    assert.is_nil(conf.nginx_user)
+    assert.equal("auto",           conf.nginx_worker_processes)
     assert.equal("127.0.0.1:9001", conf.admin_listen)
-    assert.equal("0.0.0.0:9000", conf.proxy_listen)
-    assert.equal("0.0.0.0:9443", conf.proxy_listen_ssl)
+    assert.equal("0.0.0.0:9000",   conf.proxy_listen)
+    assert.equal("0.0.0.0:9443",   conf.proxy_listen_ssl)
     assert.is_nil(getmetatable(conf))
   end)
   it("strips extraneous properties (not in defaults)", function()
@@ -68,7 +68,7 @@ describe("Configuration loader", function()
   end)
   it("loads custom plugins surrounded by spaces", function()
     local conf = assert(conf_loader(nil, {
-      custom_plugins = " hello-world ,   another-one  "  
+      custom_plugins = " hello-world ,   another-one  "
     }))
     assert.True(conf.plugins["hello-world"])
     assert.True(conf.plugins["another-one"])
@@ -115,6 +115,31 @@ describe("Configuration loader", function()
     assert.False(conf.pg_ssl)
     assert.True(conf.plugins.foobar)
     assert.True(conf.plugins["hello-world"])
+  end)
+
+  describe("nginx_user", function()
+    it("is nil by default", function()
+      local conf = assert(conf_loader(helpers.test_conf_path))
+      assert.is_nil(conf.nginx_user)
+    end)
+    it("is nil when 'nobody'", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        nginx_user = "nobody"
+      }))
+      assert.is_nil(conf.nginx_user)
+    end)
+    it("is nil when 'nobody nobody'", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        nginx_user = "nobody nobody"
+      }))
+      assert.is_nil(conf.nginx_user)
+    end)
+    it("is 'www_data www_data' when 'www_data www_data'", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        nginx_user = "www_data www_data"
+      }))
+      assert.equal("www_data www_data", conf.nginx_user)
+    end)
   end)
 
   describe("inferences", function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -1,6 +1,8 @@
 # This is a custom nginx configuration template for Kong specs
 
+> if nginx_user then
 user ${{NGINX_USER}};
+> end
 worker_processes ${{NGINX_WORKER_PROCESSES}};
 daemon ${{NGINX_DAEMON}};
 


### PR DESCRIPTION
### Summary

The PR #2311 introduced Nginx `user` directive defaults with values `nobody nobody`. While this may work with `root` user, it gives a warning with normal user:

```
2017/04/03 13:23:54 [warn] 8249#0: the "user" directive makes sense only
if the master process runs with super-user privileges,
ignored in /usr/local/kong/nginx.conf:1
```

This patch fixes the #2311 so that we do set the defaults only if `Kong` is started as a `super-user`.