### PR TITLE
Add option to retrieve JWT from a cookie

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -22,6 +22,11 @@ JwtHandler.PRIORITY = 1000
 local function retrieve_token(request, conf)
   local uri_parameters = request.get_uri_args()
 
+  local jwt_cookie = ngx.var["cookie_" ..  conf.cookie_name]
+  if jwt_cookie then
+    return jwt_cookie
+  end
+
   for _, v in ipairs(conf.uri_param_names) do
     if uri_parameters[v] then
       return uri_parameters[v]

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -16,5 +16,6 @@ return {
     secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}},
     anonymous = {type = "string", default = "", func = check_user},
+    cookie_name = {type = "string", default = "jwt_token"},
   }
 }


### PR DESCRIPTION
### Summary

Add an option to retrieve the JWT from a cookie. Can be useful when you put Kong in front of a UI website.

The change is very simple, just a new option in the schema of the plugin, and 4 lines of code in `retrieve_token` function.

I've never touched Lua before, so please let me know if there is anything missing for this to be merged.
