### PR TITLE
docs(contributing) revamp with code style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,98 +1,835 @@
-# Contributing to Kong
+# Contributing to Kong :monkey_face:
 
-### Got a question or problem?
+Hello, and welcome! Whether you are looking for help, trying to report a bug,
+thinking about getting involved in the project or about to submit a patch, this
+document is for you! It's intent is to be both an entry point for newcomers to
+the community (with various technical backgrounds), and a guide/reference for
+contributors and maintainers.
 
-Discuss it on the [Google Group](https://groups.google.com/forum/#!forum/konglayer) or chat with us on [Gitter](https://gitter.im/Mashape/kong) or freenode in [#kong](http://webchat.freenode.net/?channels=kong).
+Consult the Table of Contents below, and jump to the concerned section.
 
-### Browsing the code?
+## Table of Contents
 
-We work on two branches: `master` for stable, released code and `next`, a development branch. It might be important to distinguish them when you are reading the commit history searching for a feature or a bugfix, or when you are unsure of where to base your work from when contributing.
+- [Where to seek for help?](#where-to-seek-for-help)
+  - [Enterprise Edition](#enterprise-edition)
+  - [Community Edition](#community-edition)
+- [Where to report bugs?](#where-to-report-bugs)
+- [Contributing](#contributing)
+  - [Improving the documentation](#improving-the-documentation)
+  - [Submitting a patch](#submitting-a-patch)
+    - [Git branches](#git-branches)
+    - [Commit atomicity](#commit-atomicity)
+    - [Commit message format](#commit-message-format)
+    - [Static linting](#static-linting)
+    - [Writing tests](#writing-tests)
+    - [Writing performant code](#writing-performant-code)
+- [Code style](#code-style)
 
-### Found a bug?
 
-We would like to hear about it. Please [submit an issue][new-issue] on GitHub and we will follow up. Even better, we would appreciate a [Pull Request][new-pr] with a fix for it!
+## Where to seek for help?
 
-- If the bug was found in a release, it is best to base your work on `master` and submit your PR against it.
-- If the bug was found on `next` (the development branch), base your work on `next` and submit your PR against it.
+### Enterprise Edition
 
-Please follow the [Pull Request Guidelines][new-pr].
+If you are a Kong Enterprise customer, contact the Enterprise Support channels
+by opening an Enterprise support ticket on
+[https://support.mashape.com](https://support.mashape.com/)
 
-### Want a feature?
+If you are experiencing a P1 issue, please call the 24/7 Enterprise Support
+phone line for immediate assistance, as published in the Customer Success
+Reference Guide.
 
-Feel free to request a feature by [submitting an issue][new-issue] on GitHub and open the discussion.
+If you are interested in becoming a Kong Enterprise customer, please visit
+https://www.mashape.com/enterprise/ or contact us at
+[sales@mashape.com](mailto:sales@mashape.com).
 
-If you'd like to implement a new feature, please consider opening an issue first to talk about it. It may be that somebody is already working on it, or that there are particular issues that you should be aware of before implementing the change. If you are about to open a Pull Request, please make sure to follow the [submissions guidelines][new-pr].
+[Back to TOC](#table-of-contents)
 
-## Submission Guidelines
 
-### Submitting an issue
+### Community Edition
 
-Before you submit an issue, search the archive, maybe you will find that a similar one already exists.
+There are several channels where you can get answers from the community
+or the maintainers of this project:
 
-If you are submitting an issue for a bug, please include the following:
+- The mailing list, hosted on the [konglayer Google
+  Group](https://groups.google.com/forum/#!forum/konglayer) for asynchronous
+  and lengthy chatter
+- Gitter, for faster, but more ephemeral conversations. The room is
+  hosted at https://gitter.im/Mashape/kong
+- The IRC channel, registered on freenode as [#kong
+  ](https://webchat.freenode.net/?channels=kong)
 
-- An overview of the issue
-- Your use case (why is this a bug for you?)
-- The version of Kong you are running
-- The platform you are running Kong on
-- Steps to reproduce the issue
-- Eventually, logs from your `error.log` file. You can find this file at `<nginx_working_dir>/logs/error.log`
-- Ideally, a suggested fix
+**Please avoid opening GitHub issues for general questions or help**, as those
+should be reserved for actual bug reports. The Kong community is welcoming and
+more than willing to assist you on those channels!
 
-The more informations you give us, the more able to help we will be!
+[Back to TOC](#table-of-contents)
 
-### Submitting a Pull Request
 
-- First of all, make sure to base your work on the `next` branch (the development branch):
+## Where to report bugs?
 
+Feel free to [submit an issue](https://github.com/Mashape/kong/issues/new) on
+the GitHub repository, we would be grateful to hear about it! Please make sure
+to respect the GitHub issue template, and include:
+
+1. A summary of the issue
+2. A list of steps to reproduce the issue
+3. The version of Kong you encountered the issue with
+4. Your Kong configuration, or the parts that are relevant to your issue
+
+If you wish, you are more than welcome to propose a patch to fix the issue!
+See the [Submit a patch](#submitting-a-patch) section for more information
+on how to best do so.
+
+[Back to TOC](#table-of-contents)
+
+
+## Contributing
+
+We welcome contributions of all kinds, you do not need to code to be helpful!
+All of the following tasks are noble and worthy contributions that you can
+make without coding:
+
+- Reporting a bug (see the [report bugs](#where-to-report-bugs) section)
+- Helping other members of the community on the support channels
+- Fixing a typo in the code
+- Fixing a typo in the documentation at https://getkong.org (see
+  the [documentation contribution](#improving-the-documentation) section)
+- Providing your feedback on the proposed features and designs
+- Reviewing Pull Requests
+
+If you wish to contribute code (features or bug fixes), see the [Submitting a
+patch](#submitting-a-patch) section.
+
+[Back to TOC](#table-of-contents)
+
+
+### Improving the documentation
+
+The documentation hosted at https://getkong.org is open source and built with
+[Jekyll](https://jekyllrb.com/). You are welcome to propose changes to it
+(correct typos, add examples or clarifications...)!
+
+The repository is also hosted on GitHub at:
+https://github.com/Mashape/getkong.org/
+
+To run and test your changes locally, follow the installation instructions in
+its README.md. You will need Ruby, Node.js (for npm), and Python 2.7 on your
+system.
+
+When contributing, be weary of a few things:
+
+- The plugins documentation lives in the `app/plugins` directory. **This part
+  of the documentation is not versioned**, which means that the plugins
+  documentation is always reflecting the state of their latest release. This is
+  something we will be improving in the future.
+- The core documentation lives in `app/docs/x.x.x`. **This part is versioned**.
+  When proposing a change in this part of the documentation, consider proposing
+  it for older versions as well.
+  Example: if you fix a typo in `app/docs/0.10.x/configuration.md`, this typo
+  may also be present in `app/docs/0.9.x/configuraiton.md`.
+
+[Back to TOC](#table-of-contents)
+
+
+### Submitting a patch
+
+Feel free to contribute fixes or minor features, we love to receive Pull
+Requests! If the feature you are planning to develop is more consequent, come
+talk to us first!
+
+When contributing, please follow the guidelines provided in this document. They
+will cover topics such as the different Git branches we use, the commit message
+format to use or the appropriate code style.
+
+Once you have read them, and you are ready to submit your Pull Request, be sure
+to verify a few things:
+
+- Your work was based on the appropriate branch (`master` vs. `next`), and you
+  are opening your Pull Request against the appropriate one
+- Your commit history is clean: changes are atomic and the git message format
+  was respected
+- Rebase your work on top of the base branch (seek help online on how to use
+  `git rebase`; this is important to ensure your commit history is clean and
+   linear)
+- The static linting is succeeding: run `make lint`, or `luacheck .` (see the
+  development documentation for additional details)
+- The tests are passing: run `make test`, `make test-all`, or whichever is
+  appropriate for your change
+- Do not update CHANGELOG.md yourself. Your change will be included there in
+  due time if it is accepted, no worries!
+
+If the above guidelines are respected, your Pull Requests has all its chances
+to be considered and will be reviewed by a maintainer.
+
+If you are asked to update your patch by a reviewer, please do so! Remember:
+**you are responsible for pushing your patch forward**. If you contributed it,
+you probably are the one in need of it. You must be prepared to apply changes
+to it if necessary.
+
+If your Pull Request was accepted, congratulations! You are now an official
+contributor of Kong. Your change will be included in the subsequent release
+Changelog, and we will not forget to include your name if you are an external
+contributor. :wink:
+
+[Back to TOC](#table-of-contents)
+
+
+#### Git branches
+
+We work on two branches: `master`, where non-breaking changes land, and `next`,
+where important features or breaking changes land in-between major releases.
+
+When contributing to Kong, this distinction is important. Please ensure that
+you are basing your work on top of the appropriate branch, it might save you
+some time down the road!
+
+If you have write access to the GitHub repository, please follow the following
+naming scheme when pushing your branch(es):
+
+- `feat/foo-bar` for new features
+- `fix/foo-bar` for bug fixes
+- `tests/foo-bar` when the change concerns only the test suite
+- `refactor/foo-bar` when refactoring code without any behavior change
+- `style/foo-bar` when addressing some style issue
+- `docs/foo-bar` for updates to the README.md, this file, or similar documents
+
+[Back to TOC](#table-of-contents)
+
+
+#### Commit atomicity
+
+When submitting patches, it is important that you organize your commits in
+logical units of work. You are free to propose a patch with one or many
+commits, as long as their atomicity is respected. This means that no unrelated
+changes should be included in a commit.
+
+For example: you are writing a patch to fix a bug, but in your endeavour, you
+spot another bug. **Do not fix both bugs in the same commit!**. Finish your
+work on the initial bug, propose your patch, and come back to the second bug
+later on. This is also valid for unrelated style fixes, refactorings, etc...
+
+You should use your best judgement when facing such decisions. A good approach
+for this is to put yourself in the shoes of the person who will review your
+patch: will they understand your changes and reasoning just by reading your
+commit history? Will they find unrelated changes in a particular commit? They
+shouldn't!
+
+Writing meaningful commit messages that follow our commit message format will
+also help you respect this mantra (see the below section).
+
+[Back to TOC](#table-of-contents)
+
+
+#### Commit message format
+
+To maintain a healthy Git history, we ask of you that you write your commit
+messages as follows:
+
+- The tense of your message must be **present**
+- Your message must be prefixed by a type, and a scope
+- The header of your message should not be longer than 50 characters
+- A blank line should be included between the header and the body
+- The body of your message should not contain lines longer than 72 characters
+
+Here is a template of what your commit message should look like:
+
+```
+<type>(<scope>) <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+
+##### Type
+
+The type of your commit indicates what type of change this commit is about. The
+accepted types are:
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **hotfix**: An urgent bug fix during a release process
+- **tests**: A change that is purely related to the test suite only (fixing
+  a test, adding a test, improving its reliability, etc...)
+- **docs**: Changes to the README.md, this file, or other such documents
+- **style**: Changes that do not affect the meaning of the code (white-space
+  trimming, formatting, etc...)
+- **perf**: A code change that significantly improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature, and
+  is too big to be considered just `perf`
+- **chore**: Changes related to the build process, the dependencies, or
+  auxiliary tools and libraries such as LuaRocks, Travis-ci, etc...
+
+
+##### Scope
+
+The scope is the part of the codebase that is affected by your change. Choosing
+it is at your discretion, but here are some of the most frequent ones:
+
+- **proxy**: A change that affects the proxying of requests
+- **router**: A change that affects the router, which matches a request to the
+  desired configured API
+- **admin**: A change to the Admin API
+- **balancer**: Changes related to the internal Load Balancer
+- **core**: Changes affecting a large part of the core, and touching many parts
+  such as `proxy`, `balancer`, `dns`
+- **dns**: Changes related to internal DNS resolution
+- **dao**: A change related to the DAO, the interface to the datastores
+- **cli**: Changes to the CLI
+- **cache**: Changes to the configuration entities caching (datastore entities)
+- **deps**: When updating dependencies (to be used with the `chore` prefix)
+- **conf**: Configuration-related changes (new values, improvements...)
+- **`<plugin-name>`**: This could be `basic-auth`, or `ldap` for example
+- `*`: When the change affects too many parts of the codebase at once (this
+  should be rare and avoided)
+
+
+##### Subject
+
+Your subject should contain a succinct description of the change. It should be
+written so that:
+
+- It uses the present, imperative tense: "fix typo", and not "fixed" or "fixes"
+- It is **not** capitalized: "fix typo", and not "Fix typo"
+- It does **not** include a period. :smile:
+
+
+##### Body
+
+The body of your commit message should contain a detailed description of your
+changes. Ideally, if the change is significant, you should explain its
+motivation, the chosen implementation, and justify it.
+
+As previously mentioned, lines in the commit messages should not exceed 72
+characters.
+
+
+##### Footer
+
+The footer is the ideal place to link to related material about the change:
+related GitHub issues, Pull Requests, fixed bug reports, etc...
+
+
+##### Examples
+
+Here are a few examples of good commit messages to take inspiration from:
+
+```
+fix(admin) send HTTP 405 on unsupported method
+
+The appropriate status code when the request method is not supported
+on an endpoint it 405. We previously used to send HTTP 404, which
+is not appropriate. This updates the Admin API helpers to properly
+return 405 on such user errors.
+
+* return 405 when the method is not supported in the Admin API helpers
+* add a new test case in the Admin API test suite
+
+Fix #678
+```
+
+Or:
+
+```
+tests(proxy) add a new test case for URI encoding
+
+When proxying upstream, the URI sent by Kong should be the one
+received from the client, even if it was percent-encoded.
+
+This adds a new test case which was missing, to ensure it is
+the case.
+```
+
+[Back to TOC](#table-of-contents)
+
+
+#### Static linting
+
+As mentioned in the guidelines to submit a patch, the linter must succeed. We
+use [Luacheck](https://github.com/mpeterv/luacheck) to statically lint our Lua
+code. You can lint the code like so:
+
+```
+$ make lint
+```
+
+Or:
+
+```
+$ luacheck .
+```
+
+[Back to TOC](#table-of-contents)
+
+
+#### Writing tests
+
+We use [busted](https://olivinelabs.com/busted/) to write our tests. Your patch
+should include the related test updates or additions, in the appropriate test
+suite.
+
+- `spec/01-unit` gathers our unit tests (to test a given Lua module or
+  function)
+- `spec/02-integration` contains tests that start Kong (connected to a running
+  database), execute Admin API and proxy requests against it, and verify the
+  output
+- `spec/03-plugis` contains tests (both unit and integration) for the bundled
+  plugins (those plugins still live in the core repository as of now, but will
+  eventually be externalized)
+
+A few guidelines when writing tests:
+
+- Use appropriate `describe` and `it` blocks, so it's obvious what is being
+  tested exactly
+- Ensure the atomicity of your tests: no test should be asserting two
+  unrelated behaviors at the same time
+- Run tests related to the datastore against all supported databases
+
+And a few recommendations, when asserting types:
+
+```lua
+-- bad
+assert.Nil(foo)
+assert.True(bar)
+
+-- good
+assert.is_nil(foo)
+assert.is_true(bar)
+```
+
+Comparing tables:
+
+```lua
+-- bad (most of the time)
+assert.equal(t1, t2)
+
+-- good
+assert.same(t1, t2)
+```
+
+[Back to TOC](#table-of-contents)
+
+
+#### Writing performant code
+
+We write code for the [LuaJIT](https://github.com/Mashape/kong/issues/new)
+interpreter, **not** Lua-PUC. As such, you should follow the LuaJIT best
+practises:
+
+- Do **not** instantiate global variables
+- Consult the [LuaJIT wiki](http://wiki.luajit.org/Home)
+- Follow the [Performance
+  Guide](http://wiki.luajit.org/Numerical-Computing-Performance-Guide)
+  recommendations
+- Do **not** use [NYI functions](http://wiki.luajit.org/NYI) on hot code paths
+- Prefer using the FFI over traditional bindings via the Lua C API
+- Avoid table rehash by pre-allocating the slots of your tables when possible
+
+  ```lua
+  -- bad
+  local t = {}
+  for i = 1, 100 do
+    t[i] = i
+  end
+
+  -- good
+  local new_tab = require "table.new"
+  local t = new_tab(100, 0)
+  for i = 1, 100 do
+    t[i] = i
+  end
   ```
-  # a bugfix branch for next would be prefixed by fix/
-  # a bugfix branch for master would be prefixed by hotfix/
-  $ git checkout -b feature/my-feature next
+
+- Cache the globals used by your hot code paths
+
+  ```lua
+  -- bad
+  for i = 1, 100 do
+    t[i] = math.random()
+  end
+
+  -- good
+  local random = math.random
+  for i = 1, 100 do
+    t[i] = random()
+  end
   ```
 
-- Please create commits containing **related changes**. For example, two different bugfixes should produce two separate commits. A feature should be made of commits splitted by **logical chunks** (no half-done changes). Use your best judgement as to how many commits your changes require.
+- Cache the length and indices of your tables to avoid unnecessary CPU cycles
 
-- Write insightful and descriptive commit messages. It lets us and future contributors quickly understand your changes without having to read your changes. Please provide a summary in the first line (50-72 characters) and eventually, go to greater lengths in your message's body. We also like commit message with a **type** and **scope**. We generally follow the [Angular commit message format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format).
+  ```lua
+  -- bad
+  for i = 1, 100 do
+    t[#t + 1] = other_tab[#other_tab]
+  end
 
-- Please **include the appropriate test cases** for your patch.
-
-- Make sure all tests pass before submitting your changes. See the [Makefile operations](/README.md#makefile-operations).
-
-- Make sure the linter does not throw any error: `make lint`.
-
-- Rebase your commits. It may be that new commits have been introduced on `next`. Rebasing will update your branch with the most recent code and make your changes easier to review:
-
-  ```
-  $ git fetch
-  $ git rebase origin/next
-  ```
-
-- Push your changes:
-
-  ```
-  $ git push origin -u feature/my-feature
+  -- good
+  local n = 0
+  local n_other_tab = #other_tab
+  for i = 1, 100 do
+    n = n + 1
+    t[n] = other_tab[n_other_tab]
+  end
   ```
 
-- Open a pull request against the `next` branch.
+And finally, most importantly: use your best judgement to design an
+efficient algorithm. Doing so will always be more performant than a poorly
+design algorithms, even following all the performance tricks of the language
+you are using. :smile:
 
-- If we suggest changes:
-  - Please make the required updates (after discussion if any)
-  - Only create new commits if it makes sense. Generally, you will want to amend your latest commit or rebase your branch after the new changes:
+[Back to TOC](#table-of-contents)
 
-    ```
-    $ git rebase -i next
-    # choose which commits to edit and perform the updates
-    ```
 
-  - Re-run the test suite
-  - Force push to your branch:
+## Code style
 
-    ```
-    $ git push origin feature/my-feature -f
-    ```
+In order to ensure a healthy and consistent codebase, we ask of you that you
+respect the adopted code style. This section contains a non-exhaustive list
+of preferred styles for writing Lua. It is opinionated, but follows the
+code styles of OpenResty and, by association, Nginx. OpenResty or Nginx
+contributors should find themselves at ease when contributing to Kong.
 
-We are eager to see your contribution!
+- No line should be longer than 80 characters
+- Indentation should consist of 2 spaces
 
-[new-issue]: #submitting-an-issue
-[new-pr]: #submitting-a-pull-request
+When you are unsure about the style to adopt, please browse other parts of the
+code base to find a similar case, and stay consistent with it.
+
+You might also notice places in the code base where the described style is not
+respected. This is due to legacy code. **Contributions to update the code to
+the recommended style are welcome!**
+
+[Back to TOC](#table-of-contents)
+
+
+### Table of Contents - Code style
+
+- [Modules](#modules)
+- [Variables](#variables)
+- [Tables](#tables)
+- [Strings](#strings)
+- [Functions](#functions)
+- [Conditional expressions](#conditional-expressions)
+
+
+### Modules
+
+When writing a module (a Lua file), separate logical blocks of code with
+**two** blank lines:
+
+```lua
+local foo = require "kong.foo"
+
+
+local _M = {}
+
+
+function _M.bar()
+  -- do thing...
+end
+
+
+function _M.baz()
+  -- do thing...
+end
+
+
+return _M
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+
+### Variables
+
+When naming a variable or function, **do** use snake_case:
+
+```lua
+-- bad
+local myString = "hello world"
+
+-- good
+local my_string = "hello world"
+```
+
+When assigning a variable, **do** give it an uppercase name:
+
+```lua
+-- bad
+local max_len = 100
+
+-- good
+local MAX_LEN = 100
+```
+
+When assigning several variables on consecutive lines, **do** align their
+assignment operator:
+
+```lua
+-- bad
+local str = "world"
+local my_value = "hello"
+
+-- good
+local str      = "world"
+local my_value = "hello"
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+
+### Tables
+
+Use the constructor syntax, and **do** include a trailing comma:
+
+```lua
+-- bad
+local t = {}
+t.foo = "hello"
+t.bar = "world"
+
+-- good
+local t = {
+  foo = "hello",
+  bar = "world", -- note the trailing comma
+}
+```
+
+On single-line constructors, **do** include spaces around curly-braces and
+assignments:
+
+```lua
+-- bad
+local t = {foo="hello",bar="world"}
+
+-- good
+local t = { foo = "hello", bar = "world" }
+```
+
+When using the constructor syntax on multiple lines, **do** align the
+assignments:
+
+```lua
+-- bad
+local t = {
+  some_key = "hello",
+  some_other_key = "world",
+}
+
+-- good
+local t = {
+  some_key       = "hello",
+  some_other_key = "world",
+}
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+
+### Strings
+
+When using the concatenation operator, **do** insert spaces around it:
+
+```lua
+-- bad
+local str = "hello ".."world"
+
+-- good
+local str = "hello " .. "world"
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+
+### Functions
+
+Prefer the function syntax over variable syntax:
+
+```lua
+-- bad
+local foo = function()
+
+end
+
+-- good
+local function foo()
+
+end
+```
+
+Perform validation early and return as early as possible:
+
+```lua
+-- bad
+local function check_name(name)
+  local valid = #name > 3
+  valid = valid and #name < 30
+
+  -- other validations
+
+  return valid
+end
+
+-- good
+local function check_name(name)
+  if #name < 3 and #name > 30 then
+    return false
+  end
+
+  -- other validations
+
+  return true
+end
+```
+
+Follow the return values conventions: Lua supports multiple return values, and
+by convention, handles recoverable errors by returning `nil` plus a `string`
+describing the error:
+
+```lua
+-- bad
+local function check()
+  local ok, err = do_thing()
+  if not ok then
+    return false, { message = err }
+  end
+
+  return true
+end
+
+-- good
+local function check()
+  local ok, err = do_thing()
+  if not ok then
+    return nil, "could not do thing: " .. err
+  end
+
+  return true
+end
+```
+
+When a function call makes a line go over 80 characters, **do** align the
+overflowing arguments to the first one:
+
+```lua
+-- bad
+local str = string.format("SELECT * FROM users WHERE first_name = '%s'", first_name)
+
+-- good
+local str = string.format("SELECT * FROM users WHERE first_name = '%s'",
+                          first_name)
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+
+### Conditional expressions
+
+Avoid writing 1-liner conditions, **do** indent the child branch:
+
+```lua
+-- bad
+if err then return nil, err end
+
+-- good
+if err then
+  return nil, err
+end
+```
+
+When testing the assignment of a value, **do** use shortcuts, unless you
+care about the difference between `nil` and `false`:
+
+```lua
+-- bad
+if str ~= nil then
+
+end
+
+-- good
+if str then
+
+end
+```
+
+When creating multiple branches **do** include a blank line above the `elseif`
+and `else` statements:
+
+```lua
+-- bad
+if foo then
+  do_stuff()
+elseif bar then
+  do_other_stuff()
+else
+  error()
+end
+
+-- good
+if thing then
+  do_stuff()
+
+elseif bar then
+  do_other_stuff()
+
+else
+  error()
+end
+```
+
+When a branch returns, **do not** create subsequent branches, but write the
+rest of your logic on the parent branch:
+
+```lua
+-- bad
+if not str then
+  return nil, "bad value"
+else
+  do_thing(str)
+end
+
+-- good
+if not str then
+  return nil, "bad value"
+end
+
+do_thing(str)
+```
+
+When assigning a value or returning from a function, **do** use ternaries if
+it makes the code more readable:
+
+```lua
+-- bad
+local foo
+if bar then
+  foo = "hello"
+
+else
+  foo = "world"
+end
+
+-- good
+local foo = bar and "hello" or "world"
+```
+
+When an expression makes a line longer than 80 characters, **do** align the
+expression on the following lines:
+
+```lua
+-- bad
+if thing_one < 1 and long_and_complicated_function(arg1, arg2) < 10 or thing_two > 10 then
+
+end
+
+-- good
+if thing_one < 1 and long_and_complicated_function(arg1, arg2) < 10
+   or thing_two > 10
+then
+
+end
+```
+
+[Back to code style TOC](#table-of-contents---code-style)
+
+


### PR DESCRIPTION
A more welcoming contributing guide, addressed to both members of the
community (technical or not, seeking for help or to contribute), and new
hires.

This includes an updated code style, an FAQ about which channels to
communicate on, a contributing guide with guidelines for good commit
messages and overall healthy contributions.

This replaces #2253 which became style, and introduces a new, undesired
`CODE_SYLE.md` file.