### PR TITLE
tests(rate-limiting) improve tests reliability

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,4 +1,4 @@
-#!/usr/bin/env resty
+#!/usr/bin/env resty -c 1024
 
 require "luarocks.loader"
 

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -27,19 +27,19 @@ local function flush_redis()
   red:set_timeout(2000)
   local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
   if not ok then
-    error("failed to connect to Redis: ", err)
+    error("failed to connect to Redis: " .. err)
   end
 
   if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
     local ok, err = red:auth(REDIS_PASSWORD)
     if not ok then
-      error("failed to connect to Redis: ", err)
+      error("failed to connect to Redis: " .. err)
     end
   end
 
   local ok, err = red:select(REDIS_DATABASE)
   if not ok then
-    error("failed to change Redis database: ", err)
+    error("failed to change Redis database: " .. err)
   end
 
   red:flushall()


### PR DESCRIPTION
Improve the reliability of the rate-limiting tests. Currently, the integration tests of this plugin **do not** run on Travis. Another desired improvement is to provision Travis with a Redis instance, or at least test the `cluster` and `local` policies.