### PR TITLE
tests(upstream) correctly enumerate daos in upstream integration tests

### DIFF
--- a/spec/02-integration/03-admin_api/08-upstreams_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/08-upstreams_routes_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local dao_helpers = require "spec.02-integration.02-dao.helpers"
+local DAOFactory = require "kong.dao.factory"
 
 local slots_default, slots_max = 100, 2^16
 
@@ -36,17 +37,18 @@ dao_helpers.for_each_dao(function(kong_config)
 describe("Admin API", function()
   local client
   local config_db
+  local dao
 
   setup(function()
-    config_db = helpers.test_conf.database
-    helpers.test_conf.database = kong_config.database
+    dao = assert(DAOFactory.new(kong_config))
 
-    assert(helpers.start_kong())
+    assert(helpers.start_kong{
+      database = kong_config.database
+    })
     client = assert(helpers.admin_client())
   end)
 
   teardown(function()
-    helpers.test_conf.database = config_db
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -54,7 +56,7 @@ describe("Admin API", function()
   describe("/upstreams " .. kong_config.database, function()
     describe("POST", function()
       before_each(function()
-        helpers.dao:truncate_tables()
+        dao:truncate_tables()
       end)
       it_content_types("creates an upstream with defaults", function(content_type)
         return function()
@@ -258,7 +260,7 @@ if content_type == "application/x-www-form-urlencoded" then return end
 
     describe("PUT", function()
       before_each(function()
-        helpers.dao:truncate_tables()
+        dao:truncate_tables()
       end)
 
       it_content_types("creates if not exists", function(content_type)
@@ -377,16 +379,16 @@ if content_type == "application/x-www-form-urlencoded" then return end
 
     describe("GET", function()
       setup(function()
-        helpers.dao:truncate_tables()
+        dao:truncate_tables()
 
         for i = 1, 10 do
-          assert(helpers.dao.upstreams:insert {
+          assert(dao.upstreams:insert {
             name = "upstream-"..i,
           })
         end
       end)
       teardown(function()
-        helpers.dao:truncate_tables()
+        dao:truncate_tables()
       end)
 
       it("retrieves the first page", function()
@@ -451,7 +453,7 @@ if content_type == "application/x-www-form-urlencoded" then return end
 
       describe("empty results", function()
         setup(function()
-          helpers.dao:truncate_tables()
+          dao:truncate_tables()
         end)
 
         it("data property is an empty array", function()
@@ -466,49 +468,61 @@ if content_type == "application/x-www-form-urlencoded" then return end
     end)
 
     describe("DELETE", function()
-      it("by id", function(content_type)
-          local res = assert(client:send {
-            method = "POST",
-            path = "/upstreams",
-            body = {
-              name = "my-upstream",
-              slots = 100,
-            },
-            headers = { ["Content-Type"] = "application/json" }
-          })
+      do
+        -- DELETE is currently broken when using cassandra
+        -- because the schema defines the primary key as {id, name}
+        -- but both postgres and cassandra schemas actually define
+        -- their PK with id. this causes failures because cassandra
+        -- tries to delete against a non PK column. see #2358
+        local test = it
+        if kong_config.database == "cassandra" then
+          test = pending
+        end
 
-          assert.response(res).has.status(201)
-          local json = assert.response(res).has.jsonbody()
+        test("by id", function(content_type)
+            local res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my-upstream",
+                slots = 100,
+              },
+              headers = { ["Content-Type"] = "application/json" }
+            })
 
-          res = assert(client:send {
-            method = "DELETE",
-            path = "/upstreams/" .. json.id,
-          })
+            assert.response(res).has.status(201)
+            local json = assert.response(res).has.jsonbody()
 
-          assert.response(res).has.status(204)
-      end)
+            res = assert(client:send {
+              method = "DELETE",
+              path = "/upstreams/" .. json.id,
+            })
 
-      it("by name", function(content_type)
-          local res = assert(client:send {
-            method = "POST",
-            path = "/upstreams",
-            body = {
-              name = "my-upstream",
-              slots = 100,
-            },
-            headers = { ["Content-Type"] = "application/json" }
-          })
+            assert.response(res).has.status(204)
+        end)
 
-          assert.response(res).has.status(201)
-          local json = assert.response(res).has.jsonbody()
+        test("by name", function(content_type)
+            local res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my-upstream",
+                slots = 100,
+              },
+              headers = { ["Content-Type"] = "application/json" }
+            })
 
-          res = assert(client:send {
-            method = "DELETE",
-            path = "/upstreams/" .. json.name,
-          })
+            assert.response(res).has.status(201)
+            local json = assert.response(res).has.jsonbody()
 
-          assert.response(res).has.status(204)
-      end)
+            res = assert(client:send {
+              method = "DELETE",
+              path = "/upstreams/" .. json.name,
+            })
+
+            assert.response(res).has.status(204)
+        end)
+      end
     end)
 
     it("returns 405 on invalid method", function()


### PR DESCRIPTION
This uncovers the bug detailed in #2358. This commit does not fix
this bug, it merely fixes the test behaviors to use both cassandra
and postgres.

It's like our tests need tests... ;)