### PR TITLE
fix(oauth2) remove unique constraint on client_secret

### DIFF
--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -27,7 +27,7 @@ local OAUTH2_CREDENTIALS_SCHEMA = {
     consumer_id = { type = "id", required = true, foreign = "consumers:id" },
     name = { type = "string", required = true },
     client_id = { type = "string", required = false, unique = true, default = utils.random_string },
-    client_secret = { type = "string", required = false, unique = true, default = utils.random_string },
+    client_secret = { type = "string", required = false, default = utils.random_string },
     redirect_uri = { type = "array", required = true, func = validate_uris },
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true }
   },

--- a/kong/plugins/oauth2/migrations/postgres.lua
+++ b/kong/plugins/oauth2/migrations/postgres.lua
@@ -151,5 +151,14 @@ return {
         if err then return err end
       end
     end
+  },
+  {
+    name = "2017-04-24-oauth2_client_secret_not_unique",
+    up = [[
+      ALTER TABLE oauth2_credentials DROP CONSTRAINT IF EXISTS oauth2_credentials_client_secret_key;
+    ]],
+    down = [[
+      ALTER TABLE oauth2_credentials ADD CONSTRAINT oauth2_credentials_client_secret_key UNIQUE(client_secret);
+    ]],
   }
 }

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -25,6 +25,9 @@ describe("Plugin: oauth (API)", function()
       consumer = assert(helpers.dao.consumers:insert {
         username = "bob"
       })
+      assert(helpers.dao.consumers:insert {
+        username = "sally"
+      })
     end)
     after_each(function()
       helpers.dao:truncate_table("oauth2_credentials")
@@ -64,6 +67,34 @@ describe("Plugin: oauth (API)", function()
         assert.equal(consumer.id, body.consumer_id)
         assert.equal("Test APP", body.name)
         assert.equal(2, #body.redirect_uri)
+      end)
+      it("creates multiple oauth2 credentials with the same client_secret", function()
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/bob/oauth2",
+          body = {
+            name = "Test APP",
+            redirect_uri = "http://google.com/",
+            client_secret = "secret123",
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        assert.res_status(201, res)
+        res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/sally/oauth2",
+          body = {
+            name = "Test APP",
+            redirect_uri = "http://google.com/",
+            client_secret = "secret123",
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        assert.res_status(201, res)
       end)
       describe("errors", function()
         it("returns bad request", function()


### PR DESCRIPTION
### Summary

Remove the unique constraint on client_secret in the oauth2_credentials table. There appears to be no need to hold this constraint; indeed, no other authentication plugins take this approach (apart from JWT, which builds logic around maintaining a unique key).

### Full changelog

* remove unique constraint on client_secret

### Issues resolved

Fix #1972
