### PR TITLE
fix(plugins) add unique constraint to id field

### DIFF
--- a/kong/dao/schemas/plugins.lua
+++ b/kong/dao/schemas/plugins.lua
@@ -19,7 +19,8 @@ return {
     id = {
       type = "id",
       dao_insert_value = true,
-      required = true
+      required = true,
+      unique = true,
     },
     created_at = {
       type = "timestamp",


### PR DESCRIPTION
### Summary

The compound primary key, coupled with a lack of unique constraint
on id, allows for duplicate plugin UUIDs, breaking expected behavior.
This commit adds a unique constraint in the Kong schema, and directly
to the Postgres table definition via a migration.

### Full changelog

* fix(plugins) add unique constraint to id field

### Issues resolved

Fix #2227
