### PR TITLE
fix(cors) proper handling of the ACAC header

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -55,11 +55,19 @@ end
 
 
 local function configure_credentials(ngx, conf)
-  if ngx.ctx.cors_allow_all then
-    ngx.header["Access-Control-Allow-Credentials"] = "false"
+  if conf.credentials then
+    if not ngx.ctx.cors_allow_all then
+      ngx.header["Access-Control-Allow-Credentials"] = "true"
+      return
+    end
 
-  elseif conf.credentials then
-    ngx.header["Access-Control-Allow-Credentials"] = "true"
+    -- Access-Control-Allow-Origin is '*', must change it because ACAC cannot
+    -- be 'true' if ACAO is '*'.
+    local req_origin = ngx.var.http_origin
+    if req_origin then
+      ngx.header["Access-Control-Allow-Origin"]      = req_origin
+      ngx.header["Access-Control-Allow-Credentials"] = "true"
+    end
   end
 end
 


### PR DESCRIPTION
Access-Control-Allow-Credentials used to systematically be set to
`false` if ACAC was `*`.

However, `false` is an invalid value for ACAC, which only accepts
`true`, and ACAO cannot be `*` when credentials are desired.

* if credentials are desired, ACAO will be set to the request's Origin
* ACAC never received `false` anymore
* tests from @thefosk in #2243, plus one more to ensure port is
  included in ACAO if present in the request's Origin.

Replace #2243