### PR TITLE
perf(ip-restriction) faster iputils checking

### DIFF
--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -2,9 +2,52 @@ local BasePlugin = require "kong.plugins.base_plugin"
 local responses = require "kong.tools.responses"
 local iputils = require "resty.iputils"
 
+local new_tab
+do
+  local ok
+  ok, new_tab = pcall(require, "table.new")
+  if not ok then
+    new_tab = function() return {} end
+  end
+end
+
+
+-- cache of parsed CIDR values
+local cache = {}
+
+
 local IpRestrictionHandler = BasePlugin:extend()
 
 IpRestrictionHandler.PRIORITY = 990
+
+local function cidr_cache(cidr_tab)
+  local cidr_tab_len = #cidr_tab
+
+  local parsed_cidrs = new_tab(cidr_tab_len, 0) -- table of parsed cidrs to return
+
+  -- build a table of parsed cidr blocks based on configured
+  -- cidrs, either from cache or via iputils parse
+  -- TODO dont build a new table every time, just cache the final result
+  -- best way to do this will require a migration (see PR details)
+  for i = 1, cidr_tab_len do
+    local cidr        = cidr_tab[i]
+    local parsed_cidr = cache[cidr]
+
+    if parsed_cidr then
+      parsed_cidrs[i] = parsed_cidr
+
+    else
+      -- if we dont have this cidr block cached,
+      -- parse it and cache the results
+      local lower, upper = iputils.parse_cidr(cidr)
+
+      cache[cidr] = { lower, upper }
+      parsed_cidrs[i] = cache[cidr]
+    end
+  end
+
+  return parsed_cidrs
+end
 
 function IpRestrictionHandler:new()
   IpRestrictionHandler.super.new(self, "ip-restriction")
@@ -21,18 +64,18 @@ end
 function IpRestrictionHandler:access(conf)
   IpRestrictionHandler.super.access(self)
   local block = false
-  local remote_addr = ngx.var.remote_addr
+  local binary_remote_addr = ngx.var.binary_remote_addr
 
-  if not remote_addr then
+  if not binary_remote_addr then
     return responses.send_HTTP_FORBIDDEN("Cannot identify the client IP address, unix domain sockets are not supported.")
   end
 
   if conf.blacklist and #conf.blacklist > 0 then
-    block = iputils.ip_in_cidrs(remote_addr, iputils.parse_cidrs(conf.blacklist))
+    block = iputils.binip_in_cidrs(binary_remote_addr, cidr_cache(conf.blacklist))
   end
 
   if conf.whitelist and #conf.whitelist > 0 then
-    block = not iputils.ip_in_cidrs(remote_addr, iputils.parse_cidrs(conf.whitelist))
+    block = not iputils.binip_in_cidrs(binary_remote_addr, cidr_cache(conf.whitelist))
   end
 
   if block then


### PR DESCRIPTION
Using the binary representation of the address (e.g. via ngx.var.binary_remote_addr) is a more efficient approach, as we no longer need to rely on a small LRU cache to store binary-parsed CIDR and IP objects. To achieve this, we rely on a read-through module-level cache of parsed CIDR objects to call iputils.binip_in_cidrs directly; parsed CIDRs objects by definition are consistent, so we needn't worry about cache invalidation here.

This is still not an optimal approach, as the cache function still builds a new table on each execution. Ideally we would cache the entirety of this function as a single table; the trick here is defining the cache key. The speediest cache key would be a pregenerated string (such as a UUID) associated with the plugin object, but this would require a migration to add the schema field, as well as hooks to handle invalidations of the module cache. Given the pending EOL of serf and the associated changes to invalidation mechanisms, it makes more sense to submit such a PR targeting 0.11 after said update has been merged.