### PR TITLE
fix(jwt-auth) return 401 unauthorized instead of 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
   - hmac: Better handling of invalid base64-encoded signatures. Previously Kong
     would return an HTTP 500 error. We now properly return HTTP 403 Forbidden.
     [#2283](https://github.com/Mashape/kong/pull/2283)
+  - jwt: Returns `401 unauthorized` on invalid claims, instead of previous
+    `403 forbidden`.
+    [#2433](https://github.com/Mashape/kong/pull/2433)
 - Admin API:
   - Detect conflicts between SNI Objects in the `/snis` and `/certificates`
     endpoint.

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -148,7 +148,7 @@ local function do_authentication(conf)
   -- Verify the JWT registered claims
   local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
   if not ok_claims then
-    return false, {status = 403, message = errors}
+    return false, {status = 401, message = errors}
   end
 
   -- Retrieve the consumer


### PR DESCRIPTION
On invalid claims the JWT plugin returned `403 forbidden` instead
of the `401 unauthorized`.

fixes #2409
