### PR TITLE
Fix X-Forwarded-For when use ngx_http_realip_module

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -102,7 +102,7 @@ server {
 
         proxy_http_version 1.1;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For '$http_x_forwarded_for, $realip_remote_addr';
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $upstream_host;
         proxy_set_header Upgrade $upstream_upgrade;


### PR DESCRIPTION
### Summary

$proxy_add_x_forwarded_for be equal to '$X-Forwarded-For， $remote_addr',
if you use the module ngx_http_realip_module, $remote_addr will be reset to real-ip.
Fortunately, $realip_remote_addr keeps the original client address.

Fix #1762
