### PR TITLE
feat(statsd) new metrics and more flexible configuration

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -259,6 +259,8 @@ build = {
     ["kong.plugins.datadog.schema"] = "kong/plugins/datadog/schema.lua",
     ["kong.plugins.datadog.statsd_logger"] = "kong/plugins/datadog/statsd_logger.lua",
 
+    ["kong.plugins.statsd.migrations.cassandra"] = "kong/plugins/statsd/migrations/cassandra.lua",
+    ["kong.plugins.statsd.migrations.postgres"] = "kong/plugins/statsd/migrations/postgres.lua",
     ["kong.plugins.statsd.handler"] = "kong/plugins/statsd/handler.lua",
     ["kong.plugins.statsd.schema"] = "kong/plugins/statsd/schema.lua",
     ["kong.plugins.statsd.statsd_logger"] = "kong/plugins/statsd/statsd_logger.lua",

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -1,90 +1,149 @@
-local BasePlugin = require "kong.plugins.base_plugin"
+local BasePlugin       = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
-local statsd_logger = require "kong.plugins.statsd.statsd_logger"
+local statsd_logger    = require "kong.plugins.statsd.statsd_logger"
+
+
+local ngx_log       = ngx.log
+local ngx_timer_at  = ngx.timer.at
+local string_gsub   = string.gsub
+local pairs         = pairs
+local string_format = string.format
+local NGX_ERR       = ngx.ERR
+
 
 local StatsdHandler = BasePlugin:extend()
-
 StatsdHandler.PRIORITY = 1
 
-local ngx_log = ngx.log
-local ngx_timer_at = ngx.timer.at
-local string_gsub = string.gsub
-local pairs = pairs
-local NGX_ERR = ngx.ERR
 
-local gauges = {
-  request_size = function (api_name, message, logger)
-    local stat = api_name .. ".request.size"
-    logger:gauge(stat, message.request.size, 1)
+local get_consumer_id = {
+  consumer_id = function(consumer)
+    return consumer and string_gsub(consumer.id, "-", "_")
   end,
-  response_size = function (api_name, message, logger)
-    local stat = api_name .. ".response.size"
-    logger:gauge(stat, message.response.size, 1)
+  custom_id   = function(consumer)
+    return consumer and consumer.custom_id
   end,
-  status_count = function (api_name, message, logger)
-    local stat = api_name .. ".request.status." .. message.response.status
-    logger:counter(stat, 1, 1)
+  username    = function(consumer)
+    return consumer and consumer.username
+  end
+}
+
+
+local metrics = {
+  status_count = function (api_name, message, metric_config, logger)
+    local fmt = string_format("%s.request.status", api_name,
+                       message.response.status)
+
+    logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
+                       1, logger.stat_types.counter, metric_config.sample_rate)
+
+    logger:send_statsd(string_format("%s.%s", fmt, "total"), 1,
+                       logger.stat_types.counter, metric_config.sample_rate)
   end,
-  latency = function (api_name, message, logger)
-    local stat = api_name .. ".latency"
-    logger:gauge(stat, message.latencies.request, 1)
-  end,
-  request_count = function (api_name, message, logger)
-    local stat = api_name .. ".request.count"
-    logger:counter(stat, 1, 1)
-  end,
-  unique_users = function (api_name, message, logger)
-    if message.authenticated_entity ~= nil and message.authenticated_entity.consumer_id ~= nil then
-      local stat = api_name .. ".user.uniques"
-      logger:set(stat, message.authenticated_entity.consumer_id)
+  unique_users = function (api_name, message, metric_config, logger)
+    local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
+    local consumer_id     = get_consumer_id(message.consumer)
+
+    if consumer_id then
+      local stat = string_format("%s.user.uniques", api_name)
+
+      logger:send_statsd(stat, consumer_id, logger.stat_types.set)
     end
   end,
-  request_per_user = function (api_name, message, logger)
-    if message.authenticated_entity ~= nil and message.authenticated_entity.consumer_id ~= nil then
-      local stat = api_name .. "." .. string_gsub(message.authenticated_entity.consumer_id, "-", "_") .. ".request.count"
-      logger:counter(stat, 1, 1)    
+  request_per_user = function (api_name, message, metric_config, logger)
+    local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
+    local consumer_id     = get_consumer_id(message.consumer)
+
+    if consumer_id then
+      local stat = string_format("%s.user.%s.request.count", api_name, consumer_id)
+
+      logger:send_statsd(stat, 1, logger.stat_types.counter,
+                         metric_config.sample_rate)
     end
   end,
-  upstream_latency = function (api_name, message, logger)
-    local stat = api_name .. ".upstream_latency"
-    logger:gauge(stat, message.latencies.proxy, 1)
+  status_count_per_user = function (api_name, message, metric_config, logger)
+    local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
+    local consumer_id     = get_consumer_id(message.consumer)
+
+    if consumer_id then
+      local fmt = string_format("%s.user.%s.request.status", api_name, consumer_id)
+
+      logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
+                         1, logger.stat_types.counter,
+                         metric_config.sample_rate)
+
+      logger:send_statsd(string_format("%s.%s", fmt,  "total"),
+                         1, logger.stat_types.counter,
+                         metric_config.sample_rate)
+    end
   end,
 }
+
 
 local function log(premature, conf, message)
   if premature then
     return
+
   end
-  
+
+  local api_name   = string_gsub(message.api.name, "%.", "_")
+  local stat_name  = {
+    request_size     = api_name .. ".request.size",
+    response_size    = api_name .. ".response.size",
+    latency          = api_name .. ".latency",
+    upstream_latency = api_name .. ".upstream_latency",
+    kong_latency     = api_name .. ".kong_latency",
+    request_count    = api_name .. ".request.count",
+  }
+  local stat_value = {
+    request_size     = message.request.size,
+    response_size    = message.response.size,
+    latency          = message.latencies.request,
+    upstream_latency = message.latencies.proxy,
+    kong_latency     = message.latencies.kong,
+    request_count    = 1,
+  }
+
   local logger, err = statsd_logger:new(conf)
   if err then
     ngx_log(NGX_ERR, "failed to create Statsd logger: ", err)
     return
   end
-  
-  local api_name = string_gsub(message.api.name, "%.", "_")
-  for _, metric in pairs(conf.metrics) do
-    local gauge = gauges[metric]
-    if gauge ~= nil then
-      gauge(api_name, message, logger)
+
+  for _, metric_config in pairs(conf.metrics) do
+    local metric = metrics[metric_config.name]
+
+    if metric then
+      metric(api_name, message, metric_config, logger)
+
+    else
+      local stat_name = stat_name[metric_config.name]
+      local stat_value = stat_value[metric_config.name]
+
+      logger:send_statsd(stat_name, stat_value,
+                         logger.stat_types[metric_config.stat_type],
+                         metric_config.sample_rate)
     end
   end
-  
+
   logger:close_socket()
 end
+
 
 function StatsdHandler:new()
   StatsdHandler.super.new(self, "statsd")
 end
 
+
 function StatsdHandler:log(conf)
   StatsdHandler.super.log(self)
+
   local message = basic_serializer.serialize(ngx)
-  
+
   local ok, err = ngx_timer_at(0, log, conf, message)
   if not ok then
     ngx_log(NGX_ERR, "failed to create timer: ", err)
   end
 end
+
 
 return StatsdHandler

--- a/kong/plugins/statsd/migrations/cassandra.lua
+++ b/kong/plugins/statsd/migrations/cassandra.lua
@@ -1,0 +1,91 @@
+return {
+  {
+    name = "2017-06-09-160000_statsd_schema_changes",
+    up = function(_, _, dao)
+
+      local plugins, err = dao.plugins:find_all { name = "statsd" }
+      if err then
+        return err
+      end
+
+      local default_metrics = {
+        request_count = {
+          name        = "request_count",
+          stat_type   = "counter",
+          sample_rate = 1,
+        },
+        latency = {
+          name      = "latency",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+        request_size = {
+          name      = "request_size",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+        status_count = {
+          name        = "status_count",
+          stat_type   = "counter",
+          sample_rate = 1,
+        },
+        response_size = {
+          name      = "response_size",
+          stat_type = "timer",
+        },
+        unique_users = {
+          name                = "unique_users",
+          stat_type           = "set",
+          consumer_identifier = "consumer_id",
+        },
+        request_per_user = {
+          name                = "request_per_user",
+          stat_type           = "counter",
+          sample_rate         = 1,
+          consumer_identifier = "consumer_id",
+        },
+        upstream_latency = {
+          name      = "upstream_latency",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+      }
+
+      for i = 1, #plugins do
+        local statsd = plugins[i]
+        local _, err = dao.plugins:delete(statsd)
+        if err then
+          return err
+        end
+
+        local new_metrics = {}
+        if statsd.config.metrics then
+          for _, metric in ipairs(statsd.config.metrics) do
+            local new_metric = default_metrics[metric]
+            if new_metric then
+              table.insert(new_metrics, new_metric)
+            end
+          end
+        end
+
+        local _, err = dao.plugins:insert {
+          name    = "statsd",
+          api_id  = statsd.api_id,
+          enabled = statsd.enabled,
+          config  = {
+            host    = statsd.config.host,
+            port    = statsd.config.port,
+            metrics = new_metrics,
+            prefix  = "kong",
+          }
+        }
+
+        if err then
+          return err
+        end
+      end
+    end
+  },
+  down = function()
+  end,
+}

--- a/kong/plugins/statsd/migrations/postgres.lua
+++ b/kong/plugins/statsd/migrations/postgres.lua
@@ -1,0 +1,92 @@
+return {
+  {
+    name = "2017-06-09-160000_statsd_schema_changes",
+    up = function(_, _, dao)
+
+      local plugins, err = dao.plugins:find_all { name = "statsd" }
+      if err then
+        return err
+      end
+
+      local default_metrics = {
+        request_count = {
+          name        = "request_count",
+          stat_type   = "counter",
+          sample_rate = 1,
+        },
+        latency = {
+          name      = "latency",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+        request_size = {
+          name      = "request_size",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+        status_count = {
+          name        = "status_count",
+          stat_type   = "counter",
+          sample_rate = 1,
+        },
+        response_size = {
+          name      = "response_size",
+          stat_type = "timer",
+        },
+        unique_users = {
+          name                = "unique_users",
+          stat_type           = "set",
+          consumer_identifier = "consumer_id",
+        },
+        request_per_user = {
+          name                = "request_per_user",
+          stat_type           = "counter",
+          sample_rate         = 1,
+          consumer_identifier = "consumer_id",
+        },
+        upstream_latency = {
+          name      = "upstream_latency",
+          stat_type = "gauge",
+          sample_rate = 1,
+        },
+      }
+
+      for i = 1, #plugins do
+        local statsd = plugins[i]
+        local _, err = dao.plugins:delete(statsd)
+        if err then
+          return err
+        end
+
+        local new_metrics = {}
+        if statsd.config.metrics then
+          for _, metric in ipairs(statsd.config.metrics) do
+
+            local new_metric = default_metrics[metric]
+            if new_metric then
+              table.insert(new_metrics, new_metric)
+            end
+          end
+        end
+
+        local _, err = dao.plugins:insert {
+          name    = "statsd",
+          api_id  = statsd.api_id,
+          enabled = statsd.enabled,
+          config  = {
+            host    = statsd.config.host,
+            port    = statsd.config.port,
+            metrics = new_metrics,
+            prefix  = "kong",
+          }
+        }
+
+        if err then
+          return err
+        end
+      end
+    end
+  },
+  down = function()
+  end,
+}

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -1,24 +1,164 @@
 local metrics = {
-  "request_count",
-  "latency",
-  "request_size",
-  "status_count",
-  "response_size",
-  "unique_users",
-  "request_per_user",
-  "upstream_latency"
+  ["request_count"]         = true,
+  ["latency"]               = true,
+  ["request_size"]          = true,
+  ["status_count"]          = true,
+  ["response_size"]         = true,
+  ["unique_users"]          = true,
+  ["request_per_user"]      = true,
+  ["upstream_latency"]      = true,
+  ["kong_latency"]          = true,
+  ["status_count_per_user"] = true,
 }
+
+
+local stat_types = {
+  ["gauge"]     = true,
+  ["timer"]     = true,
+  ["counter"]   = true,
+  ["histogram"] = true,
+  ["meter"]     = true,
+  ["set"]       = true,
+}
+
+local consumer_identifiers = {
+  ["consumer_id"] = true,
+  ["custom_id"]   = true,
+  ["username"]    = true,
+}
+
+local default_metrics = {
+  {
+    name        = "request_count",
+    stat_type   = "counter",
+    sample_rate = 1,
+  },
+  {
+    name      = "latency",
+    stat_type = "timer",
+  },
+  {
+    name      = "request_size",
+    stat_type = "timer",
+  },
+  {
+    name        = "status_count",
+    stat_type   = "counter",
+    sample_rate = 1,
+  },
+  {
+    name      = "response_size",
+    stat_type = "timer"
+  },
+  {
+    name                = "unique_users",
+    stat_type           = "set",
+    consumer_identifier = "custom_id",
+  },
+  {
+    name        = "request_per_user",
+    stat_type   = "counter",
+    sample_rate = 1,
+    consumer_identifier = "custom_id",
+  },
+  {
+    name      = "upstream_latency",
+    stat_type = "timer",
+  },
+  {
+    name      = "kong_latency",
+    stat_type = "timer",
+  },
+  {
+    name                = "status_count_per_user",
+    stat_type           = "counter",
+    sample_rate         = 1,
+    consumer_identifier = "custom_id",
+  },
+}
+
+
+local function check_schema(value)
+  for _, entry in ipairs(value) do
+
+    if not entry.name or not entry.stat_type then
+      return false, "name and stat_type must be defined for all stats"
+    end
+
+    if not metrics[entry.name] then
+      return false, "unrecognized metric name: " .. entry.name
+    end
+
+    if not stat_types[entry.stat_type] then
+      return false, "unrecognized stat_type: " .. entry.stat_type
+    end
+
+    if entry.name == "unique_users" and entry.stat_type ~= "set" then
+      return false, "unique_users metric only works with stat_type 'set'"
+    end
+
+    if (entry.stat_type == "counter" or entry.stat_type == "gauge")
+        and ((not entry.sample_rate) or (entry.sample_rate
+        and type(entry.sample_rate) ~= "number")
+        or (entry.sample_rate and entry.sample_rate < 1)) then
+
+      return false, "sample rate must be defined for counters and gauges."
+    end
+
+    if (entry.name == "status_count_per_user"
+        or entry.name == "request_per_user" or entry.name == "unique_users")
+        and not entry.consumer_identifier then
+
+      return false, "consumer_identifier must be defined for metric " ..
+             entry.name
+    end
+
+    if (entry.name == "status_count_per_user"
+       or entry.name == "request_per_user"
+       or entry.name == "unique_users")
+       and entry.consumer_identifier
+       and not consumer_identifiers[entry.consumer_identifier] then
+
+        return false, "invalid consumer_identifier for metric '" ..
+               entry.name ..
+               "'. Choices are consumer_id, custom_id, and username"
+    end
+
+    if (entry.name == "status_count"
+       or entry.name == "status_count_per_user"
+       or entry.name == "request_per_user")
+       and entry.stat_type ~= "counter" then
+
+      return false, entry.name .. " metric only works with stat_type 'counter'"
+    end
+  end
+
+  return true
+end
+
 
 return {
   fields = {
-    host = {required = true, type = "string", default = "localhost"},
-    port = {required = true, type = "number", default = 8125},
-    metrics = {
-      type = "array",
+    host    = {
       required = true,
-      default = metrics,
-      enum = metrics
+      type     = "string",
+      default  = "localhost",
     },
-    timeout = {type = "number", default = 10000}
+    port    = {
+      required = true,
+      type     = "number",
+      default  = 8125,
+    },
+    metrics = {
+      type     = "array",
+      required = true,
+      default  = default_metrics,
+      func     = check_schema,
+    },
+    prefix =
+    {
+      type     = "string",
+      default  = "kong",
+    },
   }
 }

--- a/kong/plugins/statsd/statsd_logger.lua
+++ b/kong/plugins/statsd/statsd_logger.lua
@@ -1,86 +1,77 @@
 local ngx_socket_udp = ngx.socket.udp
-local ngx_log = ngx.log
-local table_concat = table.concat
-local setmetatable = setmetatable
-local NGX_ERR = ngx.ERR
-local NGX_DEBUG = ngx.DEBUG
+local ngx_log        = ngx.log
+local NGX_ERR        = ngx.ERR
+local NGX_DEBUG      = ngx.DEBUG
+local setmetatable   = setmetatable
+local tostring       = tostring
+local fmt            = string.format
+
+
+local stat_types = {
+  gauge     = "g",
+  counter   = "c",
+  timer     = "ms",
+  histogram = "h",
+  meter     = "m",
+  set       = "s",
+}
+
+
+local function create_statsd_message(prefix, stat, delta, kind, sample_rate)
+  local rate = ""
+  if sample_rate and sample_rate ~= 1 then
+    rate = "|@" .. sample_rate
+  end
+
+  return fmt("%s.%s:%s|%s%s", prefix, stat, delta, kind, rate)
+end
+
 
 local statsd_mt = {}
 statsd_mt.__index = statsd_mt
 
+
 function statsd_mt:new(conf)
-  local sock = ngx_socket_udp()
-  sock:settimeout(conf.timeout)
+  local sock   = ngx_socket_udp()
   local _, err = sock:setpeername(conf.host, conf.port)
   if err then
-    return nil, "failed to connect to " .. conf.host .. ":" .. tostring(conf.port) .. ": " .. err
+    return nil, fmt("failed to connect to %s:%s: %s", conf.host,
+                    tostring(conf.port), err)
   end
-  
+
   local statsd = {
-    host = conf.host,
-    port = conf.port,
-    socket = sock
+    host       = conf.host,
+    port       = conf.port,
+    prefix     = conf.prefix,
+    socket     = sock,
+    stat_types = stat_types,
   }
   return setmetatable(statsd, statsd_mt)
 end
 
-function statsd_mt:create_statsd_message(stat, delta, kind, sample_rate)
-  local rate = ""
-  if sample_rate and sample_rate ~= 1 then 
-    rate = "|@" .. sample_rate 
-  end
-  
-  local message = {
-    "kong.",
-    stat,
-    ":",
-    delta,
-    "|",
-    kind,
-    rate
-  }
-  return table_concat(message, "")
-end
 
 function statsd_mt:close_socket()
   local ok, err = self.socket:close()
   if not ok then
-    ngx_log(NGX_ERR, "failed to close connection from " .. self.host .. ":" .. tostring(self.port) .. ": ", err)
+    ngx_log(NGX_ERR, fmt("failed to close connection from %s:%s: %s", self.host,
+                         tostring(self.port), err))
     return
   end
 end
 
+
 function statsd_mt:send_statsd(stat, delta, kind, sample_rate)
-  local udp_message = self:create_statsd_message(stat, delta, kind, sample_rate)
-  ngx_log(NGX_DEBUG, "Sending data to statsd server: " .. udp_message)
+  local udp_message = create_statsd_message(self.prefix or "kong", stat,
+                                            delta, kind, sample_rate)
+
+  ngx_log(NGX_DEBUG, fmt("sending data to statsd server: %s", udp_message))
+
   local ok, err = self.socket:send(udp_message)
   if not ok then
-    ngx_log(NGX_ERR, "failed to send data to " .. self.host .. ":" .. tostring(self.port) .. ": ", err)
+    ngx_log(NGX_ERR, fmt("failed to send data to %s:%s: %s", self.host,
+                         tostring(self.port), err))
   end
 end
 
-function statsd_mt:gauge(stat, value, sample_rate)
-  return self:send_statsd(stat, value, "g", sample_rate)
-end
-
-function statsd_mt:counter(stat, value, sample_rate)
-  return self:send_statsd(stat, value, "c", sample_rate)
-end
-
-function statsd_mt:timer(stat, ms)
-  return self:send_statsd(stat, ms, "ms")
-end
-
-function statsd_mt:histogram(stat, value)
-  return self:send_statsd(stat, value, "h")
-end
-
-function statsd_mt:meter(stat, value)
-  return self:send_statsd(stat, value, "m")
-end
-
-function statsd_mt:set(stat, value)
-  return self:send_statsd(stat, value, "s")
-end
 
 return statsd_mt

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -4,40 +4,108 @@ local UDP_PORT = 20000
 describe("Plugin: statsd (log)", function()
   local client
   setup(function()
+    local consumer1 = assert(helpers.dao.consumers:insert {
+      username = "bob",
+      custom_id = "robert"
+    })
+    assert(helpers.dao.keyauth_credentials:insert {
+      key = "kong",
+      consumer_id = consumer1.id
+    })
+
     local api1 = assert(helpers.dao.apis:insert {
-      name = "logging1_com",
+      name = "stastd1",
       hosts = { "logging1.com" },
       upstream_url = "http://mockbin.com"
     })
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api1.id
+    })
     local api2 = assert(helpers.dao.apis:insert {
-      name = "logging2_com",
+      name = "stastd2",
       hosts = { "logging2.com" },
       upstream_url = "http://mockbin.com"
     })
     local api3 = assert(helpers.dao.apis:insert {
-      name = "logging3_com",
+      name = "stastd3",
       hosts = { "logging3.com" },
       upstream_url = "http://mockbin.com"
     })
     local api4 = assert(helpers.dao.apis:insert {
-      name = "logging4_com",
+      name = "stastd4",
       hosts = { "logging4.com" },
       upstream_url = "http://mockbin.com"
     })
     local api5 = assert(helpers.dao.apis:insert {
-      name = "logging5_com",
+      name = "stastd5",
       hosts = { "logging5.com" },
       upstream_url = "http://mockbin.com"
     })
     local api6 = assert(helpers.dao.apis:insert {
-      name = "logging6_com",
+      name = "stastd6",
       hosts = { "logging6.com" },
       upstream_url = "http://mockbin.com"
     })
     local api7 = assert(helpers.dao.apis:insert {
-      name = "logging7_com",
+      name = "stastd7",
       hosts = { "logging7.com" },
       upstream_url = "http://mockbin.com"
+    })
+    local api8 = assert(helpers.dao.apis:insert {
+      name = "stastd8",
+      hosts = { "logging8.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    local api9 = assert(helpers.dao.apis:insert {
+      name = "stastd9",
+      hosts = { "logging9.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api9.id
+    })
+    local api10 = assert(helpers.dao.apis:insert {
+      name = "stastd10",
+      hosts = { "logging10.com" },
+      upstream_url = "http://mockbin.com"
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api10.id
+    })
+    local api11 = assert(helpers.dao.apis:insert {
+      name = "stastd11",
+      hosts = { "logging11.com" },
+      upstream_url = "http://mockbin.com"
+    })
+
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api11.id
+    })
+
+    local api12 = assert(helpers.dao.apis:insert {
+      name = "stastd12",
+      hosts = { "logging12.com" },
+      upstream_url = "http://mockbin.com"
+    })
+
+    local api13 = assert(helpers.dao.apis:insert {
+      name = "stastd13",
+      hosts = { "logging13.com" },
+      upstream_url = "http://mockbin.com"
+    })
+
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api12.id
+    })
+
+    assert(helpers.dao.plugins:insert {
+      name = "key-auth",
+      api_id = api13.id
     })
 
     assert(helpers.dao.plugins:insert {
@@ -54,7 +122,10 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"latency"}
+        metrics = {{
+          name = "latency",
+          stat_type = "timer"
+        }}
       }
     })
     assert(helpers.dao.plugins:insert {
@@ -63,7 +134,11 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"status_count"}
+        metrics = {{
+          name = "status_count",
+          stat_type = "counter",
+          sample_rate = 1
+        }}
       }
     })
     assert(helpers.dao.plugins:insert {
@@ -72,7 +147,10 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"request_size"}
+        metrics = {{
+          name = "request_size",
+          stat_type = "timer"
+        }}
       }
     })
     assert(helpers.dao.plugins:insert {
@@ -81,7 +159,11 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"request_count"}
+        metrics = {{
+          name = "request_count",
+          stat_type = "counter",
+          sample_rate = 1
+        }}
       }
     })
     assert(helpers.dao.plugins:insert {
@@ -90,7 +172,10 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"response_size"}
+        metrics = {{
+          name = "response_size",
+          stat_type = "timer"
+        }}
       }
     })
     assert(helpers.dao.plugins:insert {
@@ -99,7 +184,85 @@ describe("Plugin: statsd (log)", function()
       config = {
         host = "127.0.0.1",
         port = UDP_PORT,
-        metrics = {"upstream_latency"}
+        metrics = {{
+          name = "upstream_latency",
+          stat_type = "timer"
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api8.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        metrics = {{
+          name = "kong_latency",
+          stat_type = "timer"
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api9.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        metrics = {{
+          name = "unique_users",
+          stat_type = "set",
+          consumer_identifier = "custom_id"
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api10.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        metrics = {{
+          name = "status_count_per_user",
+          stat_type = "counter",
+          consumer_identifier = "custom_id",
+          sample_rate = 1
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api11.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        metrics = {{
+          name = "request_per_user",
+          stat_type = "counter",
+          consumer_identifier = "username",
+          sample_rate = 1
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api12.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        metrics = {{
+          name = "latency",
+          stat_type = "gauge",
+          sample_rate = 1
+        }}
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      api_id = api13.id,
+      name = "statsd",
+      config = {
+        host = "127.0.0.1",
+        port = UDP_PORT,
+        prefix = "prefix"
       }
     })
 
@@ -112,46 +275,98 @@ describe("Plugin: statsd (log)", function()
     helpers.stop_kong()
   end)
 
-  it("logs over UDP with default metrics", function()
-    local threads = require "llthreads2.ex"
-
-    local thread = threads.new({
-      function(port)
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", port)
-        local metrics = {}
-        for _ = 1, 7 do
-          metrics[#metrics+1] = server:receive()
-        end
-        server:close()
-        return metrics
-      end
-    }, UDP_PORT)
-    thread:start()
-
-    local response = assert(client:send {
-      method = "GET",
-      path = "/request",
-      headers = {
-        host = "logging1.com"
-      }
-    })
-    assert.res_status(200, response)
-
-    local ok, metrics = thread:join()
-    assert.True(ok)
-    assert.contains("kong.logging1_com.request.count:1|c", metrics)
-    assert.contains("kong%.logging1_com%.latency:%d+|g", metrics, true)
-    assert.contains("kong.logging1_com.request.size:98|g", metrics)
-    assert.contains("kong.logging1_com.request.status.200:1|c", metrics)
-    assert.contains("kong%.logging1_com%.response%.size:%d+|g", metrics, true)
-    assert.contains("kong%.logging1_com%.upstream_latency:%d+|g", metrics, true)
-  end)
-
   describe("metrics", function()
+    it("logs over UDP with default metrics", function()
+      local threads = require "llthreads2.ex"
+
+      local thread = threads.new({
+        function(port)
+          local socket = require "socket"
+          local server = assert(socket.udp())
+          server:settimeout(1)
+          server:setoption("reuseaddr", true)
+          server:setsockname("127.0.0.1", port)
+          local metrics = {}
+          for i = 1, 12 do
+            metrics[#metrics+1] = server:receive()
+          end
+          server:close()
+          return metrics
+        end
+      }, UDP_PORT)
+      thread:start()
+
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging1.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, metrics = thread:join()
+      assert.True(ok)
+      assert.contains("kong.stastd1.request.count:1|c", metrics)
+      assert.contains("kong.stastd1.latency:%d+|ms", metrics, true)
+      assert.contains("kong.stastd1.request.size:110|ms", metrics)
+      assert.contains("kong.stastd1.request.status.200:1|c", metrics)
+      assert.contains("kong.stastd1.request.status.total:1|c", metrics)
+      assert.contains("kong.stastd1.response.size:%d+|ms", metrics, true)
+      assert.contains("kong.stastd1.upstream_latency:%d*|ms", metrics, true)
+      assert.contains("kong.stastd1.kong_latency:%d*|ms", metrics, true)
+      assert.contains("kong.stastd1.user.uniques:robert|s", metrics)
+      assert.contains("kong.stastd1.user.robert.request.count:1|c", metrics)
+      assert.contains("kong.stastd1.user.robert.request.status.total:1|c",
+                      metrics)
+      assert.contains("kong.stastd1.user.robert.request.status.200:1|c",
+                      metrics)
+    end)
+    it("logs over UDP with default metrics and new prefix", function()
+      local threads = require "llthreads2.ex"
+
+      local thread = threads.new({
+        function(port)
+          local socket = require "socket"
+          local server = assert(socket.udp())
+          server:settimeout(1)
+          server:setoption("reuseaddr", true)
+          server:setsockname("127.0.0.1", port)
+          local metrics = {}
+          for i = 1, 12 do
+            metrics[#metrics+1] = server:receive()
+          end
+          server:close()
+          return metrics
+        end
+      }, UDP_PORT)
+      thread:start()
+
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging13.com"
+        }
+      })
+      assert.res_status(200, response)
+      local ok, metrics = thread:join()
+      assert.True(ok)
+      assert.contains("prefix.stastd13.request.count:1|c", metrics)
+      assert.contains("prefix.stastd13.latency:%d+|ms", metrics, true)
+      assert.contains("prefix.stastd13.request.size:%d*|ms", metrics, true)
+      assert.contains("prefix.stastd13.request.status.200:1|c", metrics)
+      assert.contains("prefix.stastd13.request.status.total:1|c", metrics)
+      assert.contains("prefix.stastd13.response.size:%d+|ms", metrics, true)
+      assert.contains("prefix.stastd13.upstream_latency:%d*|ms", metrics, true)
+      assert.contains("prefix.stastd13.kong_latency:%d*|ms", metrics, true)
+      assert.contains("prefix.stastd13.user.uniques:robert|s", metrics)
+      assert.contains("prefix.stastd13.user.robert.request.count:1|c", metrics)
+      assert.contains("prefix.stastd13.user.robert.request.status.total:1|c",
+                      metrics)
+      assert.contains("prefix.stastd13.user.robert.request.status.200:1|c",
+                      metrics)
+    end)
     it("request_count", function()
       local thread = helpers.udp_server(UDP_PORT)
       local response = assert(client:send {
@@ -165,10 +380,27 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.equal("kong.logging5_com.request.count:1|c", res)
+      assert.equal("kong.stastd5.request.count:1|c", res)
     end)
     it("status_count", function()
-      local thread = helpers.udp_server(UDP_PORT)
+      local threads = require "llthreads2.ex"
+
+      local thread = threads.new({
+        function(port)
+          local socket = require "socket"
+          local server = assert(socket.udp())
+          server:settimeout(1)
+          server:setoption("reuseaddr", true)
+          server:setsockname("127.0.0.1", port)
+          local metrics = {}
+          for i = 1, 2 do
+            metrics[#metrics+1] = server:receive()
+          end
+          server:close()
+          return metrics
+        end
+      }, UDP_PORT)
+      thread:start()
       local response = assert(client:send {
         method = "GET",
         path = "/request",
@@ -180,7 +412,8 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.equal("kong.logging3_com.request.status.200:1|c", res)
+      assert.contains("kong.stastd3.request.status.200:1|c", res)
+      assert.contains("kong.stastd3.request.status.total:1|c", res)
     end)
     it("request_size", function()
       local thread = helpers.udp_server(UDP_PORT)
@@ -195,7 +428,7 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.matches("kong.logging4_com.request.size:%d+|g", res)
+      assert.matches("kong.stastd4.request.size:%d+|ms", res)
     end)
     it("latency", function()
       local thread = helpers.udp_server(UDP_PORT)
@@ -210,7 +443,7 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.matches("kong.logging2_com.latency:.*|g", res)
+      assert.matches("kong.stastd2.latency:.*|ms", res)
     end)
     it("response_size", function()
       local thread = helpers.udp_server(UDP_PORT)
@@ -225,7 +458,7 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.matches("kong.logging6_com.response.size:%d+|g", res)
+      assert.matches("kong.stastd6.response.size:%d+|ms", res)
     end)
     it("upstream_latency", function()
       local thread = helpers.udp_server(UDP_PORT)
@@ -240,7 +473,100 @@ describe("Plugin: statsd (log)", function()
 
       local ok, res = thread:join()
       assert.True(ok)
-      assert.matches("kong.logging7_com.upstream_latency:.*|g", res)
+      assert.matches("kong.stastd7.upstream_latency:.*|ms", res)
+    end)
+    it("kong_latency", function()
+      local thread = helpers.udp_server(UDP_PORT)
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          host = "logging8.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.matches("kong.stastd8.kong_latency:.*|ms", res)
+    end)
+    it("unique_users", function()
+      local thread = helpers.udp_server(UDP_PORT)
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging9.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.matches("kong.stastd9.user.uniques:robert|s", res)
+    end)
+    it("status_count_per_user", function()
+      local threads = require "llthreads2.ex"
+
+      local thread = threads.new({
+        function(port)
+          local socket = require "socket"
+          local server = assert(socket.udp())
+          server:settimeout(1)
+          server:setoption("reuseaddr", true)
+          server:setsockname("127.0.0.1", port)
+          local metrics = {}
+          for i = 1, 2 do
+            metrics[#metrics+1] = server:receive()
+          end
+          server:close()
+          return metrics
+        end
+      }, UDP_PORT)
+      thread:start()
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging10.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.contains("kong.stastd10.user.robert.request.status.200:1|c", res)
+      assert.contains("kong.stastd10.user.robert.request.status.total:1|c", res)
+    end)
+    it("request_per_user", function()
+      local thread = helpers.udp_server(UDP_PORT)
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging11.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.matches("kong.stastd11.user.bob.request.count:1|c", res)
+    end)
+    it("latency as gauge", function()
+      local thread = helpers.udp_server(UDP_PORT)
+      local response = assert(client:send {
+        method = "GET",
+        path = "/request?apikey=kong",
+        headers = {
+          host = "logging12.com"
+        }
+      })
+      assert.res_status(200, response)
+
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.matches("kong%.stastd12%.latency:%d+|g", res)
     end)
   end)
 end)

--- a/spec/03-plugins/06-statsd/02-schema_spec.lua
+++ b/spec/03-plugins/06-statsd/02-schema_spec.lua
@@ -1,0 +1,114 @@
+local schemas = require "kong.dao.schemas_validation"
+local statsd_schema = require "kong.plugins.statsd.schema"
+local validate_entity = schemas.validate_entity
+
+describe("Plugin: statsd (schema)", function()
+  it("accepts empty config", function()
+    local ok, err = validate_entity({}, statsd_schema)
+    assert.is_nil(err)
+    assert.is_true(ok)
+  end)
+  it("accepts empty metrics", function()
+    local metrics_input = {}
+    local ok, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.is_nil(err)
+    assert.is_true(ok)
+  end)
+  it("accepts just one metrics", function()
+    local metrics_input = {
+      {
+        name = "request_count",
+        stat_type = "counter",
+        sample_rate = 1
+      }
+    }
+    local ok, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.is_nil(err)
+    assert.is_true(ok)
+  end)
+  it("rejects if name or stat not defined", function()
+    local metrics_input = {
+      {
+        name = "request_count",
+        sample_rate = 1
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("name and stat_type must be defined for all stats", err.metrics)
+    local metrics_input = {
+      {
+        stat_type = "counter",
+        sample_rate = 1
+      }
+    }
+    _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("name and stat_type must be defined for all stats", err.metrics)
+  end)
+  it("rejects counters without sample rate", function()
+    local metrics_input = {
+      {
+        name = "request_count",
+        stat_type = "counter",
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+  end)
+  it("rejects invalid metrics name", function()
+    local metrics_input = {
+      {
+        name = "invalid_name",
+        stat_type = "counter",
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("unrecognized metric name: invalid_name", err.metrics)
+  end)
+  it("rejects invalid stat type", function()
+    local metrics_input = {
+      {
+        name = "request_count",
+        stat_type = "invalid_stat",
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("unrecognized stat_type: invalid_stat", err.metrics)
+  end)
+  it("rejects if customer identifier missing", function()
+    local metrics_input = {
+      {
+        name = "status_count_per_user",
+        stat_type = "counter",
+        sample_rate = 1
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("consumer_identifier must be defined for metric status_count_per_user", err.metrics)
+  end)
+  it("rejects if metric has wrong stat type", function()
+    local metrics_input = {
+      {
+        name = "unique_users",
+        stat_type = "counter"
+      }
+    }
+    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("unique_users metric only works with stat_type 'set'", err.metrics)
+    metrics_input = {
+      {
+        name = "status_count",
+        stat_type = "set",
+        sample_rate = 1
+      }
+    }
+    _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
+    assert.not_nil(err)
+    assert.equal("status_count metric only works with stat_type 'counter'", err.metrics)
+  end)
+end)


### PR DESCRIPTION
### Summary

- Now each metric supports configurable stat type,
  sample rate and customer identifier if applicable.
- Custom prefix for stats's name
- New metrics `upstream_latency`, `kong_latency` and `status_count_per_user`.

### Full changelog

- Schema updated to support new metrics
- Schema updated to support `stat_type`, `sample_rate` and `consumer_identifier`
- Added new schema checks and test 

### Issues resolved
FIX #1533

NOTE: depends on the PR on https://github.com/Mashape/kong/pull/2367