### PR TITLE
fix(core) explicitly set kong env as user read only

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -315,6 +315,12 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
 
   pl_file.write(kong_config.kong_env, table.concat(buf, "\n"))
 
+  -- ... yeah this sucks. thanks fwrite.
+  local ok, _, _, err = pl_utils.executeex("chmod 640 " .. kong_config.kong_env)
+  if not ok then
+    log.warn("Unable to set kong env permissions: ", err)
+  end
+
   return true
 end
 


### PR DESCRIPTION
### Summary

Because Kong automatically (re)creates this file, we should be define a more restrictive permissions set. Note this is related specifically to the Kong environment file, _not_ the kong.conf user-defined config file (control of which is the responsibility of the system administrator).

### Full changelog

* Set user read-write, group read, and other none permissions on `.kong_env`

### Issues resolved

Addresses some concerns in #1806
