### PR TITLE
fix(rate-limiting) invoke redis:set_keepalive method when quering usage

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -167,7 +167,12 @@ return {
         current_metric = nil
       end
 
-      return current_metric and current_metric or 0
+      local ok, err = red:set_keepalive(10000, 100)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+      end
+
+      return current_metric and current_metric or 0, err
     end
   }
 }

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -165,7 +165,12 @@ return {
         current_metric = nil
       end
 
-      return current_metric and current_metric or 0
+      local ok, err = red:set_keepalive(10000, 100)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+      end
+
+      return current_metric and current_metric or 0, err
     end
   }
 }


### PR DESCRIPTION
### Summary

The redis:set_keepalive method should be invoked every time when kong connects to redis. If not, the connection will be closed immediately after return, even though one connection already been added into the connection pool.

### Issues resolved

Fix #2626 
