### PR TITLE
refactor(plugins) Modify the initial value of the loop variable

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -31,7 +31,7 @@ return {
         if plugin_t[v] <=0 then
           invalid_value = "Value for "..v.." must be greater than zero"
         else
-          for t = i, #ordered_periods do
+          for t = i+1, #ordered_periods do
             if plugin_t[ordered_periods[t]] and plugin_t[ordered_periods[t]] < plugin_t[v] then
               invalid_order = "The limit for "..ordered_periods[t].." cannot be lower than the limit for "..v
             end

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -14,7 +14,7 @@ local function check_ordered_limits(limit_value)
       if limit_value[v] <=0 then
         invalid_value = "Value for "..v.." must be greater than zero"
       else
-        for t = i, #ordered_periods do
+        for t = i+1, #ordered_periods do
           if limit_value[ordered_periods[t]] and limit_value[ordered_periods[t]] < limit_value[v] then
             invalid_order = "The limit for "..ordered_periods[t].." cannot be lower than the limit for "..v
           end

--- a/spec/03-plugins/24-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/01-schema_spec.lua
@@ -10,19 +10,26 @@ describe("Plugin: rate-limiting (schema)", function()
     assert.is_nil(err)
   end)
   it("proper config validates (bis)", function()
-    local config = {second = 10, hour = 20}
+    local config = {second = 10, minute = 20, hour = 30, day = 40, month = 50, year = 60}
     local ok, _, err = validate_entity(config, plugin_schema)
     assert.True(ok)
     assert.is_nil(err)
   end)
 
   describe("errors", function()
-    it("limits: smaller unit is less than bigger uni", function()
+    it("limits: smaller unit is less than bigger unit", function()
       local config = {second = 20, hour = 10}
       local ok, _, err = validate_entity(config, plugin_schema)
       assert.False(ok)
       assert.equal("The limit for hour cannot be lower than the limit for second", err.message)
     end)
+    it("limits: smaller unit is less than bigger unit (bis)", function()
+      local config = {second = 10, minute = 20, hour = 30, day = 40, month = 60, year = 50}
+      local ok, _, err = validate_entity(config, plugin_schema)
+      assert.False(ok)
+      assert.equal("The limit for year cannot be lower than the limit for month", err.message)
+    end)
+
     it("invalid limit", function()
       local config = {}
       local ok, _, err = validate_entity(config, plugin_schema)

--- a/spec/03-plugins/25-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/01-schema_spec.lua
@@ -4,7 +4,13 @@ local validate_entity = schemas.validate_entity
 
 describe("Plugin: response-rate-limiting (schema)", function()
   it("proper config validates", function()
-    local config = {limits = {video = {second = 1, minute = 2}}}
+    local config = {limits = {video = {second = 1}}}
+    local ok, err = validate_entity(config, plugin_schema)
+    assert.True(ok)
+    assert.is_nil(err)
+  end)
+  it("proper config validates (bis)", function()
+    local config = {limits = {video = {second = 1, minute = 2, hour = 3, day = 4, month = 5, year = 6}}}
     local ok, err = validate_entity(config, plugin_schema)
     assert.True(ok)
     assert.is_nil(err)
@@ -28,6 +34,12 @@ describe("Plugin: response-rate-limiting (schema)", function()
       local ok, _, self_check_err = validate_entity(config, plugin_schema)
       assert.False(ok)
       assert.equal("The limit for minute cannot be lower than the limit for second", self_check_err.message)
+    end)
+    it("limits: smaller unit is less than bigger unit (bis)", function()
+      local config = {limits = {video = {second = 1, minute = 2, hour = 3, day = 4, month = 6, year = 5}}}
+      local ok, _, self_check_err = validate_entity(config, plugin_schema)
+      assert.False(ok)
+      assert.equal("The limit for year cannot be lower than the limit for month", self_check_err.message)
     end)
     it("invaldid unit type", function()
       local config = {limits = {second = 10}}


### PR DESCRIPTION
### Summary

In this way the cycling executive times can be reduced,
therefore the speed of spatial query can be further accelerated.
