### PR TITLE
feat(*) make Kong's require LuaRocks-aware

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+require "luarocks.loader"
+
 require("kong.core.globalpatches")({
   cli = true,
   rbusted = true

--- a/bin/kong
+++ b/bin/kong
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+require "luarocks.loader"
+
 package.path = "?/init.lua;"..package.path
 
 require("kong.cmd.init")(arg)

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -45,6 +45,7 @@ lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 
 init_by_lua_block {
+    require 'luarocks.loader'
     require 'resty.core'
     kong = require 'kong'
     kong.init()


### PR DESCRIPTION
Installation methods such as homebrew/kong must use unusual rock trees
locations. Currently, this patch is shipped with it since
Mashape/homebrew-kong#43