### PR TITLE
add default response format for when the 'Accept' header is missing

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -178,8 +178,9 @@
 # See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
 # for a description of this directive.
 
-#response_format = text/plain # The default response format to use when the
-                              # 'Accept' header is missing in the request
+#error_default_type = text/plain  # Default response format to use when the
+                                  # 'Accept' header is missing and Nginx
+                                  # is returning an error for the request.
 
 #------------------------------------------------------------------------------
 # DATASTORE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -178,9 +178,12 @@
 # See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
 # for a description of this directive.
 
-#error_default_type = text/plain  # Default response format to use when the
+#error_default_type = text/plain  # Default MIME type to use when the
                                   # 'Accept' header is missing and Nginx
                                   # is returning an error for the request.
+                                  # Accepted values are `text/plain`, `text/html`,
+                                  # `application/json` and `application/xml`.
+                                   
 
 #------------------------------------------------------------------------------
 # DATASTORE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -178,6 +178,9 @@
 # See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
 # for a description of this directive.
 
+#response_format = text/plain # The default response format to use when the
+                              # 'Accept' header is missing in the request
+
 #------------------------------------------------------------------------------
 # DATASTORE
 #------------------------------------------------------------------------------

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -68,7 +68,7 @@ local CONF_INFERENCES = {
   real_ip_header = {typ = "string"},
   real_ip_recursive = {typ = "ngx_boolean"},
   trusted_ips = {typ = "array"},
-  response_format = {enum = {"application/json", "application/xml", "text/html", "text/plain"}},
+  error_default_type = {enum = {"application/json", "application/xml", "text/html", "text/plain"}},
 
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -68,6 +68,7 @@ local CONF_INFERENCES = {
   real_ip_header = {typ = "string"},
   real_ip_recursive = {typ = "ngx_boolean"},
   trusted_ips = {typ = "array"},
+  response_format = {enum = {"application/json", "application/xml", "text/html", "text/plain"}},
 
   database = {enum = {"postgres", "cassandra"}},
   pg_port = {typ = "number"},

--- a/kong/core/error_handlers.lua
+++ b/kong/core/error_handlers.lua
@@ -36,7 +36,8 @@ return function(ngx)
   local template, message, content_type
 
   if accept_header == nil then
-    accept_header = singletons.configuration.response_format
+    accept_header = singletons.configuration.error_default_type
+  end
 
   if find(accept_header, TYPE_HTML, nil, true) then
     template = html_template

--- a/kong/core/error_handlers.lua
+++ b/kong/core/error_handlers.lua
@@ -36,9 +36,9 @@ return function(ngx)
   local template, message, content_type
 
   if accept_header == nil then
-    template = text_template
-    content_type = TYPE_PLAIN
-  elseif find(accept_header, TYPE_HTML, nil, true) then
+    accept_header = singletons.configuration.response_format
+
+  if find(accept_header, TYPE_HTML, nil, true) then
     template = html_template
     content_type = TYPE_HTML
   elseif find(accept_header, TYPE_JSON, nil, true) then

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -25,7 +25,7 @@ latency_tokens = on
 real_ip_header = X-Real-IP
 real_ip_recursive = off
 trusted_ips = NONE
-response_format = text/plain
+error_default_type = text/plain
 
 database = postgres
 pg_host = 127.0.0.1

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -25,6 +25,7 @@ latency_tokens = on
 real_ip_header = X-Real-IP
 real_ip_recursive = off
 trusted_ips = NONE
+response_format = text/plain
 
 database = postgres
 pg_host = 127.0.0.1

--- a/spec/02-integration/05-proxy/11-error_default_type.lua
+++ b/spec/02-integration/05-proxy/11-error_default_type.lua
@@ -1,0 +1,156 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local format = string.format
+
+local function start(config)
+  return function()
+    helpers.dao.apis:insert {
+      name = "api-1",
+      upstream_url = "http://127.0.0.1:3333/",
+      hosts = {
+        "example.com",
+      }
+    }
+
+    config = config or {}
+    config.nginx_conf = "spec/fixtures/custom_nginx.template"
+
+    assert(helpers.start_kong(config))
+  end
+end
+
+describe("Error Default Type", function()
+  local client
+
+  before_each(function()
+    client = helpers.proxy_client()
+  end)
+
+  after_each(function()
+    if client then
+      client:close()
+    end
+  end)
+
+  describe("(with default configuration values)", function()
+
+    setup(start {
+      nginx_conf         = "spec/fixtures/custom_nginx.template",
+    })
+
+    teardown(helpers.stop_kong)
+
+    it("should return error message in plain text", function()
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          accept = nil,
+          host   = "example.com",
+        }
+      })
+
+      local body = assert.response(res).has_status(502)
+      assert.equal("An invalid response was received from the upstream server", body)
+    end)
+  end)
+
+  describe("(with error_default_type = text/plain)", function()
+
+    setup(start {
+      nginx_conf         = "spec/fixtures/custom_nginx.template",
+      error_default_type = "text/plain",
+    })
+
+    teardown(helpers.stop_kong)
+
+    it("should return error message in plain text", function()
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          accept = nil,
+          host   = "example.com",
+        }
+      })
+
+      local body = assert.response(res).has_status(502)
+      assert.equal("An invalid response was received from the upstream server", body)
+    end)
+  end)
+
+  describe("(with error_default_type = application/json)", function()
+
+    setup(start {
+      nginx_conf         = "spec/fixtures/custom_nginx.template",
+      error_default_type = "application/json",
+    })
+
+    teardown(helpers.stop_kong)
+
+    it("should return error message in json", function()
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          accept = nil,
+          host   = "example.com",
+        }
+      })
+
+      local body = assert.response(res).has_status(502)
+      local json = cjson.decode(body)
+      assert.equal("An invalid response was received from the upstream server", json.message)
+    end)
+  end)
+
+  describe("(with error_default_type = application/xml)", function()
+
+    setup(start {
+      nginx_conf         = "spec/fixtures/custom_nginx.template",
+      error_default_type = "application/xml",
+    })
+
+    teardown(helpers.stop_kong)
+
+    it("should return error message in xml", function()
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          accept = nil,
+          host   = "example.com",
+        }
+      })
+
+      local body = assert.response(res).has_status(502)
+      local xml = '<?xml version="1.0" encoding="UTF-8"?>\n<error><message>%s</message></error>'
+      assert.equal(format(xml, "An invalid response was received from the upstream server"), body)
+    end)
+  end)
+
+  describe("(with error_default_type = text/html)", function()
+
+    setup(start {
+      nginx_conf         = "spec/fixtures/custom_nginx.template",
+      error_default_type = "text/html",
+    })
+
+    teardown(helpers.stop_kong)
+
+    it("should return error message in html", function()
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          accept = nil,
+          host   = "example.com",
+        }
+      })
+
+      local body = assert.response(res).has_status(502)
+      local html = '<html><head><title>Kong Error</title></head><body><h1>Kong Error</h1><p>%s.</p></body></html>'
+      assert.equal(format(html, "An invalid response was received from the upstream server"), body)
+    end)
+  end)
+end) 


### PR DESCRIPTION
### Summary

Implementation of #2332 providing a configurable default response type to be used when the `Accept` header is not present in the request and an unhandled error is being returned from Nginx / Kong.

### Full changelog

* Add `error_default_type` Kong configuration property.

### Issues resolved

Fix #2332
