### PR TITLE
refactor(meta) pre_release becomes suffix

### DIFF
--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -2,11 +2,11 @@ local version = setmetatable({
   major = 0,
   minor = 10,
   patch = 3,
-  --pre_release = ""
+  --suffix = ""
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,
-                         t.pre_release and t.pre_release or "")
+                         t.suffix and t.suffix or "")
   end
 })
 

--- a/spec/01-unit/01-rockspec_meta_spec.lua
+++ b/spec/01-unit/01-rockspec_meta_spec.lua
@@ -37,7 +37,7 @@ describe("rockspec/meta", function()
       assert.is_number(meta._VERSION_TABLE.major)
       assert.is_number(meta._VERSION_TABLE.minor)
       assert.is_number(meta._VERSION_TABLE.patch)
-      -- pre_release optional
+      -- suffix optional
     end)
 
     it("has a _DEPENDENCIES field", function()


### PR DESCRIPTION
To enable release suffix that are not necessarily pre-releases, ie `enterprise`.