### PR TITLE
fix(c*) pass lua_trusted_ssl_cert to lua-cassandra

### DIFF
--- a/kong-0.10.2-0.rockspec
+++ b/kong-0.10.2-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5",
   "version == 0.2",
   "lapis == 1.5.1",
-  "lua-cassandra == 1.2.1",
+  "lua-cassandra == 1.2.2",
   "pgmoon-mashape == 2.0.1",
   "luatz == 0.3",
   "lua_system_constants == 0.1.1",

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -47,8 +47,9 @@ function _M.new(kong_config)
     max_schema_consensus_wait = kong_config.cassandra_schema_consensus_timeout,
     ssl = kong_config.cassandra_ssl,
     verify = kong_config.cassandra_ssl_verify,
+    cafile = kong_config.lua_ssl_trusted_certificate,
     lock_timeout = 30,
-    silent = ngx.IS_CLI
+    silent = ngx.IS_CLI,
   }
 
   if ngx.IS_CLI then
@@ -196,14 +197,14 @@ function _M:close_coordinator()
     return nil, "no coordinator"
   end
 
-  local ok, err = coordinator:close()
-  if not ok then
+  local _, err = coordinator:close()
+  if err then
     return nil, err
   end
 
   coordinator = nil
 
-  return ok
+  return true
 end
 
 function _M:wait_for_schema_consensus()


### PR DESCRIPTION
Set LuaSocket's `cafile` option when we are in a context that does not
support cosockets.

Fix #2528
See thibaultcha/lua-cassandra#95