### PR TITLE
feat(dao) allow post processing with a callback on a crud_helpers

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -1,7 +1,22 @@
-local utils = require "kong.tools.utils"
-local cjson = require "cjson"
-local responses = require "kong.tools.responses"
-local app_helpers = require "lapis.application"
+local cjson         = require "cjson"
+local utils         = require "kong.tools.utils"
+local responses     = require "kong.tools.responses"
+local app_helpers   = require "lapis.application"
+
+
+local decode_base64 = ngx.decode_base64
+local encode_base64 = ngx.encode_base64
+local encode_args   = ngx.encode_args
+local tonumber      = tonumber
+local ipairs        = ipairs
+local next          = next
+local type          = type
+
+
+local function post_process_row(row, post_process)
+  return type(post_process) == "function" and post_process(row) or row
+end
+
 
 local _M = {}
 
@@ -107,11 +122,11 @@ function _M.find_target_by_target_or_id(self, dao_factory, helpers)
   end
 end
 
-function _M.paginated_set(self, dao_collection)
-  local size = self.params.size and tonumber(self.params.size) or 100
-  local offset = self.params.offset and ngx.decode_base64(self.params.offset)
+function _M.paginated_set(self, dao_collection, post_process)
+  local size   = self.params.size   and tonumber(self.params.size) or 100
+  local offset = self.params.offset and decode_base64(self.params.offset)
 
-  self.params.size = nil
+  self.params.size   = nil
   self.params.offset = nil
 
   local filter_keys = next(self.params) and self.params
@@ -128,56 +143,68 @@ function _M.paginated_set(self, dao_collection)
 
   local next_url
   if offset then
-    offset = ngx.encode_base64(offset)
+    offset = encode_base64(offset)
     next_url = self:build_url(self.req.parsed_url.path, {
-      port = self.req.parsed_url.port,
-      query = ngx.encode_args {
+      port     = self.req.parsed_url.port,
+      query    = encode_args {
         offset = offset,
-        size = size
+        size   = size
       }
     })
   end
 
-  return responses.send_HTTP_OK {
+  local data
+
+  if #rows == 0 then
     -- FIXME: remove and stick to previous `empty_array_mt` metatable
     -- assignment once https://github.com/openresty/lua-cjson/pull/16
     -- is included in the OpenResty release we use.
-    data = #rows > 0 and rows or cjson.empty_array,
-    total = total_count,
-    offset = offset,
+    data = cjson.empty_array
+
+  else
+    data = rows
+
+    if type(post_process) == "function" then
+      for i, row in ipairs(rows) do
+        data[i] = post_process(row)
+      end
+    end
+  end
+
+  return responses.send_HTTP_OK {
+    data     = data,
+    total    = total_count,
+    offset   = offset,
     ["next"] = next_url
   }
 end
 
 -- Retrieval of an entity.
 -- The DAO requires to be given a table containing the full primary key of the entity
-function _M.get(primary_keys, dao_collection)
+function _M.get(primary_keys, dao_collection, post_process)
   local row, err = dao_collection:find(primary_keys)
   if err then
     return app_helpers.yield_error(err)
   elseif row == nil then
     return responses.send_HTTP_NOT_FOUND()
   else
-    return responses.send_HTTP_OK(row)
+    return responses.send_HTTP_OK(post_process_row(row, post_process))
   end
 end
 
 --- Insertion of an entity.
-function _M.post(params, dao_collection, success)
+function _M.post(params, dao_collection, post_process)
   local data, err = dao_collection:insert(params)
   if err then
     return app_helpers.yield_error(err)
   else
-    if success then
-      success(utils.deep_copy(data))
-    end
-    return responses.send_HTTP_CREATED(data)
+    return responses.send_HTTP_CREATED(post_process_row(data, post_process))
   end
 end
 
 --- Partial update of an entity.
 -- Filter keys must be given to get the row to update.
-function _M.patch(params, dao_collection, filter_keys)
+function _M.patch(params, dao_collection, filter_keys, post_process)
   if not next(params) then
     return responses.send_HTTP_BAD_REQUEST("empty body")
   end
@@ -187,14 +214,14 @@ function _M.patch(params, dao_collection, filter_keys)
   elseif updated_entity == nil then
     return responses.send_HTTP_NOT_FOUND()
   else
-    return responses.send_HTTP_OK(updated_entity)
+    return responses.send_HTTP_OK(post_process_row(updated_entity, post_process))
   end
 end
 
 -- Full update of an entity.
 -- First, we check if the entity body has primary keys or not,
 -- if it does, we are performing an update, if not, an insert.
-function _M.put(params, dao_collection)
+function _M.put(params, dao_collection, post_process)
   local new_entity, err
 
   local model = dao_collection.model_mt(params)
@@ -202,13 +229,13 @@ function _M.put(params, dao_collection)
     -- If entity body has no primary key, deal with an insert
     new_entity, err = dao_collection:insert(params)
     if not err then
-      return responses.send_HTTP_CREATED(new_entity)
+      return responses.send_HTTP_CREATED(post_process_row(new_entity, post_process))
     end
   else
     -- If entity body has primary key, deal with update
     new_entity, err = dao_collection:update(params, params, {full = true})
     if not err then
-      return responses.send_HTTP_OK(new_entity)
+      return responses.send_HTTP_OK(post_process_row(new_entity, post_process))
     end
   end
 

--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -193,7 +193,7 @@ function _M.get(primary_keys, dao_collection, post_process)
 end
 
 --- Insertion of an entity.
-function _M.post(params, dao_collection, post_process)
+function _M.post(params, dao_collection, success, post_process)
   local data, err = dao_collection:insert(params)
   if err then
     return app_helpers.yield_error(err)

--- a/kong/api/routes/apis.lua
+++ b/kong/api/routes/apis.lua
@@ -1,4 +1,5 @@
-local crud = require "kong.api.crud_helpers"
+local crud    = require "kong.api.crud_helpers"
+local utils   = require "kong.tools.utils"
 local reports = require "kong.core.reports"
 
 return {
@@ -46,7 +47,7 @@ return {
 
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.plugins, function(data)
-        reports.send("api", data)
+        reports.send("api", utils.deep_copy(data))
       end)
     end,
 

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -29,7 +29,7 @@ return {
 
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.plugins, function(data)
-        reports.send("api", data)
+        reports.send("api", utils.deep_copy(data))
       end)
     end
   },

--- a/spec/02-integration/03-admin_api/10-post_processing_spec.lua
+++ b/spec/02-integration/03-admin_api/10-post_processing_spec.lua
@@ -1,0 +1,120 @@
+local helpers = require "spec.helpers"
+local cjson   = require "cjson"
+
+
+local function it_content_types(title, fn)
+  local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_json = fn("application/json")
+  it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with application/json", test_json)
+end
+
+
+describe("Admin API post-processing", function()
+  local client
+
+  setup(function()
+    assert(helpers.start_kong {
+      custom_plugins = "admin-api-post-process"
+    })
+
+    client = assert(helpers.admin_client())
+  end)
+
+  teardown(function()
+    if client then
+      client:close()
+    end
+
+    helpers.stop_kong()
+  end)
+
+  before_each(function()
+    helpers.dao:truncate_tables()
+    assert(helpers.dao.consumers:insert({
+      username = "michael",
+      custom_id = "landon",
+    }))
+  end)
+
+  it_content_types("post-processes paginated sets", function(content_type)
+    return function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/consumers/post_processed",
+        headers = { ["Content-Type"] = content_type }
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body).data[1]
+      assert.equal("MICHAEL", json.username)
+      assert.equal("LANDON", json.custom_id)
+    end
+  end)
+
+  it_content_types("post-processes crud.post", function(content_type)
+    return function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/consumers/post_processed",
+        body = {
+          username = "devon",
+          custom_id = "miles",
+        },
+        headers = { ["Content-Type"] = content_type }
+      })
+      local body = assert.res_status(201, res)
+      local json = cjson.decode(body)
+      assert.equal("DEVON", json.username)
+      assert.equal("MILES", json.custom_id)
+    end
+  end)
+
+  it_content_types("post-processes crud.get", function(content_type)
+    return function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/consumers/michael/post_processed",
+        headers = { ["Content-Type"] = content_type }
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("MICHAEL", json.username)
+      assert.equal("LANDON", json.custom_id)
+    end
+  end)
+
+  it_content_types("post-processes crud.patch", function(content_type)
+    return function()
+      local res = assert(client:send {
+        method = "PATCH",
+        path = "/consumers/michael/post_processed",
+        body = {
+          custom_id = "knight",
+        },
+        headers = { ["Content-Type"] = content_type }
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("MICHAEL", json.username)
+      assert.equal("KNIGHT", json.custom_id)
+    end
+  end)
+
+  it_content_types("post-processes crud.put", function(content_type)
+    return function()
+      local res = assert(client:send {
+        method = "PUT",
+        path = "/consumers/michael/post_processed",
+        body = {
+          username = "garthe",
+          custom_id = "knight",
+        },
+        headers = { ["Content-Type"] = content_type }
+      })
+      local body = assert.res_status(201, res)
+      local json = cjson.decode(body)
+      assert.equal("GARTHE", json.username)
+      assert.equal("KNIGHT", json.custom_id)
+    end
+  end)
+end)

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/api.lua
@@ -1,0 +1,53 @@
+local crud = require "kong.api.crud_helpers"
+
+
+local function uppercase_table_values(tbl)
+  local result = {}
+
+  for k, v in pairs(tbl) do
+    if type(v) == "string" then
+      result[k] = string.upper(v)
+
+    elseif type(v) == "table" then
+      result[k] = uppercase_table_values(tbl)
+
+    else
+      result[k] = v
+    end
+  end
+
+  return result
+end
+
+
+return {
+  ["/consumers/post_processed"] = {
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.consumers, uppercase_table_values)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.consumers, nil,
+                uppercase_table_values)
+    end,
+  },
+
+  ["/consumers/:username_or_id/post_processed"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      crud.get(self.consumer, dao_factory.consumers, uppercase_table_values)
+    end,
+
+    PATCH = function(self, dao_factory)
+      crud.patch(self.params, dao_factory.consumers, self.consumer,
+                 uppercase_table_values)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.consumers, uppercase_table_values)
+    end,
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/handler.lua
@@ -1,0 +1,16 @@
+-- a plugin fixture to test post-processing on the admin api
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local AdminApiPostProcess = BasePlugin:extend()
+
+
+AdminApiPostProcess.PRIORITY = 1000
+
+
+function AdminApiPostProcess:new()
+  AdminApiPostProcess.super.new(self, "admin-api-post-process")
+end
+
+
+return AdminApiPostProcess

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/schema.lua
@@ -1,0 +1,3 @@
+return {
+  fields = {}
+}


### PR DESCRIPTION
### Summary

Adds 3rd parameter to `paginated_set` function, and when given as a function allows post processing of a paginated results.

Usage example:

```lua
crud.paginated_set(self, dao.oic_issuers, function(row)
  local configuration = row.configuration
  if configuration then
    configuration = json.decode(configuration)
    if configuration then
      row.configuration = configuration

    else
      configuration = {}
    end
  end

  local keys = row.keys
  if keys then
    keys = json.decode(keys)
    if keys then
      row.keys = keys

    else
      keys = {}
    end
  end
end)
```