### PR TITLE
fix(file-log) add timeout to reopen files automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
     which contains the properties of the authenticated Consumer
     (`id`, `custom_id`, and `username`), if any.
     [#2367](https://github.com/Mashape/kong/pull/2367)
+  - File-log plugin now has a new `valid` setting (in seconds) to close and 
+    reopen the logfiles automatically which enables rotating the logs.
+    [#2348](https://github.com/Mashape/kong/pull/2348)
 
 ### Fixed
 

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -11,8 +11,17 @@ local function validate_file(value)
   return true
 end
 
+local function validate_valid(value)
+  if value < 0 then
+    return false, "Value for 'valid' cannot be less than 0"
+  end
+
+  return true
+end
+
 return {
   fields = {
-    path = { required = true, type = "string", func = validate_file }
+    path = { required = true, type = "string", func = validate_file },
+    valid = { type = "number", default = 60, func = validate_valid },
   }
 }

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -20,7 +20,8 @@ describe("Plugin: file-log (log)", function()
       api_id = api1.id,
       name = "file-log",
       config = {
-        path = FILE_LOG_PATH
+        path = FILE_LOG_PATH,
+        valid = 0.2,
       }
     })
 
@@ -32,9 +33,11 @@ describe("Plugin: file-log (log)", function()
 
   before_each(function()
     client = helpers.proxy_client()
+    os.remove(FILE_LOG_PATH)
   end)
   after_each(function()
     if client then client:close() end
+    os.remove(FILE_LOG_PATH)
   end)
 
   it("logs to file", function()
@@ -59,7 +62,61 @@ describe("Plugin: file-log (log)", function()
     local log_message = cjson.decode(pl_stringx.strip(file_log))
     assert.same("127.0.0.1", log_message.client_ip)
     assert.same(uuid, log_message.request.headers["file-log-uuid"])
+  end)
+  
+  it("reopens file after 'valid' period expires", function()
+    local uuid1 = utils.random_string()
 
+    -- Making the request
+    local res = assert(client:send({
+      method = "GET",
+      path = "/status/200",
+      headers = {
+        ["file-log-uuid"] = uuid1,
+        ["Host"] = "file_logging.com"
+      }
+    }))
+    assert.res_status(200, res)
+
+    helpers.wait_until(function()
+      return pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0
+    end, 10)
+
+    -- remove the file to see whether it gets recreated
     os.remove(FILE_LOG_PATH)
+    ngx.sleep(0.3) -- wait for file to expire
+
+    -- Making the next request
+    local uuid2 = utils.random_string()
+    local res = assert(client:send({
+      method = "GET",
+      path = "/status/200",
+      headers = {
+        ["file-log-uuid"] = uuid2,
+        ["Host"] = "file_logging.com"
+      }
+    }))
+    assert.res_status(200, res)
+
+    local uuid3 = utils.random_string()
+    local res = assert(client:send({
+      method = "GET",
+      path = "/status/200",
+      headers = {
+        ["file-log-uuid"] = uuid3,
+        ["Host"] = "file_logging.com"
+      }
+    }))
+    assert.res_status(200, res)
+
+    helpers.wait_until(function()
+      return pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0
+    end, 10)
+
+    local file_log, err = pl_file.read(FILE_LOG_PATH)
+    assert.is_nil(err)
+    assert(not file_log:find(uuid1, nil, true), "did not expected 1st request in logfile")
+    assert(file_log:find(uuid2, nil, true), "expected 2nd request in logfile")
+    assert(file_log:find(uuid3, nil, true), "expected 3rd request in logfile")
   end)
 end)


### PR DESCRIPTION
If files got rotated, the plugin would keep writing to the existing file-descriptor, instead of recreating a new file. The new `valid` property (in seconds, default 60) will automatically reopen the file after the specified number of seconds.

This is modeled after the nginx directive [open_log_file_cache](http://nginx.org/en/docs/http/ngx_http_log_module.html#open_log_file_cache), which has a similar `valid` property, with the same default.

Remains: this plugin is not really suitable for production use. There are too many issues related to blocking io, file errors, etc. Those have been properly solved by tools like `syslog` etc. so those remain the preferred solution.

### Issues resolved

Fix #2325 
