### PR TITLE
Allow rate limits to be applied across APIs.

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -62,6 +62,14 @@ local function get_usage(conf, api_id, identifier, current_timestamp, limits)
   return usage, stop
 end
 
+local function get_api_id(conf)
+  if conf.cross_api then
+    return "00000000-0000-0000-0000-000000000000"
+  else
+    return ngx.ctx.api.id
+  end
+end
+
 function RateLimitingHandler:new()
   RateLimitingHandler.super.new(self, "rate-limiting")
 end
@@ -72,7 +80,7 @@ function RateLimitingHandler:access(conf)
 
   -- Consumer is identified by ip address or authenticated_credential id
   local identifier = get_identifier(conf)
-  local api_id = ngx.ctx.api.id
+  local api_id = get_api_id(conf)
   local policy = conf.policy
   local fault_tolerant = conf.fault_tolerant
 

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -17,7 +17,8 @@ return {
     redis_port = { type = "number", default = 6379 },
     redis_password = { type = "string" },
     redis_timeout = { type = "number", default = 2000 },
-    redis_database = { type = "number", default = 0 }
+    redis_database = { type = "number", default = 0 },
+    cross_api = { type = "boolean", default = false }
   },
   self_check = function(schema, plugin_t, dao, is_update)
     local ordered_periods = { "second", "minute", "hour", "day", "month", "year"}


### PR DESCRIPTION
### Summary

This PR adds the capabilities requested in #2347. A new attribute has been added to the schema to allow the caller to specify that they want the rate-limiting plugin applied across APIs. The handler has been updated to read this attribute and use a constant api_id whenever it is applied across APIs so that all requests will be allocated to the same bucket.

### Full changelog

* Add new "cross_api" schema attribute
* Update handler to honor the new attribute

### Issues resolved
Fix #2347
