### PR TITLE
chore(deps) update dns resolver lib to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
 - SSL connections to Cassandra can now properly verify the
   certificate in use (when `cassandra_ssl_verify` is enabled).
   [#2531](https://github.com/Mashape/kong/pull/2531)
+- [DNS resolver dependency](https://github.com/Mashape/lua-resty-dns-client/tree/0.4.x)
+  updated to 0.4.2. This fixes a casing bug, a problem
+  with looking up ip addresses and adds more verbose logging.
+  
 - Plugins
   - All authentication plugins don't throw an error anymore when
     invalid credentials are given and the `anonymous` user isn't

--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.4.1",
+  "lua-resty-dns-client == 0.4.2",
   "lua-resty-worker-events == 0.3.0",
 }
 build = {


### PR DESCRIPTION
fixes:

- problem with case sensitivity
- ip addresses being erratically looked up
- adds more verbose logging
