### PR TITLE
perf(core) get ngx.ctx once and pass along to handlers

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -64,28 +64,26 @@ return {
     end
   },
   certificate = {
-    before = function()
+    before = function(ctx)
       certificate.execute()
     end
   },
   rewrite = {
-    before = function()
-      ngx.ctx.KONG_REWRITE_START = get_now()
+    before = function(ctx)
+      ctx.KONG_REWRITE_START = get_now()
     end,
-    after = function ()
-      local ctx = ngx.ctx
+    after = function (ctx)
       ctx.KONG_REWRITE_TIME = get_now() - ctx.KONG_REWRITE_START -- time spent in Kong's rewrite_by_lua
     end
   },
   access = {
-    before = function()
+    before = function(ctx)
       if not router then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(
           "no router to route request (reason: " .. tostring(router_err) .. ")"
         )
       end
 
-      local ctx = ngx.ctx
       local var = ngx.var
 
       ctx.KONG_ACCESS_START = get_now()
@@ -139,8 +137,7 @@ return {
 
     end,
     -- Only executed if the `router` module found an API and allows nginx to proxy it.
-    after = function()
-      local ctx = ngx.ctx
+    after = function(ctx)
       local var = ngx.var
 
       do
@@ -166,17 +163,15 @@ return {
     end
   },
   header_filter = {
-    before = function()
-      local ctx = ngx.ctx
-
+    before = function(ctx)
       if ctx.KONG_PROXIED then
         local now = get_now()
         ctx.KONG_WAITING_TIME = now - ctx.KONG_ACCESS_ENDED_AT -- time spent waiting for a response from upstream
         ctx.KONG_HEADER_FILTER_STARTED_AT = now
       end
     end,
-    after = function()
-      local ctx, header = ngx.ctx, ngx.header
+    after = function(ctx)
+      local header = ngx.header
 
       if ctx.KONG_PROXIED then
         if singletons.configuration.latency_tokens then
@@ -199,17 +194,17 @@ return {
     end
   },
   body_filter = {
-    after = function()
-      if ngx.arg[2] and ngx.ctx.KONG_PROXIED then
+    after = function(ctx)
+      if ngx.arg[2] and ctx.KONG_PROXIED then
         -- time spent receiving the response (header_filter + body_filter)
         -- we could uyse $upstream_response_time but we need to distinguish the waiting time
         -- from the receiving time in our logging plugins (especially ALF serializer).
-        ngx.ctx.KONG_RECEIVE_TIME = get_now() - ngx.ctx.KONG_HEADER_FILTER_STARTED_AT
+        ctx.KONG_RECEIVE_TIME = get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT
       end
     end
   },
   log = {
-    after = function()
+    after = function(ctx)
       reports.log()
     end
   }

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -217,7 +217,8 @@ function Kong.init_worker()
 end
 
 function Kong.ssl_certificate()
-  core.certificate.before()
+  local ctx = ngx.ctx
+  core.certificate.before(ctx)
 
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, true) do
     plugin.handler:certificate(plugin_conf)
@@ -225,7 +226,8 @@ function Kong.ssl_certificate()
 end
 
 function Kong.balancer()
-  local addr = ngx.ctx.balancer_address
+  local ctx = ngx.ctx
+  local addr = ctx.balancer_address
   local tries = addr.tries
 
   addr.try_count = addr.try_count + 1
@@ -278,7 +280,8 @@ function Kong.balancer()
 end
 
 function Kong.rewrite()
-  core.rewrite.before()
+  local ctx = ngx.ctx
+  core.rewrite.before(ctx)
 
   -- we're just using the iterator, as in this rewrite phase no consumer nor
   -- api will have been identified, hence we'll just be executing the global
@@ -287,43 +290,47 @@ function Kong.rewrite()
     plugin.handler:rewrite(plugin_conf)
   end
 
-  core.rewrite.after()
+  core.rewrite.after(ctx)
 end
 
 function Kong.access()
-  core.access.before()
+  local ctx = ngx.ctx
+  core.access.before(ctx)
 
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, true) do
     plugin.handler:access(plugin_conf)
   end
 
-  core.access.after()
+  core.access.after(ctx)
 end
 
 function Kong.header_filter()
-  core.header_filter.before()
+  local ctx = ngx.ctx
+  core.header_filter.before(ctx)
 
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins) do
     plugin.handler:header_filter(plugin_conf)
   end
 
-  core.header_filter.after()
+  core.header_filter.after(ctx)
 end
 
 function Kong.body_filter()
+  local ctx = ngx.ctx
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins) do
     plugin.handler:body_filter(plugin_conf)
   end
 
-  core.body_filter.after()
+  core.body_filter.after(ctx)
 end
 
 function Kong.log()
+  local ctx = ngx.ctx
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins) do
     plugin.handler:log(plugin_conf)
   end
 
-  core.log.after()
+  core.log.after(ctx)
 end
 
 return Kong


### PR DESCRIPTION
### Summary

Gets the `ngx.ctx` table once, and passes it on to the handlers, reducing the expensive meta-table magic. This could be extended to the plugins, but omitted that. Considering that part of the new plugin api.

