### PR TITLE
add flat option to file-log plugin

### DIFF
--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -71,7 +71,7 @@ end
 
 function FileLogHandler:log(conf)
   FileLogHandler.super.log(self)
-  local message = basic_serializer.serialize(ngx)
+  local message = basic_serializer.serialize(ngx, conf)
 
   local ok, err = ngx_timer(0, log, conf, message)
   if not ok then

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -17,5 +17,6 @@ return {
   fields = {
     path = { required = true, type = "string", func = validate_file },
     reopen = { type = "boolean", default = false },
+    flat = { type = "boolean", default = false },
   }
 }

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,10 +1,13 @@
 local tablex = require "pl.tablex"
+local utils = require "kong.tools.utils"
 
 local _M = {}
 
 local EMPTY = tablex.readonly({})
 
-function _M.serialize(ngx)
+function _M.serialize(ngx, conf)
+  conf = conf or {}
+
   local authenticated_entity
   if ngx.ctx.authenticated_credential ~= nil then
     authenticated_entity = {
@@ -13,7 +16,7 @@ function _M.serialize(ngx)
     }
   end
   
-  return {
+  local message = {
     request = {
       uri = ngx.var.request_uri,
       request_uri = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. ngx.var.request_uri,
@@ -42,6 +45,11 @@ function _M.serialize(ngx)
     client_ip = ngx.var.remote_addr,
     started_at = ngx.req.start_time() * 1000
   }
+
+  if conf.flat then
+    message = utils.flat_table(message)
+
+  return message
 end
 
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -633,4 +633,33 @@ _M.validate_header_name = function(name)
               "', allowed characters are A-Z, a-z, 0-9, '_', and '-'"
 end
 
+_M.flat_table = function (table)
+  local cache = {}
+  local r = {}
+
+  local function fullname(prefix, name)
+    return (prefix and prefix .. '.' .. tostring(name)) or tostring(name)
+  end
+
+  local function flat(data, prefix)
+    if type(data) ~= "table" then
+      r[prefix] = data
+      return
+    end
+
+    -- check circular references
+    local str = tostring(data)
+    if cache[str] then
+      return
+    end
+    cache[str] = true
+
+    for k, v in pairs(data) do
+      flat(v, fullname(prefix, k))
+    end
+  end
+
+  flat(table, nil)
+  return r
+end
 return _M


### PR DESCRIPTION
### Summary

Add a `flat` option in file-log plugin to make the output as a "flat" table instead of nested table. 

For example, the output of 
```
{
  "api": {
    "methods": [
      "GET",
      "POST"
    ],
    "http_if_terminated": true,
    "upstream_read_timeout": 60000,
    "preserve_host": false,
    "hosts": [
      "a.example.com",
      "b.example.com",
      "c.example.com"
    ]
  }
}
```
will be flattened as follow
```
{
  "api.headers.host.1": "a.example.com",
  "api.headers.host.2": "b.example.com",
  "api.headers.host.3": "c.example.com",
  "api.methods.1": "GET",
  "api.methods.2": "POST",
  "api.http_if_terminated": true,
  "api.preserve_host": false,
  "api.upstream_read_timeout": 60000,
}
```

### Full changelog

* `kong/plugins/file-log/schema.lua` add `flat` option
* `kong/plugins/file-log/handler.lua` pass `conf.flat` option to `log-serializers`
* `kong/plugins/log-serializers/basic.lua` add `flat` option to `serialize` function
* `kong/tools/utils.lua` add a function flat_table