### PR TITLE
fix(proxy) check_https respects trusted_ips

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -122,7 +122,8 @@ local function authorize(conf)
   local allowed_redirect_uris, client, redirect_uri, parsed_redirect_uri
   local is_implicit_grant
 
-  local is_https, err = check_https(conf.accept_http_if_already_terminated)
+  local is_https, err = check_https(singletons.ip.trusted(ngx.var.realip_remote_addr),
+                                    conf.accept_http_if_already_terminated)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else
@@ -256,7 +257,8 @@ local function issue_token(conf)
   local parameters = retrieve_parameters()
   local state = parameters[STATE]
 
-  local is_https, err = check_https(conf.accept_http_if_already_terminated)
+  local is_https, err = check_https(singletons.ip.trusted(ngx.var.realip_remote_addr),
+                                    conf.accept_http_if_already_terminated)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -297,12 +297,14 @@ do
   end
 end
 
---- Checks whether a request is https or was originally https (but already terminated).
--- It will check in the current request (global `ngx` table). If the header `X-Forwarded-Proto` exists
--- with value `https` then it will also be considered as an https connection.
+--- Checks whether a request is https or was originally https (but already
+-- terminated). It will check in the current request (global `ngx` table). If
+-- the header `X-Forwarded-Proto` exists -- with value `https` then it will also
+-- be considered as an https connection.
+-- @param trusted_ip boolean indicating if the client is a trusted IP
 -- @param allow_terminated if truthy, the `X-Forwarded-Proto` header will be checked as well.
 -- @return boolean or nil+error in case the header exists multiple times
-_M.check_https = function(allow_terminated)
+_M.check_https = function(trusted_ip, allow_terminated)
   if ngx.var.scheme:lower() == "https" then
     return true
   end
@@ -311,15 +313,20 @@ _M.check_https = function(allow_terminated)
     return false
   end
 
-  local forwarded_proto_header = ngx.req.get_headers()["x-forwarded-proto"]
-  if tostring(forwarded_proto_header):lower() == "https" then
-    return true
-  end
+  -- if we trust this IP, examine it's X-Forwarded-Proto header
+  -- otherwise, we fall back to relying on the client scheme
+  -- (which was either validated earlier, or we fall through this block)
+  if trusted_ip then
+    local scheme = ngx.req.get_headers()["x-forwarded-proto"]
 
-  if type(forwarded_proto_header) == "table" then
-    -- we could use the first entry (lower security), or check the contents of each of them (slow). So for now defensive, and error
+    -- we could use the first entry (lower security), or check the contents of
+    -- each of them (slow). So for now defensive, and error
     -- out on multiple entries for the x-forwarded-proto header.
-    return nil, "Only one X-Forwarded-Proto header allowed"
+    if type(scheme) == "table" then
+      return nil, "Only one X-Forwarded-Proto header allowed"
+    end
+
+    return tostring(scheme):lower() == "https"
   end
 
   return false

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -301,7 +301,9 @@ describe("Plugin: oauth2 (access)", function()
       }
     })
 
-    assert(helpers.start_kong())
+    assert(helpers.start_kong({
+      trusted_ips = "127.0.0.1",
+    }))
     proxy_client = helpers.proxy_client()
     proxy_ssl_client = helpers.proxy_ssl_client()
   end)


### PR DESCRIPTION
### Summary

We now only examine the X-Forwarded-Proto header if we have defined the connecting client as a trusted IP.

### Full changelog

* `kong.tools.utils.check_https` now accepts a boolean derived from `singletons.ip.trusted` to determine how it should examine `X-Forwarded-Proto`.
* Untrusted clients sending `X-Forwarded-Proto: https` via a plaintext connection are denied with 426 when the selected API has `https_only` set.
* Oauth2 plugin SSL requirements leverage the trusted_ips / X-F-P logic.
* Updated various tests to define 127.0.0.1 as a trusted IP.

### Issues resolved

Tangentially references #2583.
