### PR TITLE
chore(deps) updates dns resolver dependency to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@
 - Ensure consumer based plugins run if the consumer was set without a
   credential.
   [#2424](https://github.com/Mashape/kong/pull/2424)
+- CNAME records are now properly cached by the dns resolver.
+  [#2303](https://github.com/Mashape/kong/pull/2303)
 - Plugins:
   - hmac: Better handling of invalid base64-encoded signatures. Previously Kong
     would return an HTTP 500 error. We now properly return HTTP 403 Forbidden.

--- a/kong-0.10.1-0.rockspec
+++ b/kong-0.10.1-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.4.0",
+  "lua-resty-dns-client == 0.4.1",
   "lua-resty-worker-events == 0.3.0",
 }
 build = {


### PR DESCRIPTION
Fixes an issue with the dns resolver not properly caching CNAME records.

fixes #2303
