### PR TITLE
hotfix(conf) convert custom nginx conf dns_resolver to string

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -180,6 +180,10 @@ local function compile_conf(kong_config, conf_template)
 
   compile_env = pl_tablex.merge(compile_env, kong_config, true) -- union
 
+  if type(compile_env.dns_resolver) == "table" then
+    compile_env.dns_resolver = table.concat(compile_env.dns_resolver, " ")
+  end
+
   local post_template = pl_template.substitute(conf_template, compile_env)
   return string.gsub(post_template, "(${%b{}})", function(w)
     local name = w:sub(4, -3)

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -179,10 +179,7 @@ local function compile_conf(kong_config, conf_template)
   end
 
   compile_env = pl_tablex.merge(compile_env, kong_config, true) -- union
-
-  if type(compile_env.dns_resolver) == "table" then
-    compile_env.dns_resolver = table.concat(compile_env.dns_resolver, " ")
-  end
+  compile_env.dns_resolver = table.concat(compile_env.dns_resolver, " ")
 
   local post_template = pl_template.substitute(conf_template, compile_env)
   return string.gsub(post_template, "(${%b{}})", function(w)

--- a/spec/01-unit/03-prefix_handler_spec.lua
+++ b/spec/01-unit/03-prefix_handler_spec.lua
@@ -154,6 +154,14 @@ describe("NGINX conf compiler", function()
       assert.matches("worker_connections %d+;", nginx_conf)
       assert.matches("multi_accept on;", nginx_conf)
     end)
+    it("converts dns_resolver to string", function()
+      local nginx_conf = prefix_handler.compile_nginx_conf({
+        dns_resolver = { "8.8.8.8", "8.8.4.4" }
+      }, [[
+        "resolver ${{DNS_RESOLVER}} ipv6=off;"
+      ]])
+      assert.matches("resolver 8.8.8.8 8.8.4.4 ipv6=off;", nginx_conf, nil, true)
+    end)
   end)
 
   describe("prepare_prefix()", function()


### PR DESCRIPTION
### Summary

If you have this in your custom nginx template:

```nginx
resolver ${{DNS_RESOLVER}} ipv6=off;
```

It will yield an error. This PR fixes the issue by transforming
the `dns_resolver` from `table` to `string` for template usage.

### Issues resolved

Fix #2319