### PR TITLE
feat(aws-lambda) Add support for setting a custom response code

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -83,7 +83,14 @@ function AWSLambdaHandler:access(conf)
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
 
-  ngx.status = res.status
+  if conf.unhandled_status
+     and headers["X-Amzn-Function-Error"] == "Unhandled"
+  then
+    ngx.status = conf.unhandled_status
+
+  else
+    ngx.status = res.status
+  end
 
   -- Send response to client
   for k, v in pairs(headers) do

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -1,3 +1,11 @@
+local function check_status(status)
+  if status and (status < 100 or status > 999) then
+    return false, "unhandled_status must be within 100 - 999."
+  end
+
+  return true
+end
+
 return {
   fields = {
     timeout = {type = "number", default = 60000, required = true },
@@ -14,5 +22,6 @@ return {
     log_type = {type = "string", required = true, default = "Tail", 
                        enum = {"Tail", "None"}},
     port = { type = "number", default = 443 },
+    unhandled_status = { type = "number", func = check_status },
   }
 }

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -1,0 +1,46 @@
+local aws_lambda_schema = require "kong.plugins.aws-lambda.schema"
+local schemas = require "kong.dao.schemas_validation"
+local utils = require "kong.tools.utils"
+local validate_entity = schemas.validate_entity
+
+describe("Plugin: AWS Lambda (schema)", function()
+  local DEFAULTS = {
+    timeout = 60000,
+    keepalive = 60000,
+    aws_key = "my-key",
+    aws_secret = "my-secret",
+    aws_region = "us-east-1",
+    function_name = "my-function",
+    invocation_type  = "RequestResponse",
+    log_type = "Tail",
+    port  = 443,
+  }
+
+  it("accepts nil Unhandled Response Status Code", function()
+    local entity = utils.table_merge(DEFAULTS, { unhandled_status = nil })
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
+    assert.True(ok)
+  end)
+
+  it("accepts correct Unhandled Response Status Code", function()
+    local entity = utils.table_merge(DEFAULTS, { unhandled_status = 412 })
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
+    assert.True(ok)
+  end)
+
+  it("errors with Unhandled Response Status Code less than 100", function()
+    local entity = utils.table_merge(DEFAULTS, { unhandled_status = 99 })
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("unhandled_status must be within 100 - 999.", err.unhandled_status)
+    assert.False(ok)
+  end)
+
+  it("errors with Unhandled Response Status Code greater than 999", function()
+    local entity = utils.table_merge(DEFAULTS, { unhandled_status = 1000 })
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("unhandled_status must be within 100 - 999.", err.unhandled_status)
+    assert.False(ok)
+  end)
+end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -275,6 +275,9 @@ http {
             content_by_lua_block {
                 local function say(res, status)
                   ngx.header["x-amzn-RequestId"] = "foo"
+                  if string.match(ngx.var.uri, "functionWithUnhandledError") then
+                    ngx.header["X-Amzn-Function-Error"] = "Unhandled"
+                  end
                   ngx.status = status
 
                   if type(res) == 'string' then


### PR DESCRIPTION
This is a feature request for the Kong aws-lambda plugin. The use case is for allowing users to set a custom response code for APIs they've configured. AWS Lambda's Invoke call returns a 20x code regardless of whether an error occurred. This supports configuring a different response code via the API.

### Summary
Adds a new `unhandled_status` configuration option for the aws-lambda
plugin. If set - when the [`X-Amzn-Function-Error`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_ResponseSyntax) invoke call response
header is set to `Unhandled` then the numeric value will be used as the
response code for the API.

### Full changelog
* Add support to override response code for unhandled exceptions via `unhandled_status`.
* Updated spec for usage without `unhandled_status`.
* Added specs for `unhandled_status` usage.

Looks like there will be conflicts with https://github.com/Mashape/kong/pull/2470 depending on which is merged first. 😅