### PR TITLE
feat(admin) remove DB counters in favor of a connection test

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -4,7 +4,6 @@ local conf_loader = require "kong.conf_loader"
 
 local sub = string.sub
 local find = string.find
-local pairs = pairs
 local ipairs = ipairs
 local select = select
 local tonumber = tonumber
@@ -90,15 +89,18 @@ return {
           connections_handled = tonumber(handled),
           total_requests = tonumber(total)
         },
-        database = {}
+        database = {
+          reachable = false,
+        },
       }
 
-      for k, v in pairs(dao.daos) do
-        local count, err = v:count()
-        if err then
-          return helpers.responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
-        end
-        status_response.database[k] = count
+      local ok, err = dao.db:reachable()
+      if not ok then
+        ngx.log(ngx.ERR, "failed to reach database as part of ",
+                         "/status endpoint: ", err)
+
+      else
+        status_response.database.reachable = true
       end
 
       return helpers.responses.send_HTTP_OK(status_response)

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -661,4 +661,15 @@ function _M:record_migration(id, name)
   return true
 end
 
+function _M:reachable()
+  local peer, err = self.cluster:next_coordinator()
+  if not peer then
+    return nil, Errors.db(err)
+  end
+
+  peer:setkeepalive()
+
+  return true
+end
+
 return _M

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -516,4 +516,18 @@ function _M:record_migration(id, name)
   return true
 end
 
+function _M:reachable()
+  local conn_opts = self:clone_query_options()
+  local pg = pgmoon.new(conn_opts)
+
+  local ok, err = pg:connect()
+  if not ok then
+    return nil, Errors.db(err)
+  end
+
+  pg:keepalive()
+
+  return true
+end
+
 return _M

--- a/spec/02-integration/03-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/03-admin_api/01-kong_routes_spec.lua
@@ -1,113 +1,146 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("Admin API", function()
-  local client
-  setup(function()
-    assert(helpers.start_kong {
-      pg_password = "hide_me"
-    })
-    client = helpers.admin_client(10000)
-  end)
-  teardown(function()
-    if client then client:close() end
-    helpers.stop_kong()
-  end)
+local dao_helpers = require "spec.02-integration.02-dao.helpers"
 
-  describe("Kong routes", function()
-    describe("/", function()
-      local meta = require "kong.meta"
+describe("Admin API - Kong routes", function()
+  describe("/", function()
+    local meta = require "kong.meta"
+    local client
 
-      it("returns Kong's version number and tagline", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/"
-        })
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        assert.equal(meta._VERSION, json.version)
-        assert.equal("Welcome to kong", json.tagline)
-      end)
-      it("response has the correct Server header", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/"
-        })
-        assert.res_status(200, res)
-        assert.equal(string.format("%s/%s", meta._NAME, meta._VERSION), res.headers.server)
-        assert.is_nil(res.headers.via) -- Via is only set for proxied requests
-      end)
-      it("returns 405 on invalid method", function()
-        local methods = {"POST", "PUT", "DELETE", "PATCH", "GEEEET"}
-        for i = 1, #methods do
-          local res = assert(client:send {
-            method = methods[i],
-            path = "/",
-            body = {}, -- tmp: body to allow POST/PUT to work
-            headers = {["Content-Type"] = "application/json"}
-          })
-          local body = assert.response(res).has.status(405)
-          local json = cjson.decode(body)
-          assert.same({ message = "Method not allowed" }, json)
-        end
-      end)
-      it("exposes the node's configuration", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/"
-        })
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        assert.is_table(json.configuration)
-      end)
-      it("obfuscates sensitive settings from the configuration", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/"
-        })
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        assert.is_string(json.configuration.pg_password)
-        assert.not_equal("hide_me", json.configuration.pg_password)
-      end)
-      it("returns PRNG seeds", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/",
-        })
-        local body = assert.response(res).has.status(200)
-        local json = cjson.decode(body)
-        assert.is_table(json.prng_seeds)
-        for k, v in pairs(json.prng_seeds) do
-          assert.matches("pid: %d+", k)
-          assert.matches("%d+", k)
-        end
-      end)
+    setup(function()
+      assert(helpers.start_kong {
+        pg_password = "hide_me"
+      })
+      client = helpers.admin_client(10000)
     end)
-  end)
 
-  describe("/status", function()
-    it("returns status info", function()
+    teardown(function()
+      if client then client:close() end
+      helpers.stop_kong()
+    end)
+
+    it("returns Kong's version number and tagline", function()
       local res = assert(client:send {
         method = "GET",
-        path = "/status"
+        path = "/"
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.is_table(json.database)
-      assert.is_table(json.server)
-
-      for k in pairs(helpers.dao.daos) do
-        assert.is_number(json.database[k])
+      assert.equal(meta._VERSION, json.version)
+      assert.equal("Welcome to kong", json.tagline)
+    end)
+    it("response has the correct Server header", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      assert.res_status(200, res)
+      assert.equal(string.format("%s/%s", meta._NAME, meta._VERSION), res.headers.server)
+      assert.is_nil(res.headers.via) -- Via is only set for proxied requests
+    end)
+    it("returns 405 on invalid method", function()
+      local methods = {"POST", "PUT", "DELETE", "PATCH", "GEEEET"}
+      for i = 1, #methods do
+        local res = assert(client:send {
+          method = methods[i],
+          path = "/",
+          body = {}, -- tmp: body to allow POST/PUT to work
+          headers = {["Content-Type"] = "application/json"}
+        })
+        local body = assert.response(res).has.status(405)
+        local json = cjson.decode(body)
+        assert.same({ message = "Method not allowed" }, json)
       end
+    end)
+    it("exposes the node's configuration", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.is_table(json.configuration)
+    end)
+    it("obfuscates sensitive settings from the configuration", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.is_string(json.configuration.pg_password)
+      assert.not_equal("hide_me", json.configuration.pg_password)
+    end)
+    it("returns PRNG seeds", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/",
+      })
+      local body = assert.response(res).has.status(200)
+      local json = cjson.decode(body)
+      assert.is_table(json.prng_seeds)
+      for k, v in pairs(json.prng_seeds) do
+        assert.matches("pid: %d+", k)
+        assert.matches("%d+", k)
+      end
+    end)
+  end)
 
-      assert.is_number(json.server.connections_accepted)
-      assert.is_number(json.server.connections_active)
-      assert.is_number(json.server.connections_handled)
-      assert.is_number(json.server.connections_reading)
-      assert.is_number(json.server.connections_writing)
-      assert.is_number(json.server.connections_waiting)
-      assert.is_number(json.server.total_requests)
+  dao_helpers.for_each_dao(function(kong_conf)
+    describe("/status with DB: " .. kong_conf.database, function()
+      local client
+
+      setup(function()
+        assert(helpers.start_kong {
+          database = kong_conf.database,
+        })
+        client = helpers.admin_client(10000)
+      end)
+
+      teardown(function()
+        if client then client:close() end
+        helpers.stop_kong()
+      end)
+
+      it("returns status info", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.database)
+        assert.is_table(json.server)
+
+        assert.is_boolean(json.database.reachable)
+
+        assert.is_number(json.server.connections_accepted)
+        assert.is_number(json.server.connections_active)
+        assert.is_number(json.server.connections_handled)
+        assert.is_number(json.server.connections_reading)
+        assert.is_number(json.server.connections_writing)
+        assert.is_number(json.server.connections_waiting)
+        assert.is_number(json.server.total_requests)
+      end)
+
+      it("database.reachable is `true` when DB connection is healthy", function()
+        -- In this test, we know our DB is reachable because it must be
+        -- so in our test suite. Ideally, a test when the DB isn't reachable
+        -- should be provided (start Kong, kill DB, request `/status`),
+        -- but this isn't currently possible in our test suite.
+        -- Additionally, let's emphasize that we only test DB connection, not
+        -- the health of said DB itself.
+
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+
+        assert.is_true(json.database.reachable)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
This is a replacement proposal for #2554. As discussed, the point of this change is to provide a connection test to the database, and not to evaluate its health. Following this logic, this patch is more aligned with the intended goal.

cc @shashiranjan84 @p0pr0ck5 @thefosk 