### PR TITLE
fix(admin) CORS ACAC header cannot receive false

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -152,7 +152,7 @@ server {
         default_type application/json;
         content_by_lua_block {
             ngx.header['Access-Control-Allow-Origin'] = '*'
-            ngx.header['Access-Control-Allow-Credentials'] = 'false'
+
             if ngx.req.get_method() == 'OPTIONS' then
                 ngx.header['Access-Control-Allow-Methods'] = 'GET,HEAD,PUT,PATCH,POST,DELETE'
                 ngx.header['Access-Control-Allow-Headers'] = 'Content-Type'


### PR DESCRIPTION
Remove the ACAC header set to `false` in the Admin API.

This raises an interesting concern about the Admin API: we do not allow
requests with credentials to be made to it (since ACAC is not sent with
`true`). This might warrant an update and some testing in the future.