### PR TITLE
hotfix(router) allow url escaped uris

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -615,16 +615,22 @@ function _M.new(apis)
 
 
   function self.exec(ngx)
-    local method      = ngx.req.get_method()
-    local uri         = ngx.var.uri
-    local uri_root    = uri == "/"
-    local new_uri     = uri
-    local host_header
-    local req_host
+    local method   = ngx.req.get_method()
+    local uri      = ngx.var.request_uri
+
+
+    do
+      local s = find(uri, "?", 2, true)
+      if s then
+        uri = sub(uri, 1, s - 1)
+      end
+    end
 
 
     --print("grab host header: ", grab_host)
 
+
+    local req_host
 
     if grab_host then
       req_host = ngx.var.http_host
@@ -636,8 +642,13 @@ function _M.new(apis)
       return nil
     end
 
+    local new_uri
+    local uri_root = uri == "/"
 
-    if not uri_root and api_t.strip_uri_regex then
+    if uri_root or not api_t.strip_uri_regex then
+      new_uri = uri
+
+    else
       local err
       new_uri, err = re_sub(uri, api_t.strip_uri_regex, "/$1", "ajo")
       if not new_uri then
@@ -677,6 +688,8 @@ function _M.new(apis)
       ngx.req.set_uri(new_uri)
     end
 
+
+    local host_header
 
     if api_t.preserve_host then
       host_header = req_host or ngx.var.http_host

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -712,12 +712,12 @@ describe("Router", function()
       nop = function() end
     }
 
-    local function mock_ngx(method, uri, headers)
+    local function mock_ngx(method, request_uri, headers)
       local _ngx
       _ngx = {
         re = ngx.re,
         var = setmetatable({
-          uri = uri,
+          request_uri = request_uri,
           http_kong_debug = headers.kong_debug
         }, {
           __index = function(_, key)
@@ -728,8 +728,8 @@ describe("Router", function()
           end
         }),
         req = {
-          set_uri = function(uri)
-            _ngx.var.uri = uri
+          set_uri = function(request_uri)
+            _ngx.var.request_uri = request_uri
           end,
           get_method = function()
             return method
@@ -816,6 +816,43 @@ describe("Router", function()
       assert.equal(8443, upstream.port)
     end)
 
+    it("allows url encoded uris", function()
+      local use_case_apis = {
+        {
+          name = "api-1",
+          uris = {
+            "/endel%C3%B8st"
+          },
+        },
+      }
+
+      local _ngx   = mock_ngx("GET", "/endel%C3%B8st", {})
+      local router = assert(Router.new(use_case_apis))
+      local api    = router.exec(_ngx)
+
+      assert.same(use_case_apis[1], api)
+      assert.equal("/endel%C3%B8st", _ngx.var.request_uri)
+    end)
+
+    it("strips url encoded uris", function()
+      local use_case_apis = {
+        {
+          name      = "api-1",
+          strip_uri = true,
+          uris      = {
+            "/endel%C3%B8st"
+          },
+        },
+      }
+
+      local _ngx   = mock_ngx("GET", "/endel%C3%B8st", {})
+      local router = assert(Router.new(use_case_apis))
+      local api    = router.exec(_ngx)
+
+      assert.same(use_case_apis[1], api)
+      assert.equal("/", _ngx.var.request_uri)
+    end)
+
     describe("grab_headers", function()
       local use_case_apis = {
         {
@@ -882,7 +919,7 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/hello/world", _ngx.var.uri)
+        assert.equal("/hello/world", _ngx.var.request_uri)
       end)
 
       it("strips if matched URI is plain (not a prefix)", function()
@@ -890,7 +927,7 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.uri)
+        assert.equal("/", _ngx.var.request_uri)
       end)
 
       it("doesn't strip if 'strip_uri' is not enabled", function()
@@ -898,7 +935,7 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[2], api)
-        assert.equal("/my-api/hello/world", _ngx.var.uri)
+        assert.equal("/my-api/hello/world", _ngx.var.request_uri)
       end)
 
       it("does not strips root / URI", function()
@@ -916,7 +953,7 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/my-api/hello/world", _ngx.var.uri)
+        assert.equal("/my-api/hello/world", _ngx.var.request_uri)
       end)
 
       it("can find an API with stripped URI several times in a row", function()
@@ -924,12 +961,12 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.uri)
+        assert.equal("/", _ngx.var.request_uri)
 
         _ngx = mock_ngx("GET", "/my-api", {})
         local api2 = router.exec(_ngx)
         assert.same(use_case_apis[1], api2)
-        assert.equal("/", _ngx.var.uri)
+        assert.equal("/", _ngx.var.request_uri)
       end)
 
       it("can proxy an API with stripped URI with different URIs in a row", function()
@@ -937,12 +974,12 @@ describe("Router", function()
 
         local api = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.uri)
+        assert.equal("/", _ngx.var.request_uri)
 
         _ngx = mock_ngx("GET", "/this-api", {})
         local api2 = router.exec(_ngx)
         assert.same(use_case_apis[1], api2)
-        assert.equal("/", _ngx.var.uri)
+        assert.equal("/", _ngx.var.request_uri)
       end)
     end)
 
@@ -1102,7 +1139,7 @@ describe("Router", function()
           local api, upstream = router.exec(_ngx)
           assert.same(use_case_apis[1], api)
           assert.equal(args[1], upstream.path)
-          assert.equal(args[4], _ngx.var.uri)
+          assert.equal(args[4], _ngx.var.request_uri)
         end)
       end
     end)


### PR DESCRIPTION
### Summary

Change the router to use `ngx.var.request_uri` instead of the normalized `ngx.var.uri`. Makes proxying more transparent.

### Issues resolved

Fix #2366