### PR TITLE
fix(proxy) iterator to act on consumer, not on credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - Prevent an upstream or legitimate internal error in the load balancing code
   from throwing a Lua-land error as well.
   [#2327](https://github.com/Mashape/kong/pull/2327)
+- Ensure consumer based plugins run if the consumer was set without a
+  credential.
+  [#2424](https://github.com/Mashape/kong/pull/2424)
 - Plugins:
   - hmac: Better handling of invalid base64-encoded signatures. Previously Kong
     would return an HTTP 500 error. We now properly return HTTP 403 Forbidden.

--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -73,7 +73,7 @@ local function iter_plugins_for_req(loaded_plugins, access_or_cert_ctx)
         local plugin_configuration
 
         -- Search API and Consumer specific, or consumer specific
-        local consumer_id = (ctx.authenticated_credential or empty).consumer_id
+        local consumer_id = (ctx.authenticated_consumer or empty).id        
         if consumer_id and plugin.schema and not plugin.schema.no_consumer then
           plugin_configuration = load_plugin_configuration(ctx.api.id, consumer_id, plugin.name)
           if not plugin_configuration then


### PR DESCRIPTION
Credentials will not always be set, hence the iterator should base
itself on the consumer id set.

fixes #2414

