### PR TITLE
perf(postgres) creating indexes on ttls table

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -510,4 +510,18 @@ return {
       DROP TABLE nodes;
     ]],
   },
+  {
+    name = "2017-06-16-283123_ttl_indexes",
+    up = [[
+      DO $$
+      BEGIN
+        IF (SELECT to_regclass('ttls_primary_uuid_value_idx')) IS NULL THEN
+          CREATE INDEX ttls_primary_uuid_value_idx ON ttls(primary_uuid_value);
+        END IF;
+      END$$;
+    ]],
+    down = [[
+      DROP INDEX ttls_primary_uuid_value_idx;
+    ]]
+  },
 }


### PR DESCRIPTION
An attempt to fix #2208.

Creates two indexes on the `ttls` table in Postgres to improve performance on `SELECT` statements.

Effectively we do make a TTL check on every `SELECT` statement on these columns: https://github.com/Mashape/kong/blob/master/kong/dao/db/postgres.lua#L238-L244

This should improve performance by a lot. 

