### PR TITLE
fix(router) respect strip_uri for APIs with multiple uris

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -517,7 +517,8 @@ function _M.new(apis)
 
     do
       local api_t_from_cache = cache:get(cache_key)
-      if api_t_from_cache then
+      if api_t_from_cache and match_api(api_t_from_cache, method, uri, host)
+      then
         return api_t_from_cache
       end
     end

--- a/spec/01-unit/11-router_spec.lua
+++ b/spec/01-unit/11-router_spec.lua
@@ -1025,8 +1025,18 @@ describe("Router", function()
         assert.equal("/", _ngx.var.request_uri)
 
         _ngx = mock_ngx("GET", "/this-api", {})
-        local api2 = router.exec(_ngx)
-        assert.same(use_case_apis[1], api2)
+        api = router.exec(_ngx)
+        assert.same(use_case_apis[1], api)
+        assert.equal("/", _ngx.var.request_uri)
+
+        _ngx = mock_ngx("GET", "/my-api", {})
+        api = router.exec(_ngx)
+        assert.same(use_case_apis[1], api)
+        assert.equal("/", _ngx.var.request_uri)
+
+        _ngx = mock_ngx("GET", "/this-api", {})
+        api = router.exec(_ngx)
+        assert.same(use_case_apis[1], api)
         assert.equal("/", _ngx.var.request_uri)
       end)
 

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -280,6 +280,66 @@ describe("Router", function()
     end)
   end)
 
+  describe("strip_uri", function()
+
+    setup(function()
+      insert_apis {
+        {
+          name         = "api-strip-uri",
+          upstream_url = "http://httpbin.org",
+          uris         = { "/x/y/z", "/z/y/x" },
+          strip_uri    = true,
+        },
+      }
+
+      assert(helpers.start_kong())
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    describe(" = true", function()
+      it("strips subsequent calls to an API with different [uris]", function()
+        local res_uri_1 = assert(client:send {
+          method = "GET",
+          path   = "/x/y/z/get",
+        })
+
+        local body = assert.res_status(200, res_uri_1)
+        local json = cjson.decode(body)
+        assert.matches("httpbin.org/get", json.url, nil, true)
+
+        local res_uri_2 = assert(client:send {
+          method = "GET",
+          path   = "/z/y/x/get",
+        })
+
+        body = assert.res_status(200, res_uri_2)
+        json = cjson.decode(body)
+        assert.matches("httpbin.org/get", json.url, nil, true)
+
+        local res_2_uri_1 = assert(client:send {
+          method = "GET",
+          path   = "/x/y/z/get",
+        })
+
+        body = assert.res_status(200, res_2_uri_1)
+        json = cjson.decode(body)
+        assert.matches("httpbin.org/get", json.url, nil, true)
+
+        local res_2_uri_2 = assert(client:send {
+          method = "GET",
+          path   = "/x/y/z/get",
+        })
+
+        body = assert.res_status(200, res_2_uri_2)
+        json = cjson.decode(body)
+        assert.matches("httpbin.org/get", json.url, nil, true)
+      end)
+    end)
+  end)
+
   describe("preserve_host", function()
 
     setup(function()


### PR DESCRIPTION
Because of our Lua-land LRU cache, we used not to execute `match_api`,
which takes care of discovering which configured uri matched a given
API, and should be stripped.

This operation is O(1) for plain text URIs, as well as hosts and
methods, hence, we do not suffer any performance penalty.

Fix #2562