### PR TITLE
fix(balancer) do not send body from balancer ctx

### DIFF
--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -221,9 +221,10 @@ function Kong.balancer()
 
     local ok, err = balancer_execute(addr)
     if not ok then
-      return responses.send_HTTP_INTERNAL_SERVER_ERROR("failed to retry the "..
-        "dns/balancer resolver for '"..addr.upstream.host..
-        "' with: "..tostring(err))
+      ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ",
+              addr.upstream.host, "' with: ", tostring(err))
+
+      return responses.send(500)
     end
   else
     -- first try, so set the max number of retries
@@ -236,9 +237,11 @@ function Kong.balancer()
   -- set the targets as resolved
   local ok, err = set_current_peer(addr.ip, addr.port)
   if not ok then
-    ngx.log(ngx.ERR, "failed to set the current peer (address:'",
-      tostring(addr.ip),"' port:",tostring(addr.port),"): ", tostring(err))
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR()
+    ngx.log(ngx.ERR, "failed to set the current peer (address: ",
+            tostring(addr.ip), " port: ", tostring(addr.port),"): ",
+            tostring(err))
+
+    return responses.send(500)
   end
 
   ok, err = set_timeouts(addr.connect_timeout / 1000,


### PR DESCRIPTION
### Summary

The `kong.tools.responses` module sends a body with `ngx.say` when
calling `responses.send_HTTP_SERVER_ERROR()`. This produces an error on
top of a previous error, as in:

```
2017/04/03 23:42:00 [error] 11076#0: *29 [lua] kong.lua:239: balancer(): failed to set the current peer (address:'2400:cb00:2048:1:0:0:681c:767' port:80): invalid port while connecting to upstream, client: 127.0.0.1, server: kong, request: "GET /status/200?apikey=secret123 HTTP/1.1", host: "acl_test1.com"
2017/04/03 23:42:00 [error] 11076#0: *29 failed to run balancer_by_lua*: ...he/luarocks-2.4.2/share/lua/5.1/kong/tools/responses.lua:127: API disabled in the context of balancer_by_lua*
stack traceback:
	[C]: in function 'say'
	...he/luarocks-2.4.2/share/lua/5.1/kong/tools/responses.lua:127: in function 'balancer'
	balancer_by_lua:2: in function <balancer_by_lua:1> while connecting to upstream, client: 127.0.0.1, server: kong, request: "GET /status/200?apikey=secret123 HTTP/1.1", host: "acl_test1.com"'
```

This is because, as pointed out in the error, `ngx.say` is not supported
in the `balancer_by_lua` context.

This logs the errors directly from the balancer context and simply sends
the `500` status to the client.


