### PR TITLE
chore(deps) Update dns dependency and options

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.5.0",
+  "lua-resty-dns-client == 0.6.0",
   "lua-resty-worker-events == 0.3.0",
   "lua-resty-mediador == 0.1.2",
 }

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -425,16 +425,31 @@
                                  # To read the file again after modifying it,
                                  # Kong must be reloaded.
 
-#dns_order = LAST,SRV,A,CNAME    # the order in which to resolve different
+#dns_order = LAST,SRV,A,CNAME    # The order in which to resolve different
                                  # record types. The `LAST` type means the
                                  # type of the last successful lookup (for the
                                  # specified name). The format is a (case
                                  # insensitive) comma separated list.
 
-#dns_not_found_ttl = 30.0        # ttl in seconds for empty DNS responses and
+#dns_stale_ttl = 4               # Defines, in seconds, how long a record will
+                                 # remain in cache past its TTL. This value
+                                 # will be used while the new DNS record is
+                                 # fetched in the background.
+                                 # Stale data will be used from expiry of a
+                                 # record until either the refresh query
+                                 # completes, or the `dns_stale_ttl` number of
+                                 # seconds have passed.
+
+#dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
                                  # "(3) name error" responses.
 
-#dns_error_ttl = 1.0             # ttl in seconds for error responses.
+#dns_error_ttl = 1               # TTL in seconds for error responses.
+
+#dns_no_sync = off               # If enabled, then upon a cache-miss every
+                                 # request will trigger its own dns query.
+                                 # When disabled multiple requests for the
+                                 # same name/type will be synchronised to a
+                                 # single query.
 
 #------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -97,8 +97,10 @@ local CONF_INFERENCES = {
   dns_resolver = {typ = "array"},
   dns_hostsfile = {typ = "string"},
   dns_order = {typ = "array"},
+  dns_stale_ttl = {typ = "number"},
   dns_not_found_ttl = {typ = "number"},
   dns_error_ttl = {typ = "number"},
+  dns_no_sync = {typ = "boolean"},
 
   ssl = {typ = "boolean"},
   client_ssl = {typ = "boolean"},

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -69,8 +69,10 @@ db_cache_ttl = 3600
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts
 dns_order = LAST,SRV,A,CNAME
-dns_not_found_ttl = 30.0
-dns_error_ttl = 1.0
+dns_stale_ttl = 4
+dns_not_found_ttl = 30
+dns_error_ttl = 1
+dns_no_sync = off
 
 lua_code_cache = on
 lua_socket_pool_size = 30

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -27,7 +27,9 @@ local setup_client = function(conf)
     timeout = nil,                   -- taken from system resolv.conf; timeout
     badTtl = conf.dns_not_found_ttl, -- ttl in seconds for dns error responses (except 3 - name error)
     emptyTtl = conf.dns_error_ttl,   -- ttl in seconds for empty and "(3) name error" dns responses
+    staleTtl = conf.dns_stale_ttl,   -- ttl in seconds for records once they become stale
     order = conf.dns_order,          -- order of trying record types
+    noSynchronisation = conf.dns_no_sync,
   }
   
   assert(dns_client.init(opts))


### PR DESCRIPTION
updates the dns lib to 0.6.0, adds the new `dns_stale_ttl` option.

