### PR TITLE
tests(websocket) set suite to pending

### DIFF
--- a/spec/02-integration/05-proxy/08-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/08-websockets_spec.lua
@@ -2,7 +2,14 @@ local client = require "resty.websocket.client"
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("Websockets", function()
+pending("Websockets", function()
+  -- Pending (2017/06/16)
+  -- Since sockb.in appears to be offline, we'll need to find a way to test
+  -- WebSocket proxying support differently.
+  --  * Use another service
+  --  * Spawn our own sockb.in instance on Heroku
+  --  * Compile our test Nginx with the stream module for local testing (ideal)
+
   setup(function()
     assert(helpers.dao.apis:insert {
       name = "ws",


### PR DESCRIPTION
Since sockb.in appears to be offline, we'll need to find a way to test
WebSocket proxying support differently.

- Use another service
- Spawn our own sockb.in instance on Heroku
- Compile our test Nginx with the stream module for local testing
(ideal)