### PR TITLE
chore(gh) Improve GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
-*Note: GitHub issues should be reserved only for bug reports. Please use the
-[Kong mailing list](https://groups.google.com/forum/#!forum/konglayer) or
-[Gitter](https://gitter.im/Mashape/kong) for user support, development
-questions, feature requests, etc.*
+NOTE: GitHub issues are reserved for bug reports only.
+
+Please read the CONTRIBUTING.md guidelines to learn on which channels you can
+seek for help and ask general questions:
+
+https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md#where-to-seek-for-help
 
 ### Summary
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,7 @@
-*Note: New features are to be opened against `next`, hotfixes against `master`.
-Please also note that we will no longer be accepting PRs for new plugin concepts
-into Kong core at this time. Feel free to publish this plugin on your own
-following the [distributing your plugin](https://getkong.org/docs/0.10.x/plugin-development/distribution/#distribute-your-plugin)
-guide. You are also encouraged to advertise it on the [mailing list](https://groups.google.com/forum/#!forum/konglayer),
-and we will soon provide a "community plugins" section on
-[getkong.org/plugins/](http://getkong.org/plugins/) on which you will be able to
-document it.*
+NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
+and ensure you followed them all:
+
+https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md#contributing
 
 ### Summary
 


### PR DESCRIPTION
Following the recent improvements in the CONTRIBUTING.md guidelines, we
can update those templates to:

- better redirect contributors to meaningful resources
- shorter and thus more susceptible to actually be read by contributors
- not use a Markdown syntax which isn't supported in the issue
  composition text field