### PR TITLE
fix(oauth2) body params creds: require both client_id and client_secret

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -219,7 +219,7 @@ end
 local function retrieve_client_credentials(parameters)
   local client_id, client_secret, from_authorization_header
   local authorization_header = ngx.req.get_headers()["authorization"]
-  if parameters[CLIENT_ID] then
+  if parameters[CLIENT_ID] and parameters[CLIENT_SECRET] then
     client_id = parameters[CLIENT_ID]
     client_secret = parameters[CLIENT_SECRET]
   elseif authorization_header then

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -1083,6 +1083,24 @@ describe("Plugin: oauth2 (access)", function()
         local body = assert.res_status(200, res)
         assert.is_table(ngx.re.match(body, [[^\{"token_type":"bearer","access_token":"[\w]{32,32}","expires_in":5\}$]]))
       end)
+      it("returns success with authorization header and client_id body param", function()
+        local res = assert(proxy_ssl_client:send {
+          method = "POST",
+          path = "/oauth2/token",
+          body = {
+            client_id = "clientid123",
+            scope = "email",
+            grant_type = "client_credentials"
+          },
+          headers = {
+            ["Host"] = "oauth2_4.com",
+            ["Content-Type"] = "application/json",
+            Authorization = "Basic Y2xpZW50aWQxMjM6c2VjcmV0MTIz"
+          }
+        })
+        local body = assert.res_status(200, res)
+        assert.is_table(ngx.re.match(body, [[^\{"token_type":"bearer","access_token":"[\w]{32,32}","expires_in":5\}$]]))
+      end)
       it("returns an error with a wrong authorization header", function()
         local res = assert(proxy_ssl_client:send {
           method = "POST",


### PR DESCRIPTION
### Summary

Fixes POST /oauth2/token request client credentials checking when having:
* `client_id:client_secret` passed via the authorization header;
* and `client_id` passed as a request body parameter.
To retrieve client credentials from the body parameters, both `client_id` and `client_secret` must be present.

### Full changelog

* oauth2: body params creds: require both client_id and client_secret
* added a test case into `spec/03-plugins/26-oauth2/03-access_spec.lua`

### Issues resolved

Fix #2446
