### PR TITLE
fix(cors) send '*' in ACAO when 'conf.origins' is empty

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -16,13 +16,15 @@ CorsHandler.PRIORITY = 2000
 
 
 local function configure_origin(ngx, conf)
-  if not conf.origins then
+  local n_origins = conf.origins ~= nil and #conf.origins or 0
+
+  if n_origins == 0 then
     ngx.header["Access-Control-Allow-Origin"] = "*"
     ngx.ctx.cors_allow_all = true
     return
   end
 
-  if #conf.origins == 1 then
+  if n_origins == 1 then
     if conf.origins[1] == "*" then
       ngx.ctx.cors_allow_all = true
 

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -40,6 +40,11 @@ describe("Plugin: cors (access)", function()
       hosts = { "cors7.com" },
       upstream_url = "http://mockbin.com"
     })
+    local api8 = assert(helpers.dao.apis:insert {
+      name = "api-8",
+      hosts = { "cors-empty-origins.com" },
+      upstream_url = "http://mockbin.com"
+    })
 
     assert(helpers.dao.plugins:insert {
       name = "cors",
@@ -112,6 +117,14 @@ describe("Plugin: cors (access)", function()
       }
     })
 
+    assert(helpers.dao.plugins:insert {
+      name = "cors",
+      api_id = api8.id,
+      config = {
+        origins = {},
+      }
+    })
+
     assert(helpers.start_kong())
     client = helpers.proxy_client()
   end)
@@ -127,6 +140,28 @@ describe("Plugin: cors (access)", function()
         method = "OPTIONS",
         headers = {
           ["Host"] = "cors1.com"
+        }
+      })
+      assert.res_status(204, res)
+      assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
+      assert.equal("*", res.headers["Access-Control-Allow-Origin"])
+      assert.is_nil(res.headers["Access-Control-Allow-Headers"])
+      assert.is_nil(res.headers["Access-Control-Expose-Headers"])
+      assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+      assert.is_nil(res.headers["Access-Control-Max-Age"])
+    end)
+
+    it("gives * wildcard when origins is empty", function()
+      -- this test covers a regression introduced in 0.10.1, where
+      -- the 'multiple_origins' migration would always insert a table
+      -- (that might be empty) in the 'config.origins' field, and the
+      -- * wildcard would only been sent when said table was **nil**,
+      -- and not necessarily empty.
+
+      local res = assert(client:send {
+        method  = "OPTIONS",
+        headers = {
+          ["Host"] = "cors-empty-origins.com",
         }
       })
       assert.res_status(204, res)


### PR DESCRIPTION
### Summary

This fixes a regression introduced in 0.10.1, where the migration would
set the new `conf.origins` field to an empty table, but the code would
only set `*` if the table was `nil`, and not empty.

We are reluctant to update the migration due to the immutable nature
that they should carry (in order to avoid divergence between users who
already ran them, and users who will run it after this patch), so this
changes the business logic to be more robust instead, which we probably
want anyways.

This regression was documented post-release, in #2517.

### Full changelog

* handle empty `config.origins` in the CORS ACAO business logic
* regression test

Relates to #2517
