### PR TITLE
docs(contributing) fix typo in code style section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -586,7 +586,7 @@ local myString = "hello world"
 local my_string = "hello world"
 ```
 
-When assigning a variable, **do** give it an uppercase name:
+When assigning a constant variable, **do** give it an uppercase name:
 
 ```lua
 -- bad


### PR DESCRIPTION
### Summary

Fix typo in code style content for variables defined in uppercase
 
### Full changelog

* Fix typo in CONTRIBUTING.md