### PR TITLE
hotfix(rate-limiting) properly use the selected Redis database

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -142,6 +142,14 @@ return {
         end
       end
 
+      if conf.redis_database ~= nil and conf.redis_database > 0 then
+        local ok, err = red:select(conf.redis_database)
+        if not ok then
+          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          return nil, err
+        end
+      end
+
       local periods = timestamp.get_timestamps(current_timestamp)
       local cache_key = get_local_key(api_id, identifier, periods[name], name)
       local current_metric, err = red:get(cache_key)

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -144,6 +144,14 @@ return {
         end
       end
 
+      if conf.redis_database ~= nil and conf.redis_database > 0 then
+        local ok, err = red:select(conf.redis_database)
+        if not ok then
+          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          return nil, err
+        end
+      end
+
       local periods = timestamp.get_timestamps(current_timestamp)
       local cache_key = get_local_key(api_id, identifier, periods[period], name, period)
       local current_metric, err = red:get(cache_key)

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 local REDIS_HOST = "127.0.0.1"
 local REDIS_PORT = 6379
 local REDIS_PASSWORD = ""
-local REDIS_DATABASE = 0
+local REDIS_DATABASE = 1
 
 local SLEEP_TIME = 1
 

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -5,7 +5,7 @@ local timestamp = require "kong.tools.timestamp"
 local REDIS_HOST = "127.0.0.1"
 local REDIS_PORT = 6379
 local REDIS_PASSWORD = ""
-local REDIS_DATABASE = 0
+local REDIS_DATABASE = 1
 
 local SLEEP_TIME = 1
 


### PR DESCRIPTION
* Rate Limiting and Response Rate Limiting: properly selects the Redis Database (if not `0`) when retrieving counters if the `config.policy=redis`.

