### PR TITLE
feat(cors) match configured origins as a regular expression

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -27,21 +27,30 @@ local function configure_origin(ngx, conf)
   if n_origins == 1 then
     if conf.origins[1] == "*" then
       ngx.ctx.cors_allow_all = true
-
-    else
-      ngx.header["Vary"] = "Origin"
+      ngx.header["Access-Control-Allow-Origin"] = "*"
+      return
     end
 
-    ngx.header["Access-Control-Allow-Origin"] = conf.origins[1]
-    return
+    ngx.header["Vary"] = "Origin"
+
+    -- if this doesnt look like a regex, set the ACAO header directly
+    -- otherwise, we'll fall through to an iterative search and
+    -- set the ACAO header based on the client Origin
+    local from, _, err = re_find(conf.origins[1], "^[A-Za-z0-9.:/-]+$", "jo")
+    if err then
+      ngx.log(ngx.ERR, "[cors] could not inspect origin for type: ", err)
+    end
+
+    if from then
+      ngx.header["Access-Control-Allow-Origin"] = conf.origins[1]
+      return
+    end
   end
 
   local req_origin = ngx.var.http_origin
   if req_origin then
     for _, domain in ipairs(conf.origins) do
-      local from, _, err = re_find(req_origin,
-                                   [[\Q]] .. domain .. [[\E$]],
-                                   "jo")
+      local from, _, err = re_find(req_origin, domain, "jo")
       if err then
         ngx.log(ngx.ERR, "[cors] could not search for domain: ", err)
       end

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -1,7 +1,21 @@
+local re_match = ngx.re.match
+
+local check_regex = function(value)
+  if value and (#value > 1 or value[1] ~= "*") then
+    for _, origin in ipairs(value) do
+      local _, err = re_match("just a string to test", origin)
+      if err then
+        return false, "origin '" .. origin .. "' is not a valid regex"
+      end
+    end
+  end
+  return true
+end
+
 return {
   no_consumer = true,
   fields = {
-    origins = { type = "array" },
+    origins = { type = "array", func = check_regex },
     headers = { type = "array" },
     exposed_headers = { type = "array" },
     methods = { type = "array", enum = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE" } },

--- a/spec/03-plugins/14-cors/02-schema_spec.lua
+++ b/spec/03-plugins/14-cors/02-schema_spec.lua
@@ -1,0 +1,35 @@
+local validate_entity = require("kong.dao.schemas_validation").validate_entity
+local cors_schema = require "kong.plugins.cors.schema"
+
+describe("cors schema", function()
+  it("validates '*'", function()
+    local ok, err = validate_entity({ origins = { "*" } }, cors_schema)
+
+    assert.True(ok)
+    assert.is_nil(err)
+  end)
+
+  it("validates what looks like a domain", function()
+    local ok, err = validate_entity({ origins = { "example.com" } }, cors_schema)
+
+    assert.True(ok)
+    assert.is_nil(err)
+  end)
+
+  it("validates what looks like a regex", function()
+    local ok, err = validate_entity({ origins = { [[.*\.example(?:-foo)?\.com]] } }, cors_schema)
+
+    assert.True(ok)
+    assert.is_nil(err)
+  end)
+
+  describe("errors", function()
+    it("with invalid regex in origins", function()
+      local mock_origins = { [[.*.example.com]], [[invalid_**regex]] }
+      local ok, err = validate_entity({ origins = mock_origins }, cors_schema)
+
+      assert.False(ok)
+      assert.equals("origin '" .. mock_origins[2] .. "' is not a valid regex", err.origins)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

Use the ngx.re API to match configured origins as regular expressions against the client Origin header. In cases where a single origin is configured for the plugin, set the ACAO header based on the plugin configuration if the configuration contains only non-PCRE metacharacters; otherwise, treat the single configured origin as a though multiple origins were configured, by iterating through the array and setting the ACAO header based on the client Origin.

This changeset will be accompanied by a sister PR that includes a migration of existing configured `origins` to escape `.` characters. Because such a migration will target Kong 0.11, and this PR targets Kong 0.10.3, we will commit these as separate PRs.

### Full changelog

* Examine the client Origin header against configured `origins` as a full expression
* Test setting ACAO as the plugin-configured origin when it doesn't look like a regex
* Test setting ACAO based on the client Origin when the plugin-configured origin looks like a regex
* Validate the value of configured `origins` as a valid regular expression.