### PR TITLE
feat(key-auth) allow underscore in key header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
     weight Targets, instead of all nonzero weight targets. This is to provide
     a better picture of the Targets currently in use by the Kong load balancer.
     [#2310](https://github.com/Mashape/kong/pull/2310)
+- Plugins:
+  - key-auth: Allow setting API key header names with an underscore.
+    [#2370](https://github.com/Mashape/kong/pull/2370)
 
 ### Added
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -598,12 +598,12 @@ _M.validate_header_name = function(name)
     return nil, "no header name provided"
   end
 
-  if re_match(name, "^[a-zA-Z0-9-]+$", "jo") then
+  if re_match(name, "^[a-zA-Z0-9-_]+$", "jo") then
     return name
   end
 
   return nil, "bad header name '" .. name ..
-              "', allowed characters are A-Z, a-z, 0-9 and '-'"
+              "', allowed characters are A-Z, a-z, 0-9, '_', and '-'"
 end
 
 return _M

--- a/spec/01-unit/04-utils_spec.lua
+++ b/spec/01-unit/04-utils_spec.lua
@@ -472,7 +472,7 @@ describe("Utils", function()
   end)
 
   it("validate_header_name() validates header names", function()
-    local header_chars = [[-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
+    local header_chars = [[_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
 
     for i = 1, 255 do
       local c = string.char(i)

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -282,8 +282,8 @@ describe("Plugin: key-auth (API)", function()
       assert.response(res).has.status(400)
       local body = assert.response(res).has.jsonbody()
       assert.equal("'hello\\world' is illegal: bad header name " ..
-                   "'hello\\world', allowed characters are A-Z, a-z, 0-9 " ..
-                   "and '-'", body["config.key_names"])
+                   "'hello\\world', allowed characters are A-Z, a-z, 0-9," ..
+                   " '_', and '-'", body["config.key_names"])
     end)
     it("succeeds with valid key_names", function()
       local key_name = "hello-world"


### PR DESCRIPTION
There is no incentive for Kong to not allow a header name containing an
underscore. This reverts the change in behavior introduced in #2142
and 73437ef01d1514492fd645f1e9e04a74776878eb.

The `underscores_in_headers` directive seems to already be enabled.