### PR TITLE
fix(jwt) remove unique constraint on secret

### DIFF
--- a/kong/plugins/jwt/daos.lua
+++ b/kong/plugins/jwt/daos.lua
@@ -10,7 +10,7 @@ local SCHEMA = {
     created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
     consumer_id = {type = "id", required = true, foreign = "consumers:id"},
     key = {type = "string", unique = true, default = utils.random_string},
-    secret = {type = "string", unique = true, default = utils.random_string},
+    secret = {type = "string", default = utils.random_string},
     rsa_public_key = {type = "string"},
     algorithm = {type = "string", enum = {"HS256", "RS256", "ES256"}, default = 'HS256'}
   },

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -38,5 +38,14 @@ return {
       ALTER TABLE jwt_secrets DROP COLUMN algorithm;
       ALTER TABLE jwt_secrets DROP COLUMN rsa_public_key;
     ]]
+  },
+  {
+    name = "2017-05-22-jwt_secret_not_unique",
+    up = [[
+      ALTER TABLE jwt_secrets DROP CONSTRAINT IF EXISTS jwt_secrets_secret_key;
+    ]],
+    down = [[
+      ALTER TABLE jwt_secrets ADD CONSTRAINT jwt_secrets_secret_key UNIQUE(secret);
+    ]],
   }
 }

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -20,6 +20,9 @@ describe("Plugin: jwt (API)", function()
       consumer = assert(helpers.dao.consumers:insert {
         username = "bob"
       })
+      assert(helpers.dao.consumers:insert {
+        username = "alice"
+      })
     end)
 
     describe("POST", function()
@@ -59,6 +62,41 @@ describe("Plugin: jwt (API)", function()
         assert.equal("bob2", body.key)
         assert.equal("tooshort", body.secret)
         jwt2 = body
+      end)
+      it("accepts duplicate `secret` parameters across jwt_secrets", function()
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/alice/jwt/",
+          body = {
+            key = "alice",
+            secret = "foobarbaz"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = cjson.decode(assert.res_status(201, res))
+        assert.equal("alice", body.key)
+        assert.equal("foobarbaz", body.secret)
+        jwt1 = body
+
+        res = assert(admin_client:send {
+          method = "POST",
+          path = "/consumers/bob/jwt/",
+          body = {
+            key = "bobsyouruncle",
+            secret = "foobarbaz"
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        body = cjson.decode(assert.res_status(201, res))
+        assert.equal("bobsyouruncle", body.key)
+        assert.equal("foobarbaz", body.secret)
+        jwt2 = body
+
+        assert.equals(jwt1.secret, jwt2.secret)
       end)
       it("accepts a valid public key for RS256 when posted urlencoded", function()
         local rsa_public_key = fixtures.rs256_public_key
@@ -180,7 +218,7 @@ describe("Plugin: jwt (API)", function()
           path = "/consumers/bob/jwt/",
         })
         local body = cjson.decode(assert.res_status(200, res))
-        assert.equal(4, #(body.data))
+        assert.equal(6, #(body.data))
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

Remove the unique constraint from `jwt_secrets.secret`. This constraint was applied when the plugin was initially introduced; it does not provide any use.

### Full changelog

* Remove unique constraint from `jwt_secrets` DAO.
* Remove unique constraint from Postgres schema.
* Add test allowing duplicate secrets.

### Issues resolved

Fix #1512 
