### PR TITLE
perf(hmac) use a simpler comparison for signature validation

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -82,28 +82,11 @@ local function create_hash(request, hmac_params, headers)
   return ngx_sha1(hmac_params.secret, signing_string)
 end
 
-local function is_digest_equal(digest_1, digest_2)
-  local result = true
-  for i=1, #digest_1 do
-    if digest_1:sub(i, i) ~= digest_2:sub(i, i) then
-      result = false
-    end
-  end
-  return result
-end
-
 local function validate_signature(request, hmac_params, headers)
   local digest = create_hash(request, hmac_params, headers)
   local sig = ngx_decode_base64(hmac_params.signature)
 
-  -- we didnt receive a well-formed base64 encoding
-  if not sig then
-    return false
-  end
-
-  if digest then
-   return is_digest_equal(digest, sig)
-  end
+  return digest == sig
 end
 
 local function load_credential_into_memory(username)


### PR DESCRIPTION
This (partially) reverts commit f5010994b9b921d799504a46a0f8d1817d656f5c.
The initial premise upon which this commit was built is incorrect;
Lua's interning of strings always means that EQ operators are constant
time. Given this, we don't need to place additional stress on the Lua
VM by creating unique string objects for each character in the client
header.
