### PR TITLE
fix(admin-api/status) removed counters and added simple DB ping

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -90,15 +90,18 @@ return {
           connections_handled = tonumber(handled),
           total_requests = tonumber(total)
         },
-        database = {}
+        database = {
+          reachable = false
+        }
       }
 
-      for k, v in pairs(dao.daos) do
-        local count, err = v:count()
-        if err then
-          return helpers.responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
-        end
-        status_response.database[k] = count
+      -- ping DB
+      local ok, err = dao.db:reachable()
+      if not ok then
+        ngx.log(ngx.ERR, "failed to reach database as part of ",
+                         "/status endpoint: ", err)
+      else
+        status_response.database.reachable = true
       end
 
       return helpers.responses.send_HTTP_OK(status_response)

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -24,8 +24,8 @@ _M.dao_insert_values = {
     return uuid()
   end,
   timestamp = function()
-    -- return time in UNIT millisecond, and PRECISION millisecond 
-    return math.floor(timestamp.get_utc_ms()) 
+    -- return time in UNIT millisecond, and PRECISION millisecond
+    return math.floor(timestamp.get_utc_ms())
   end
 }
 
@@ -658,6 +658,40 @@ function _M:record_migration(id, name)
   })
   if not res then return nil, err end
   return true
+end
+
+function _M:reachable()
+  local q_keyspace_exists
+
+  assert(self.release_version, "release_version not set for Cassandra cluster")
+
+  if self.release_version == 3 then
+    q_keyspace_exists = [[
+      SELECT * FROM system_schema.keyspaces
+      WHERE keyspace_name = ?
+    ]]
+  else
+    q_keyspace_exists = [[
+      SELECT * FROM system.schema_keyspaces
+      WHERE keyspace_name = ?
+    ]]
+  end
+
+  local rows, err = self:query(q_keyspace_exists, {
+    self.cluster_options.keyspace
+  }, {
+    prepared = false
+  }, nil, true)
+
+  if not rows then
+    return nil, err
+  end
+
+  if #rows > 0  then
+    return true
+  end
+
+  return false
 end
 
 return _M

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -516,4 +516,20 @@ function _M:record_migration(id, name)
   return true
 end
 
+function _M:reachable()
+  local query = fmt("SELECT * FROM pg_stat_database where datname='%s'",
+                    self.query_options.database)
+
+  local rows, err = self:query(query)
+  if not rows then
+    return nil, err
+  end
+
+  if #rows > 0  then
+    return true
+  end
+
+  return false
+end
+
 return _M

--- a/spec/02-integration/03-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/01-kong_routes_spec.lua
@@ -97,9 +97,7 @@ describe("Admin API", function()
       assert.is_table(json.database)
       assert.is_table(json.server)
 
-      for k in pairs(helpers.dao.daos) do
-        assert.is_number(json.database[k])
-      end
+      assert.is_boolean(json.database.reachable)
 
       assert.is_number(json.server.connections_accepted)
       assert.is_number(json.server.connections_active)


### PR DESCRIPTION
### Summary

In favor to make `/status` admin API fast and constant time execution(short of), counters are removed and DB reachability status added.

### Full changelog

* Added reachability check to DB is done by firing a light query
  to check if keyspace/database exists in DB.
* Removed counters from `/status` api response and `reachable` status added.
![image](https://cloud.githubusercontent.com/assets/8146958/26426510/b7d671da-408d-11e7-9e39-f993ae965f24.png)

* Updated related test.


Note: Existing version of DataDog agent will not work with above fix.
  A separate PR would be sent to DD repo to fix that too.