### PR TITLE
feat(cli) add --migrate-timeout option

### DIFF
--- a/kong/cmd/restart.lua
+++ b/kong/cmd/restart.lua
@@ -38,10 +38,13 @@ This command is equivalent to doing both 'kong stop' and
 'kong start'.
 
 Options:
- -c,--conf        (optional string)   configuration file
- -p,--prefix      (optional string)   prefix at which Kong should be running
- --nginx-conf     (optional string)   custom Nginx configuration template
- --run-migrations (optional boolean)  optionally run migrations on the DB
+ -c,--conf         (optional string)   configuration file
+ -p,--prefix       (optional string)   prefix at which Kong should be running
+ --nginx-conf      (optional string)   custom Nginx configuration template
+ --run-migrations  (optional boolean)  optionally run migrations on the DB
+ --migrate-timeout (optional number)   how long to wait for migrations to be
+                                       completed by another node
+
 ]]
 
 return {

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -287,7 +287,7 @@ function _M:are_migrations_uptodate()
       then
         local log = require "kong.cmd.utils.log"
         local infos = self.db:infos()
-        log.warn("%s %s '%s' is missing migration: (%s) %s",
+        log.debug("%s %s '%s' is missing migration: (%s) %s",
                   self.db_type, infos.desc, infos.name, module, migration.name)
         return false, "migrations are not up to date"
       end


### PR DESCRIPTION
implements a commandline option to wait for migrations to complete.

If set it will check every second wether the migrations are up to date, and only start when positive. After the timeout expires a failure to start will be reported.

This allows starting multiple nodes, with one running migrations, and the others not starting until migrations are complete. The timeout is also applied if the datastore is uninitialized.

this builds on top of #2421