### PR TITLE
fix(cli) handle serf shutdown correctly

### DIFF
--- a/kong/cmd/utils/serf_signals.lua
+++ b/kong/cmd/utils/serf_signals.lua
@@ -149,12 +149,21 @@ function _M.stop(kong_config, dao)
   if not ok then return nil, err end
   log.verbose("left serf cluster")
 
-  log.verbose("stopping serf agent at %s", kong_config.serf_pid)
-  local code = kill.kill(kong_config.serf_pid, "-15") --SIGTERM
-  if code == 256 then -- If no error is returned
+  if not kill.is_running(kong_config.serf_pid) then
     pl_file.delete(kong_config.serf_pid)
+
+  else
+    log.verbose("stopping serf agent at %s", kong_config.serf_pid)
+    local code = kill.kill(kong_config.serf_pid, "-15") --SIGTERM
+    if code ~= 0 then
+      log.error("serf agent could not be stopped")
+
+    else
+      pl_file.delete(kong_config.serf_pid)
+      log.verbose("serf agent stopped")
+    end
   end
-  log.verbose("serf agent stopped")
+
   return true
 end
 


### PR DESCRIPTION
### Summary

With LuaJIT Lua 5.2 compatibility the error code `256` is not returned from `os.execute`, but instead `code % 256`, and in this case `0`.

This PR fixes the code handling, and usually `serf:leave` is all that needs to be done. This is also related to a patch to `Penlight`. Without this PR the Serf Agent `pid` file will not be deleted even if the Serf Agent is not running anymore when using Lua 5.2 compatibility.

### Related Pull-Requests

Related Fix stevedonovan/Penlight/pull/244
