### PR TITLE
fix(proxy) set http_if_terminated false by default

### DIFF
--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -197,7 +197,7 @@ return {
     methods = {type = "array", func = check_methods},
     strip_uri = {type = "boolean", default = true},
     https_only = {type = "boolean", default = false},
-    http_if_terminated = {type = "boolean", default = true},
+    http_if_terminated = {type = "boolean", default = false},
     upstream_url = {type = "url", required = true, func = validate_upstream_url},
     preserve_host = {type = "boolean", default = false},
     retries = {type = "number", default = 5, func = check_smallint},


### PR DESCRIPTION
### Summary

Assume a (very mildly) more agressive posture by disabling interpretation of the X-Forwarded-Proto header in HTTPS-only APIs by default when the client sent a plaintext connection. This does not improve any functional posturing in the analysis of plaintext connections, but it does require that operators explicitly set this value (and thus assumedly understand the current implications of such a configuration)

### Full changelog

* Set the `http_if_terminated` API schema member to false by default.

### Issues resolved

Fix #2583