### PR TITLE
feat(log) add balancer tries and failure information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   configured log target-url includes credentials. Thanks to
   [Amir M. Saeid](https://github.com/amir) for the contribution.
   [#2430](https://github.com/Mashape/kong/pull/2430)
+- Logging retries and failure information.
+  [#2429](https://github.com/Mashape/kong/pull/2429).
 - Plugins:
   - :fireworks: **New Request termination plugin**. This plugin allows to
     temporarily disable an API and return a pre-configured response status and

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -215,9 +215,14 @@ function Kong.balancer()
     -- where the retries are executed
 
     -- record failure data
-    addr.failures = addr.failures or {}
     local state, code = get_last_failure()
-    addr.failures[addr.tries-1] = { name = state, code = code }
+    addr.failures = addr.failures or {}
+    addr.failures[addr.tries-1] = {
+      state = state,
+      code  = code,
+      ip    = addr.ip,
+      port  = addr.port,
+    }
 
     local ok, err = balancer_execute(addr)
     if not ok then

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -8,6 +8,10 @@ function _M.serialize(ngx)
       consumer_id = ngx.ctx.authenticated_credential.consumer_id
     }
   end
+  
+  local addr = ngx.ctx.balancer_address
+  local tries = addr.failures or {}
+  tries.count = addr.tries
 
   return {
     request = {
@@ -23,6 +27,7 @@ function _M.serialize(ngx)
       headers = ngx.resp.get_headers(),
       size = ngx.var.bytes_sent
     },
+    tries = tries,
     latencies = {
       kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
              (ngx.ctx.KONG_RECEIVE_TIME or 0),


### PR DESCRIPTION
The number of tries will be logged in the basic serializer. If any retries occurred, then failure information will be added as well.
