### PR TITLE
feat(core) handle native 400 response codes

### DIFF
--- a/kong/core/error_handlers.lua
+++ b/kong/core/error_handlers.lua
@@ -14,6 +14,7 @@ local xml_template = '<?xml version="1.0" encoding="UTF-8"?>\n<error><message>%s
 local html_template = '<html><head><title>Kong Error</title></head><body><h1>Kong Error</h1><p>%s.</p></body></html>'
 
 local BODIES = {
+  s400 = "Bad request",
   s404 = "Not found",
   s408 = "Request timeout",
   s411 = "Length required",

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -67,7 +67,7 @@ server {
 > else
     listen ${{PROXY_LISTEN}};
 > end
-    error_page 404 408 411 412 413 414 417 /kong_error_handler;
+    error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
     access_log logs/access.log;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -80,7 +80,7 @@ http {
 > else
         listen ${{PROXY_LISTEN}};
 > end
-        error_page 404 408 411 412 413 414 417 /kong_error_handler;
+        error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
         error_page 500 502 503 504 /kong_error_handler;
 
         access_log logs/access.log;


### PR DESCRIPTION
### Summary

In addition to BAD_REQUEST messages sent by Kong, we should also
handle natively-generated 400 response codes.

### Full changelog

* handle native 400 response codes

### Issues resolved

Fix #1816, #2085 
