### PR TITLE
hotfix(ngxconf) ensure init/init_worker logs show up

### DIFF
--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -3,7 +3,7 @@ worker_processes ${{NGINX_WORKER_PROCESSES}};
 daemon ${{NGINX_DAEMON}};
 
 pid pids/nginx.pid;
-error_log logs/error.log ${{LOG_LEVEL}};
+error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if nginx_optimizations then
 worker_rlimit_nofile ${{WORKER_RLIMIT}};

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -5,6 +5,8 @@ charset UTF-8;
 ${{SYSLOG_REPORTS}}
 > end
 
+error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
+
 > if nginx_optimizations then
 >-- send_timeout 60s;          # default value
 >-- keepalive_timeout 75s;     # default value


### PR DESCRIPTION
This is a follow up fix to
23585aad6db6bc4dfc7436965369ed2199e3d44a.

Since the `anonymous_reports` configuration property enables
an `error_log` directive with an `error` level, most of the
logs from the `init_worker` phase would be ignored.

This adds an `error_log` directive in the `http` block to
ensure we log `init_worker` logs at the proper level.

We also set the proper path (from the new configuration value)
to the master process's error logs. We use the proxy value as
we consider Kong's proxy server to be the main server on a Kong
instance.