### PR TITLE
feat(core) set SNI for upstream SSL connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - The Kong DNS resolver now honors the `MAXNS` setting (3) when parsing the
   `resolv.conf` nameservers.
   [#2290](https://github.com/Mashape/kong/issues/2290)
+- Upstream requests sent via TLS now set the upstream SNI field based on the
+  downstream request when `preserve_host` is set to true. Thanks
+  [konrade](https://github.com/konrade) for the original patch.
+  [#2225](https://github.com/Mashape/kong/pull/2225)
 - Admin API:
   - The "active targets" endpoint now only return the most recent nonzero
     weight Targets, instead of all nonzero weight targets. This is to provide

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -108,6 +108,8 @@ server {
         proxy_set_header Upgrade $upstream_upgrade;
         proxy_set_header Connection $upstream_connection;
 
+        proxy_ssl_name $upstream_host;
+
         proxy_pass_header Server;
         proxy_pass $upstream_scheme://kong_upstream;
 

--- a/spec/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/05-ssl_spec.lua
@@ -42,7 +42,30 @@ describe("SSL", function()
       http_if_terminated = false,
     })
 
-    assert(helpers.start_kong())
+    assert(helpers.dao.apis:insert {
+      name = "api-3",
+      hosts = { "ssl3.com" },
+      upstream_url = "https://localhost:10001",
+      preserve_host = true,
+    })
+
+    assert(helpers.dao.apis:insert {
+      name = "api-4",
+      hosts = { "no-sni.com" },
+      upstream_url = "https://localhost:10001",
+      preserve_host = false,
+    })
+
+    assert(helpers.dao.apis:insert {
+      name = "api-5",
+      hosts = { "nil-sni.com" },
+      upstream_url = "https://127.0.0.1:10001",
+      preserve_host = false,
+    })
+
+    assert(helpers.start_kong {
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    })
 
     admin_client = helpers.admin_client()
     client = helpers.proxy_client()
@@ -144,6 +167,59 @@ describe("SSL", function()
         }
       })
       assert.res_status(426, res)
+    end)
+  end)
+
+  describe("proxy_ssl_name", function()
+    local https_client_sni
+
+    before_each(function()
+      assert(helpers.kong_exec("restart --conf " .. helpers.test_conf_path ..
+                               " --nginx-conf spec/fixtures/custom_nginx.template"))
+
+      https_client_sni = helpers.proxy_ssl_client()
+    end)
+
+    after_each(function()
+      https_client_sni:close()
+    end)
+
+    describe("properly sets the upstream SNI with preserve_host", function()
+      it("true", function()
+        local res = assert(https_client_sni:send {
+          method = "GET",
+          path = "/ssl-inspect",
+          headers = {
+            Host = "ssl3.com"
+          }
+        })
+        local body = assert.res_status(200, res)
+        assert.equal("ssl3.com", body)
+      end)
+
+      it("false", function()
+        local res = assert(https_client_sni:send {
+          method = "GET",
+          path = "/ssl-inspect",
+          headers = {
+            Host = "no-sni.com"
+          }
+        })
+        local body = assert.res_status(200, res)
+        assert.equal("localhost", body)
+      end)
+
+      it("false and IP-based upstream_url", function()
+        local res = assert(https_client_sni:send {
+          method = "GET",
+          path = "/ssl-inspect",
+          headers = {
+            Host = "nil-sni.com"
+          }
+        })
+        local body = assert.res_status(200, res)
+        assert.equal("no SNI", body)
+      end)
     end)
   end)
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -118,6 +118,8 @@ http {
             proxy_set_header Upgrade $upstream_upgrade;
             proxy_set_header Connection $upstream_connection;
 
+            proxy_ssl_name $upstream_host;
+
             proxy_pass_header Server;
             proxy_pass $upstream_scheme://kong_upstream;
 
@@ -187,6 +189,11 @@ http {
     server {
         server_name custom_server;
         listen 9999;
+        listen 10001 ssl;
+
+        ssl_certificate ${{SSL_CERT}};
+        ssl_certificate_key ${{SSL_CERT_KEY}};
+        ssl_protocols TLSv1.1 TLSv1.2;
 
         location /custom_server_path {
             return 200;
@@ -247,6 +254,20 @@ http {
                 ngx.status = 200
                 ngx.say(json)
                 ngx.exit(200)
+            }
+        }
+
+        # N.B. this fixture only exists because the current testing environment
+        # offers no other tenable method to inspect the upstream TLS handshake
+        # this fixture SHOULD NOT be used in the future to build further tests;
+        # the location blocks here must be treated as temporary exceptions, not
+        # an acceptable pattern on which to derive further test architectures
+        location /ssl-inspect {
+            content_by_lua_block {
+                local name = ngx.var.ssl_server_name and ngx.var.ssl_server_name
+                  or "no SNI"
+
+                ngx.say(name)
             }
         }
     }


### PR DESCRIPTION
### Summary

Define the SNI field for upstream requests sent over TLS based on the downstream Host header when `preserve_host` is true (when `preserve_host` is false, the value returned from the downstream balancer is an IP address).

This PR supersedes #2225.

### Full changelog

* Define the upstream SNI field via the `proxy_ssl_name` directive.
* Use the custom Nginx template fixture to test the upstream SNI (use of this fixture is an exception, and should not be used in future tests design).

### Issues resolved

Fix #2129
