### PR TITLE
sort category.apis_by_methods to fix a routing problem 

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -433,7 +433,7 @@ function _M.new(apis)
     categorize_api_t(api_t, categories)
   end
 
-  local compare = function(a,b, category_bit)
+  local function compare(a,b, category_bit)
     if not band(category_bit, MATCH_RULES.URI) then
       return
     end
@@ -462,6 +462,11 @@ function _M.new(apis)
     end)
     for _, apilist_by_method in pairs(category.apis_by_methods) do
       table.sort(apilist_by_method, function(a,b)
+        return compare(a,b,category_bit)
+      end)
+    end
+    for _, apilist_by_host in pairs(category.apis_by_plain_hosts) do
+      table.sort(apilist_by_host, function(a,b)
         return compare(a,b,category_bit)
       end)
     end

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -433,30 +433,38 @@ function _M.new(apis)
     categorize_api_t(api_t, categories)
   end
 
+  local compare = function(a,b, category_bit)
+    if not band(category_bit, MATCH_RULES.URI) then
+      return
+    end
+
+    local max_uri_a = 0
+    local max_uri_b = 0
+
+    for _, prefix in ipairs(a.uris_prefixes_regexes) do
+      if #prefix.regex > max_uri_a then
+        max_uri_a = #prefix.regex
+      end
+    end
+
+    for _, prefix in ipairs(b.uris_prefixes_regexes) do
+      if #prefix.regex > max_uri_b then
+        max_uri_b = #prefix.regex
+      end
+    end
+
+    return max_uri_a > max_uri_b
+  end
 
   for category_bit, category in pairs(categories) do
-    table.sort(category.apis, function(a, b)
-      if not band(category_bit, MATCH_RULES.URI) then
-        return
-      end
-
-      local max_uri_a = 0
-      local max_uri_b = 0
-
-      for _, prefix in ipairs(a.uris_prefixes_regexes) do
-        if #prefix.regex > max_uri_a then
-          max_uri_a = #prefix.regex
-        end
-      end
-
-      for _, prefix in ipairs(b.uris_prefixes_regexes) do
-        if #prefix.regex > max_uri_b then
-          max_uri_b = #prefix.regex
-        end
-      end
-
-      return max_uri_a > max_uri_b
+    table.sort(category.apis, function(a,b)
+      return compare(a,b,category_bit)
     end)
+    for _, apilist_by_method in pairs(category.apis_by_methods) do
+      table.sort(apilist_by_method, function(a,b)
+        return compare(a,b,category_bit)
+      end)
+    end
   end
 
 

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -207,6 +207,43 @@ describe("Router", function()
         assert.same(use_case[1], api_t.api)
       end)
 
+      it("does not superseds another API with a longer URI prefix while hosts are also defined", function()
+        local use_case = {
+          {
+            name = "api-1",
+            uris = { "/my-api" },
+            headers = {
+              ["host"] = {"domain.org"},
+            },
+          },
+          {
+            name = "api-2",
+            uris = { "/my-api/hello" },
+            headers = {
+              ["host"] = {"domain.org"},
+            },
+          }
+        }
+
+        local router = assert(Router.new(use_case))
+
+        local api_t = router.select("GET", "/my-api/hello", "domain.org")
+        assert.truthy(api_t)
+        assert.same(use_case[2], api_t.api)
+
+        api_t = router.select("GET", "/my-api/hello/world", "domain.org")
+        assert.truthy(api_t)
+        assert.same(use_case[2], api_t.api)
+
+        api_t = router.select("GET", "/my-api", "domain.org")
+        assert.truthy(api_t)
+        assert.same(use_case[1], api_t.api)
+
+        api_t = router.select("GET", "/my-api/world", "domain.org")
+        assert.truthy(api_t)
+        assert.same(use_case[1], api_t.api)
+      end)
+
       it("only matches URI as a prefix (anchored mode)", function()
         local use_case = {
           {

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -174,6 +174,39 @@ describe("Router", function()
         assert.same(use_case[2], api_t.api)
       end)
 
+      it("does not superseds another API with a longer URI prefix while methods are also defined", function()
+        local use_case = {
+          {
+            name = "api-1",
+            methods = {"POST", "PUT", "GET"},
+            uris = { "/my-api" },
+          },
+          {
+            name = "api-2",
+            methods = {"POST", "PUT", "GET"},
+            uris = { "/my-api/hello" },
+          }
+        }
+
+        local router = assert(Router.new(use_case))
+
+        local api_t = router.select("GET", "/my-api/hello")
+        assert.truthy(api_t)
+        assert.same(use_case[2], api_t.api)
+
+        api_t = router.select("GET", "/my-api/hello/world")
+        assert.truthy(api_t)
+        assert.same(use_case[2], api_t.api)
+
+        api_t = router.select("GET", "/my-api")
+        assert.truthy(api_t)
+        assert.same(use_case[1], api_t.api)
+
+        api_t = router.select("GET", "/my-api/world")
+        assert.truthy(api_t)
+        assert.same(use_case[1], api_t.api)
+      end)
+
       it("only matches URI as a prefix (anchored mode)", function()
         local use_case = {
           {

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -390,7 +390,7 @@ describe("Router", function()
       end)
     end)
   end)
-  
+
   describe("edge-cases", function()
 
     setup(function()
@@ -465,6 +465,43 @@ describe("Router", function()
         method = "GET",
         path = "/root/fixture/get",
         headers = { ["kong-debug"] = 1 }
+      })
+
+      assert.response(res).has_status(200)
+      assert.equal("fixture-api", res.headers["kong-api-name"])
+    end)
+  end)
+
+  describe("edge-cases where longer uris should be matched first while host and uri are both defined", function()
+
+    setup(function()
+      insert_apis {
+        {
+          name = "root-api",
+          hosts = "api.com",
+          upstream_url = "http://httpbin.org",
+          uris = "/root",
+        },
+        {
+          name = "fixture-api",
+          hosts = "api.com",
+          upstream_url = "http://httpbin.org",
+          uris = "/root/fixture",
+        },
+      }
+
+      assert(helpers.start_kong())
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    it("route to the correct api when requested with a subpath", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/root/fixture/get",
+        headers = { ["kong-debug"] = 1, ["Host"] = "api.com" }
       })
 
       assert.response(res).has_status(200)


### PR DESCRIPTION
### Summary

Sort category.apis_by_methods in router.lua to fix a routing problem for APIs defined with method and uri (path)

### Full changelog

* Sort category.apis_by_methods in router.lua to fix a routing problem for APIs defined with method and uri (path). Also add unit test and integration test for it.

### Issues resolved

Fix #2522
