### PR TITLE
fix(router) ensure transparent proxying of URIs

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -632,8 +632,9 @@ function _M.new(apis)
 
 
   function self.exec(ngx)
-    local method = ngx.req.get_method()
-    local uri    = ngx.var.request_uri
+    local method      = ngx.req.get_method()
+    local request_uri = ngx.var.request_uri
+    local uri         = request_uri
 
 
     do
@@ -659,16 +660,12 @@ function _M.new(apis)
       return nil
     end
 
-    local new_uri
-    local uri_root = uri == "/"
+    local uri_root = request_uri == "/"
 
-    if uri_root or not api_t.strip_uri_regex then
-      new_uri = uri
-
-    else
+    if not uri_root and api_t.strip_uri_regex then
       local _, err
-      new_uri, _, err = re_sub(uri, api_t.strip_uri_regex, "/$1", "ajo")
-      if not new_uri then
+      uri, _, err = re_sub(uri, api_t.strip_uri_regex, "/$1", "ajo")
+      if not uri then
         log(ERR, "could not strip URI: ", err)
         return
       end
@@ -677,32 +674,27 @@ function _M.new(apis)
 
     local upstream = api_t.upstream
     if upstream.path and upstream.path ~= "/" then
-      if new_uri ~= "/" then
-        new_uri = upstream.file .. new_uri
+      if uri ~= "/" then
+        uri = upstream.file .. uri
 
       else
         if upstream.path ~= upstream.file then
-          if uri_root or sub(uri, -1) == "/" then
-            new_uri = upstream.path
+          if uri_root or sub(request_uri, -1) == "/" then
+            uri = upstream.path
 
           else
-            new_uri = upstream.file
+            uri = upstream.file
           end
 
         else
-          if uri_root or sub(uri, -1) ~= "/" then
-            new_uri = upstream.file
+          if uri_root or sub(request_uri, -1) ~= "/" then
+            uri = upstream.file
 
           else
-            new_uri = upstream.file .. new_uri
+            uri = upstream.file .. uri
           end
         end
       end
-    end
-
-
-    if new_uri ~= uri then
-      uri = new_uri
     end
 
 

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -702,7 +702,7 @@ function _M.new(apis)
 
 
     if new_uri ~= uri then
-      ngx.req.set_uri(new_uri)
+      uri = new_uri
     end
 
 
@@ -717,7 +717,7 @@ function _M.new(apis)
       ngx.header["Kong-Api-Name"] = api_t.api.name
     end
 
-    return api_t.api, api_t.upstream, host_header
+    return api_t.api, api_t.upstream, host_header, uri
   end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -108,6 +108,7 @@ server {
     location / {
         set $upstream_host nil;
         set $upstream_scheme nil;
+        set $upstream_uri nil;
 
         rewrite_by_lua_block {
             kong.rewrite()
@@ -128,7 +129,7 @@ server {
 
         proxy_ssl_name $upstream_host;
 
-        proxy_pass $upstream_scheme://kong_upstream;
+        proxy_pass $upstream_scheme://kong_upstream$upstream_uri;
 
         header_filter_by_lua_block {
             kong.header_filter()

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -798,9 +798,6 @@ describe("Router", function()
           end
         }),
         req = {
-          set_uri = function(request_uri)
-            _ngx.var.request_uri = request_uri
-          end,
           get_method = function()
             return method
           end,
@@ -813,7 +810,7 @@ describe("Router", function()
       return _ngx
     end
 
-    it("returns api/scheme/host/port", function()
+    it("returns api/upstream info/host/uri", function()
       local use_case_apis = {
         {
           name = "api-1",
@@ -830,18 +827,22 @@ describe("Router", function()
       local router = assert(Router.new(use_case_apis))
 
       local _ngx = mock_ngx("GET", "/my-api", {})
-      local api, upstream = router.exec(_ngx)
+      local api, upstream, host_header, uri = router.exec(_ngx)
       assert.same(use_case_apis[1], api)
       assert.equal("http", upstream.scheme)
       assert.equal("httpbin.org", upstream.host)
       assert.equal(80, upstream.port)
+      assert.is_nil(host_header) -- only when `preserve_host = true`
+      assert.equal("/my-api", uri)
 
       local _ngx = mock_ngx("GET", "/my-api-2", {})
-      api, upstream = router.exec(_ngx)
+      api, upstream, host_header, uri = router.exec(_ngx)
       assert.same(use_case_apis[2], api)
       assert.equal("https", upstream.scheme)
       assert.equal("httpbin.org", upstream.host)
       assert.equal(443, upstream.port)
+      assert.is_nil(host_header) -- only when `preserve_host = true`
+      assert.equal("/my-api-2", uri)
     end)
 
     it("parses path component from upstream_url property", function()
@@ -897,9 +898,9 @@ describe("Router", function()
       local router = assert(Router.new(use_case_apis))
 
       local _ngx = mock_ngx("GET", "/endel%C3%B8st", {})
-      local api  = router.exec(_ngx)
+      local api, _, _, uri = router.exec(_ngx)
       assert.same(use_case_apis[1], api)
-      assert.equal("/endel%C3%B8st", _ngx.var.request_uri)
+      assert.equal("/endel%C3%B8st", uri)
     end)
 
     describe("grab_headers", function()
@@ -965,25 +966,25 @@ describe("Router", function()
       it("strips the specified uris from the given uri if matching", function()
         local _ngx = mock_ngx("GET", "/my-api/hello/world", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/hello/world", _ngx.var.request_uri)
+        assert.equal("/hello/world", uri)
       end)
 
       it("strips if matched URI is plain (not a prefix)", function()
         local _ngx = mock_ngx("GET", "/my-api", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
       end)
 
       it("doesn't strip if 'strip_uri' is not enabled", function()
         local _ngx = mock_ngx("POST", "/my-api/hello/world", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[2], api)
-        assert.equal("/my-api/hello/world", _ngx.var.request_uri)
+        assert.equal("/my-api/hello/world", uri)
       end)
 
       it("does not strips root / URI", function()
@@ -999,45 +1000,45 @@ describe("Router", function()
 
         local _ngx = mock_ngx("POST", "/my-api/hello/world", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/my-api/hello/world", _ngx.var.request_uri)
+        assert.equal("/my-api/hello/world", uri)
       end)
 
       it("can find an API with stripped URI several times in a row", function()
         local _ngx = mock_ngx("GET", "/my-api", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
 
         _ngx = mock_ngx("GET", "/my-api", {})
-        local api2 = router.exec(_ngx)
+        local api2, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api2)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
       end)
 
       it("can proxy an API with stripped URI with different URIs in a row", function()
         local _ngx = mock_ngx("GET", "/my-api", {})
 
-        local api = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
 
         _ngx = mock_ngx("GET", "/this-api", {})
-        api = router.exec(_ngx)
+        api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
 
         _ngx = mock_ngx("GET", "/my-api", {})
-        api = router.exec(_ngx)
+        api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
 
         _ngx = mock_ngx("GET", "/this-api", {})
-        api = router.exec(_ngx)
+        api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
       end)
 
       it("strips url encoded uris", function()
@@ -1052,9 +1053,9 @@ describe("Router", function()
         local router = assert(Router.new(use_case_apis))
 
         local _ngx = mock_ngx("GET", "/endel%C3%B8st", {})
-        local api  = router.exec(_ngx)
+        local api, _, _, uri = router.exec(_ngx)
         assert.same(use_case_apis[1], api)
-        assert.equal("/", _ngx.var.request_uri)
+        assert.equal("/", uri)
       end)
     end)
 
@@ -1211,10 +1212,10 @@ describe("Router", function()
           local router = assert(Router.new(use_case_apis) )
 
           local _ngx = mock_ngx("GET", args[3], {})
-          local api, upstream = router.exec(_ngx)
+          local api, upstream, _, uri = router.exec(_ngx)
           assert.same(use_case_apis[1], api)
           assert.equal(args[1], upstream.path)
-          assert.equal(args[4], _ngx.var.request_uri)
+          assert.equal(args[4], uri)
         end)
       end
     end)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -149,6 +149,79 @@ describe("Router", function()
     end)
   end)
 
+  describe("URI arguments (querystring)", function()
+
+    setup(function()
+      insert_apis {
+        {
+          name = "api-1",
+          upstream_url = "http://httpbin.org",
+          hosts = { "example.com" },
+        },
+        {
+          name = "api-2",
+          upstream_url = "http://localhost:9999",
+          hosts = { "localhost" },
+        },
+      }
+
+      assert(helpers.start_kong {
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      })
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    it("preserves URI arguments", function()
+      local res = assert(client:send {
+        method = "GET",
+        path   = "/get",
+        query  = {
+          foo   = "bar",
+          hello = "world",
+        },
+        headers = {
+          ["Host"] = "example.com",
+        },
+      })
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("bar", json.args.foo)
+      assert.equal("world", json.args.hello)
+    end)
+
+    it("does proxy an empty querystring if URI does not contain arguments", function()
+      local res = assert(client:send {
+        method = "GET",
+        path   = "/get?",
+        headers = {
+          ["Host"] = "localhost",
+        },
+      })
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.matches("/get%?$", json.vars.request_uri)
+    end)
+
+    it("does proxy a querystring with an empty value", function()
+      local res = assert(client:send {
+        method = "GET",
+        path   = "/get?hello",
+        headers = {
+          ["Host"] = "example.com",
+        },
+      })
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.matches("/get%?hello$", json.url)
+    end)
+  end)
+
   describe("percent-encoded URIs", function()
 
     setup(function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -105,6 +105,7 @@ http {
         location / {
             set $upstream_host nil;
             set $upstream_scheme nil;
+            set $upstream_uri nil;
 
             access_by_lua_block {
                 kong.access()
@@ -121,7 +122,7 @@ http {
 
             proxy_ssl_name $upstream_host;
 
-            proxy_pass $upstream_scheme://kong_upstream;
+            proxy_pass $upstream_scheme://kong_upstream$upstream_uri;
 
             header_filter_by_lua_block {
                 kong.header_filter()


### PR DESCRIPTION
### Summary

Since `ngx.req.set_uri` will make Nginx's proxying escape the upstream URI, we do not use this API anymore. As it was the case prior to Kong 0.10, we go back to inlining an Nginx variable containing the desired, plain URI, and thus ensure Nginx will not unconditionally percent-encode before proxying.

### Full Changelog

* The router now returns a 4th value: the URI to use for the upstream
  call.
* The `proxy_pass` directive now inlines a new `$upstream_uri` variable
  which contains a raw string with both the Nginx `$request_uri` and
  `$args` variables.
* Update the router value return test
* New test to ensure we proxy the request's querystring
* New regression test to ensure we do not double percent-encode request
  URIs.
* simplify URI stripping logic

### Issues resolved

Fix #2512