### PR TITLE
perf(ratelimiting) reduce the number of shm accesses in increment

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -28,9 +28,8 @@ return {
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(api_id, identifier, period_date, period)
-          cache.sh_add(cache_key, 0, EXPIRATIONS[period])
 
-          local _, err = cache.sh_incr(cache_key, value)
+          local _, err = cache.sh_incr(cache_key, value, 0)
           if err then
             ngx_log("[rate-limiting] could not increment counter for period '" .. period .. "': " .. tostring(err))
             return nil, err

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -27,9 +27,8 @@ return {
       local periods = timestamp.get_timestamps(current_timestamp)
       for period, period_date in pairs(periods) do
         local cache_key = get_local_key(api_id, identifier, period_date, name, period)
-        cache.sh_add(cache_key, 0, EXPIRATIONS[period])
 
-        local _, err = cache.sh_incr(cache_key, value)
+        local _, err = cache.sh_incr(cache_key, value, 0)
         if err then
           ngx_log("[response-ratelimiting] could not increment counter for period '" .. period .. "': " .. tostring(err))
           return nil, err


### PR DESCRIPTION
### Summary

dict:incr() takes a third param 'init', and always sets the expire time of node entries to 0, so the initial call to dict:add() is useless

### Full changelog

* Replace `add` and `incr` calls with a single `incr` with init value.