### PR TITLE
fix(serializer) stop failing on missing structure

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,4 +1,8 @@
+local tablex = require "pl.tablex"
+
 local _M = {}
+
+local EMPTY = tablex.readonly({})
 
 function _M.serialize(ngx)
   local authenticated_entity
@@ -9,8 +13,6 @@ function _M.serialize(ngx)
     }
   end
   
-  local addr = ngx.ctx.balancer_address
-
   return {
     request = {
       uri = ngx.var.request_uri,
@@ -25,7 +27,7 @@ function _M.serialize(ngx)
       headers = ngx.resp.get_headers(),
       size = ngx.var.bytes_sent
     },
-    tries = addr.tries,
+    tries = (ngx.ctx.balancer_address or EMPTY).tries,
     latencies = {
       kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
              (ngx.ctx.KONG_RECEIVE_TIME or 0) +

--- a/spec/01-unit/13-log_serializer_spec.lua
+++ b/spec/01-unit/13-log_serializer_spec.lua
@@ -135,5 +135,14 @@ describe("Log Serializer", function()
           },
         }, res.tries)
     end)
+
+    it("does not fail when the 'balancer_address' structure is missing", function()
+      ngx.ctx.balancer_address = nil
+
+      local res = basic.serialize(ngx)
+      assert.is_table(res)
+
+      assert.is_nil(res.tries)
+    end)
   end)
 end)


### PR DESCRIPTION
if the `ngx.ctx.balancer_address` structure was missing the basic
serializer would fail.

```
2017/05/10 15:33:42 [error] 14766#0: *98833 failed to run log_by_lua*: ...cal/share/lua/5.1/kong/plugins/log-serializers/basic.lua:28: attempt to index local 'addr' (a nil value)
stack traceback:
    ...cal/share/lua/5.1/kong/plugins/log-serializers/basic.lua:28: in function 'serialize'
    /usr/local/share/lua/5.1/kong/plugins/file-log/handler.lua:76: in function 'log'
    /usr/local/share/lua/5.1/kong.lua:321: in function 'log'
    log_by_lua(nginx-kong.conf:109):2: in function <log_by_lua(nginx-kong.conf:109):1> while logging request, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", host: "localhost:8000"
```