### PR TITLE
tests(router) check only the request line portion of the url

### DIFF
--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -381,7 +381,8 @@ describe("Router", function()
 
         local body = assert.res_status(200, res_uri_1)
         local json = cjson.decode(body)
-        assert.matches("httpbin.org/get", json.url, nil, true)
+        assert.matches("/get", json.url, nil, true)
+        assert.not_matches("/x/y/z/get", json.url, nil, true)
 
         local res_uri_2 = assert(client:send {
           method = "GET",
@@ -390,7 +391,8 @@ describe("Router", function()
 
         body = assert.res_status(200, res_uri_2)
         json = cjson.decode(body)
-        assert.matches("httpbin.org/get", json.url, nil, true)
+        assert.matches("/get", json.url, nil, true)
+        assert.not_matches("/z/y/x/get", json.url, nil, true)
 
         local res_2_uri_1 = assert(client:send {
           method = "GET",
@@ -399,7 +401,8 @@ describe("Router", function()
 
         body = assert.res_status(200, res_2_uri_1)
         json = cjson.decode(body)
-        assert.matches("httpbin.org/get", json.url, nil, true)
+        assert.matches("/get", json.url, nil, true)
+        assert.not_matches("/x/y/z/get", json.url, nil, true)
 
         local res_2_uri_2 = assert(client:send {
           method = "GET",
@@ -408,7 +411,8 @@ describe("Router", function()
 
         body = assert.res_status(200, res_2_uri_2)
         json = cjson.decode(body)
-        assert.matches("httpbin.org/get", json.url, nil, true)
+        assert.matches("/get", json.url, nil, true)
+        assert.not_matches("/x/y/z/get", json.url, nil, true)
       end)
     end)
   end)

--- a/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -134,7 +134,7 @@ describe("URI encoding", function()
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
 
-    assert.equal("http://mockbin.com/request/auth%7C123", json.url)
+    assert.matches("/request/auth%7C123", json.url, nil, true)
 
     -- with `uris` matching
     local res2 = assert(client:send {
@@ -145,7 +145,7 @@ describe("URI encoding", function()
     local body2 = assert.res_status(200, res2)
     local json2 = cjson.decode(body2)
 
-    assert.equal("http://mockbin.com/request/auth%7C123", json2.url)
+    assert.matches("/request/auth%7C123", json2.url, nil, true)
 
     -- with `uris` matching + `strip_uri`
     local res3 = assert(client:send {
@@ -156,6 +156,6 @@ describe("URI encoding", function()
     local body3 = assert.res_status(200, res3)
     local json3 = cjson.decode(body3)
 
-    assert.equal("http://mockbin.com/request/auth%7C123", json3.url)
+    assert.matches("/request/auth%7C123", json3.url, nil, true)
   end)
 end)


### PR DESCRIPTION
httpbin.org generates the "url" portion of the response seemingly from magic (actually, we assume from a combination of the Host/X-Forwarded-Host headers). Router tests that leveraged this response field are updated to examine only the path portion of the resource, as the introduction of X-Forwarded-Host handling, combined with Nginx's internal "host" variable, broke several assumptions about httpbin's response.

The nature of the router strip_uri tests is such that we need to define a separate negative assertion to confirm the strip behavior, as we can no longer rely on the anchoring that the host portion of the "url" field provided (compared with the affected URI encoding tests, which only examine encoding behaviors of unstripped portion of the request line).
