### PR TITLE
feat(resolver) implements search and ndots options

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.4.2",
+  "lua-resty-dns-client == 0.5.0",
   "lua-resty-worker-events == 0.3.0",
   "lua-resty-mediador == 0.1.2",
 }

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -399,6 +399,11 @@
 # DNS RESOLVER
 #------------------------------------------------------------------------------
 
+# By default the DNS resolver will use the standard configuration files
+# `/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be
+# overridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if
+# they have been set.
+
 #dns_resolver =                  # Comma separated list of nameservers, each
                                  # entry in `ipv4[:port]` format to be used by
                                  # Kong. If not specified the nameservers in
@@ -409,6 +414,17 @@
                                  # once and its content is static in memory.
                                  # To read the file again after modifying it,
                                  # Kong must be reloaded.
+
+#dns_order = LAST,SRV,A,CNAME    # the order in which to resolve different
+                                 # record types. The `LAST` type means the
+                                 # type of the last successful lookup (for the
+                                 # specified name). The format is a (case
+                                 # insensitive) comma separated list.
+
+#dns_not_found_ttl = 30.0        # ttl in seconds for empty DNS responses and
+                                 # "(3) name error" responses.
+
+#dns_error_ttl = 1.0             # ttl in seconds for error responses.
 
 #------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -99,6 +99,10 @@ local CONF_INFERENCES = {
   cluster_ttl_on_failure = {typ = "number"},
 
   dns_resolver = {typ = "array"},
+  dns_hostsfile = {typ = "string"},
+  dns_order = {typ = "array"},
+  dns_not_found_ttl = {typ = "number"},
+  dns_error_ttl = {typ = "number"},
 
   ssl = {typ = "boolean"},
   client_ssl = {typ = "boolean"},
@@ -278,6 +282,21 @@ local function check_and_infer(conf)
       if (not dns) or (dns.type ~= "ipv4") then
         errors[#errors+1] = "dns_resolver must be a comma separated list in "..
                             "the form of IPv4 or IPv4:port, got '"..server.."'"
+      end
+    end
+  end
+
+  if conf.dns_hostsfile then
+    if not pl_path.isfile(conf.dns_hostsfile) then
+      errors[#errors+1] = "dns_hostsfile: file does not exist"
+    end
+  end
+
+  if conf.dns_order then
+    local allowed = { LAST = true, A = true, CNAME = true, SRV = true }
+    for _, name in ipairs(conf.dns_order) do
+      if not allowed[name:upper()] then
+        errors[#errors+1] = "dns_order: invalid entry '" .. tostring(name) .. "'"
       end
     end
   end

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -299,7 +299,7 @@ local function execute(target)
   -- have to do a regular DNS lookup
   local ip, port = toip(target.host, target.port, dns_cache_only)
   if not ip then
-    if port == "dns server error; 3 name error" then
+    if port == "dns server error: 3 name error" then
       -- in this case a "503 service unavailable", others will be a 500.
       log(ERROR, "name resolution failed for '", tostring(target.host),
                  "': ", port)

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -69,6 +69,9 @@ cluster_ttl_on_failure = 3600
 
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts
+dns_order = LAST,SRV,A,CNAME
+dns_not_found_ttl = 30.0
+dns_error_ttl = 1.0
 
 lua_code_cache = on
 lua_socket_pool_size = 30

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -9,7 +9,6 @@ local setup_client = function(conf)
   end
 
   conf = conf or {}
-  local hosts = conf.dns_hostsfile      -- filename
   local servers = {}
   
   -- servers must be reformatted as name/port sub-arrays
@@ -21,12 +20,14 @@ local setup_client = function(conf)
   end
     
   local opts = {
-    hosts = hosts,
-    resolvConf = nil,      -- defaults to system resolv.conf
-    nameservers = servers, -- provided list or taken from resolv.conf
-    retrans = nil,         -- taken from system resolv.conf; attempts
-    timeout = nil,         -- taken from system resolv.conf; timeout
-    badTtl = nil,          -- ttl in seconds for bad dns responses (empty/error)
+    hosts = conf.dns_hostsfile,
+    resolvConf = nil,                -- defaults to system resolv.conf
+    nameservers = servers,           -- provided list or taken from resolv.conf
+    retrans = nil,                   -- taken from system resolv.conf; attempts
+    timeout = nil,                   -- taken from system resolv.conf; timeout
+    badTtl = conf.dns_not_found_ttl, -- ttl in seconds for dns error responses (except 3 - name error)
+    emptyTtl = conf.dns_error_ttl,   -- ttl in seconds for empty and "(3) name error" dns responses
+    order = conf.dns_order,          -- order of trying record types
   }
   
   assert(dns_client.init(opts))

--- a/spec/01-unit/02-conf_loader_spec.lua
+++ b/spec/01-unit/02-conf_loader_spec.lua
@@ -294,6 +294,30 @@ describe("Configuration loader", function()
       assert.is_nil(err)
       assert.is_table(conf)
     end)
+    it("errors when the hosts file does not exist", function()
+      local tmpfile = "/a_file_that_does_not_exist"
+      local conf, err = conf_loader(nil, {
+        dns_hostsfile = tmpfile,
+      })
+      assert.equal([[dns_hostsfile: file does not exist]], err)
+      assert.is_nil(conf)
+    end)
+    it("accepts an existing hosts file", function()
+      local tmpfile = require("pl.path").tmpname()  -- this creates the file!
+      finally(function() os.remove(tmpfile) end)
+      local conf, err = conf_loader(nil, {
+        dns_hostsfile = tmpfile,
+      })
+      assert.is_nil(err)
+      assert.equal(tmpfile, conf.dns_hostsfile)
+    end)
+    it("errors on bad entries in the order list", function()
+      local conf, err = conf_loader(nil, {
+        dns_order = "A,CXAME,SRV",
+      })
+      assert.is_nil(conf)
+      assert.equal([[dns_order: invalid entry 'CXAME']], err)
+    end)
     it("errors when hosts have a bad format in cassandra_contact_points", function()
       local conf, err = conf_loader(nil, {
           cassandra_contact_points = [[some/really\bad/host\name,addr2]]


### PR DESCRIPTION
implements search and ndots options from in the dns resolver.
additionally makes some more options configurable


### Issues resolved

Fixes #2201


### Notes

- Waits for the new dns resolver lib version (0.5) to be released.
- the new `ttl` settings are in `seconds` aligned with existing `ttl` settings (as opposed to `timeout` settings which all are in `milliseconds`)
