### PR TITLE
chore(luacheck) re-enable unused vars linting

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,5 @@
 std             = "ngx_lua"
-unused          = false
+unused_args     = false
 redefined       = false
 max_line_length = false
 

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -183,7 +183,7 @@ return {
       clean_history(self.upstream.id, dao_factory)
 
       -- this is just a wrapper around POSTing a new target with weight=0
-      local data, err = dao_factory.targets:insert({
+      local _, err = dao_factory.targets:insert({
         target      = self.target.target,
         upstream_id = self.upstream.id,
         weight      = 0,

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -60,7 +60,6 @@ end
 
 local match_api
 local reduce
-local empty_t = {}
 
 
 local function marshall_api(api)

--- a/kong/plugins/request-termination/schema.lua
+++ b/kong/plugins/request-termination/schema.lua
@@ -1,5 +1,4 @@
 local Errors = require "kong.dao.errors"
-local utils = require "kong.tools.utils"
 
 return {
   no_consumer = true,

--- a/kong/plugins/runscope/handler.lua
+++ b/kong/plugins/runscope/handler.lua
@@ -3,8 +3,6 @@ local BasePlugin = require "kong.plugins.base_plugin"
 local log = require "kong.plugins.runscope.log"
 local public_utils = require "kong.tools.public"
 
-local ngx_log = ngx.log
-local ngx_log_ERR = ngx.ERR
 local string_find = string.find
 local req_read_body = ngx.req.read_body
 local req_get_headers = ngx.req.get_headers

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -843,7 +843,6 @@ describe("Router", function()
       it("does not read Host header if not required", function()
         local _ngx = mock_ngx("GET", "/my-api", {})
 
-        local var_mt = getmetatable(_ngx.var)
         spy.on(spy_stub, "nop")
 
         local router = assert(Router.new(use_case_apis))

--- a/spec/03-plugins/09-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/09-galileo/01-alf_spec.lua
@@ -1,5 +1,4 @@
 _G.ngx = require "spec.03-plugins.09-galileo.ngx"
-local json = require "cjson"
 
 -- asserts if an array contains a given table
 local function contains(state, args)

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -342,7 +342,7 @@ end)
 
 describe("Plugin: ldap-auth (access)", function()
 
-  local client, user1, user2, anonymous
+  local client, user1, anonymous
 
   setup(function()
     local api1 = assert(helpers.dao.apis:insert {
@@ -482,7 +482,7 @@ describe("Plugin: ldap-auth (access)", function()
       assert.request(res).has.no.header("x-anonymous-consumer")
       local id = assert.request(res).has.header("x-consumer-id")
       assert.not_equal(id, anonymous.id)
-      assert(id == user1.id or id == user2.id)
+      assert(id == user1.id)
     end)
 
     it("passes with only the first credential provided", function()

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -66,7 +66,7 @@ pending("Plugin: AWS Lambda (access)", function()
     -- invocation will take the most time
     client = helpers.proxy_client()
     client:set_timeout(2 * 60 * 1000) -- 2 minute timeout for the warmup
-    local res = assert(client:send {
+    assert(client:send {
       method = "GET",
       path = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
       headers = {

--- a/spec/03-plugins/27-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/27-request-termination/02-access_spec.lua
@@ -1,9 +1,7 @@
 local helpers = require "spec.helpers"
-local cache = require "kong.tools.database_cache"
 local cjson = require "cjson"
 
 describe("Plugin: request-termination (access)", function()
-  local plugin_config
   local client, admin_client
 
   setup(function()


### PR DESCRIPTION
The recent .luacheckrc file disabled both unused args and unused
variables. We make sure to re-enable unused variables linting, and fix
all of the mistakes made in the meanwhile.