### PR TITLE
allow ipv6 nameservers

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "luacrypto == 0.3.2",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.4",
-  "lua-resty-dns-client == 0.5.0",
+  "lua-resty-dns-client == 0.6.0",
   "lua-resty-worker-events == 0.3.0",
   "lua-resty-mediador == 0.1.2",
 }

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -425,16 +425,31 @@
                                  # To read the file again after modifying it,
                                  # Kong must be reloaded.
 
-#dns_order = LAST,SRV,A,CNAME    # the order in which to resolve different
+#dns_order = LAST,SRV,A,CNAME    # The order in which to resolve different
                                  # record types. The `LAST` type means the
                                  # type of the last successful lookup (for the
                                  # specified name). The format is a (case
                                  # insensitive) comma separated list.
 
-#dns_not_found_ttl = 30.0        # ttl in seconds for empty DNS responses and
+#dns_stale_ttl = 4               # Defines, in seconds, how long a record will
+                                 # remain in cache past its TTL. This value
+                                 # will be used while the new DNS record is
+                                 # fetched in the background.
+                                 # Stale data will be used from expiry of a
+                                 # record until either the refresh query
+                                 # completes, or the `dns_stale_ttl` number of
+                                 # seconds have passed.
+
+#dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
                                  # "(3) name error" responses.
 
-#dns_error_ttl = 1.0             # ttl in seconds for error responses.
+#dns_error_ttl = 1               # TTL in seconds for error responses.
+
+#dns_no_sync = off               # If enabled, then upon a cache-miss every
+                                 # request will trigger its own dns query.
+                                 # When disabled multiple requests for the
+                                 # same name/type will be synchronised to a
+                                 # single query.
 
 #------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -415,10 +415,11 @@
 # they have been set.
 
 #dns_resolver =                  # Comma separated list of nameservers, each
-                                 # entry in `ipv4[:port]` format to be used by
+                                 # entry in `ip[:port]` format to be used by
                                  # Kong. If not specified the nameservers in
                                  # the local `resolv.conf` file will be used.
-                                 # Port defaults to 53 if omitted.
+                                 # Port defaults to 53 if omitted. Accepts
+                                 # both IPv4 and IPv6 addresses.
 
 #dns_hostsfile = /etc/hosts      # The hosts file to use. This file is read
                                  # once and its content is static in memory.

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -97,8 +97,10 @@ local CONF_INFERENCES = {
   dns_resolver = {typ = "array"},
   dns_hostsfile = {typ = "string"},
   dns_order = {typ = "array"},
+  dns_stale_ttl = {typ = "number"},
   dns_not_found_ttl = {typ = "number"},
   dns_error_ttl = {typ = "number"},
+  dns_no_sync = {typ = "boolean"},
 
   ssl = {typ = "boolean"},
   client_ssl = {typ = "boolean"},

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -286,9 +286,9 @@ local function check_and_infer(conf)
   if conf.dns_resolver then
     for _, server in ipairs(conf.dns_resolver) do
       local dns = utils.normalize_ip(server)
-      if not dns or dns.type ~= "ipv4" then
+      if not dns or dns.type == "name" then
         errors[#errors+1] = "dns_resolver must be a comma separated list in " ..
-                            "the form of IPv4 or IPv4:port, got '" .. server .. "'"
+                            "the form of IPv4/6 or IPv4/6:port, got '" .. server .. "'"
       end
     end
   end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -69,8 +69,10 @@ db_cache_ttl = 3600
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts
 dns_order = LAST,SRV,A,CNAME
-dns_not_found_ttl = 30.0
-dns_error_ttl = 1.0
+dns_stale_ttl = 4
+dns_not_found_ttl = 30
+dns_error_ttl = 1
+dns_no_sync = off
 
 lua_code_cache = on
 lua_socket_pool_size = 30

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -1,3 +1,4 @@
+local utils = require "kong.tools.utils"
 local dns_client
 
 --- Load and setup the DNS client according to the provided configuration.
@@ -14,8 +15,8 @@ local setup_client = function(conf)
   -- servers must be reformatted as name/port sub-arrays
   if conf.dns_resolver then
     for i, server in ipairs(conf.dns_resolver) do
-      local ip, port = server:match("^([^:]+)%:*(%d*)$")
-      servers[i] = { ip, tonumber(port) or 53 }   -- inserting port if omitted
+      local s = utils.normalize_ip(server)
+      servers[i] = { s.host, s.port or 53 }   -- inserting port if omitted
     end
   end
     
@@ -23,6 +24,7 @@ local setup_client = function(conf)
     hosts = conf.dns_hostsfile,
     resolvConf = nil,                -- defaults to system resolv.conf
     nameservers = servers,           -- provided list or taken from resolv.conf
+    enable_ipv6 = true,              -- allow for ipv6 nameserver addresses
     retrans = nil,                   -- taken from system resolv.conf; attempts
     timeout = nil,                   -- taken from system resolv.conf; timeout
     badTtl = conf.dns_not_found_ttl, -- ttl in seconds for dns error responses (except 3 - name error)

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -27,7 +27,9 @@ local setup_client = function(conf)
     timeout = nil,                   -- taken from system resolv.conf; timeout
     badTtl = conf.dns_not_found_ttl, -- ttl in seconds for dns error responses (except 3 - name error)
     emptyTtl = conf.dns_error_ttl,   -- ttl in seconds for empty and "(3) name error" dns responses
+    staleTtl = conf.dns_stale_ttl,   -- ttl in seconds for records once they become stale
     order = conf.dns_order,          -- order of trying record types
+    noSynchronisation = conf.dns_no_sync,
   }
   
   assert(dns_client.init(opts))

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -246,27 +246,27 @@ describe("Configuration loader", function()
       assert.is_nil(conf)
       assert.equal("proxy_listen_ssl must be of form 'address:port'", err)
     end)
-    it("errors when dns_resolver is not a list in ipv4[:port] format", function()
-      local conf, err = conf_loader(nil, {
-        dns_resolver = "[::1]:53"
-      })
-      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port, got '[::1]:53'", err)
-      assert.is_nil(conf)
-
+    it("errors when dns_resolver is not a list in ipv4/6[:port] format", function()
       local conf, err = conf_loader(nil, {
         dns_resolver = "1.2.3.4:53;4.3.2.1" -- ; as separator
       })
-      assert.equal("dns_resolver must be a comma separated list in the form of IPv4 or IPv4:port, got '1.2.3.4:53;4.3.2.1'", err)
+      assert.equal("dns_resolver must be a comma separated list in the form of IPv4/6 or IPv4/6:port, got '1.2.3.4:53;4.3.2.1'", err)
       assert.is_nil(conf)
 
       conf, err = conf_loader(nil, {
-        dns_resolver = "8.8.8.8,1.2.3.4:53"
+        dns_resolver = "8.8.8.8:53"
       })
       assert.is_nil(err)
       assert.is_table(conf)
 
       conf, err = conf_loader(nil, {
-        dns_resolver = "8.8.8.8:53"
+        dns_resolver = "[::1]:53"
+      })
+      assert.is_nil(err)
+      assert.is_table(conf)
+
+      conf, err = conf_loader(nil, {
+        dns_resolver = "8.8.8.8,1.2.3.4:53,::1,[::1]:53"
       })
       assert.is_nil(err)
       assert.is_table(conf)


### PR DESCRIPTION
allows the nameservers to be configured in both `ipv4` and `ipv6` format. And if the `/etc/resolv.conf` file contains `ipv6` nameserver entries, they will be used as well.

Fixes the _"Error: Invalid configuration, no dns servers found"_ error on systems with only `ipv6` nameservers configured.

(this builds on top of PR #2625 )