### PR TITLE
fix(proxy) resolve DNS hostnames post-plugins

### DIFF
--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -230,7 +230,7 @@ function Kong.balancer()
 
   addr.try_count = addr.try_count + 1
   if addr.try_count > 1 then
-    -- only call balancer on retry, first one is done in `core.access.before` which runs
+    -- only call balancer on retry, first one is done in `core.access.after` which runs
     -- in the ACCESS context and hence has less limitations than this BALANCER context
     -- where the retries are executed
 


### PR DESCRIPTION
This is mainly to address the Lambda and OpenWhisk plugins not being
able to run if the specified ùpstream_url`'s hostname does not resolve,
hence resulting in an HTTP 500 error.

Ideally, this change should probably be reverted, since some future
plugins might need to know the resolved IP address or the upstream Host
header in their `access` phase.

No tests for now, just running the CI.