### PR TITLE
add readable timestamp format in log serializers basic

### DIFF
--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -71,7 +71,7 @@ end
 
 function FileLogHandler:log(conf)
   FileLogHandler.super.log(self)
-  local message = basic_serializer.serialize(ngx)
+  local message = basic_serializer.serialize(ngx, conf)
 
   local ok, err = ngx_timer(0, log, conf, message)
   if not ok then

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -17,5 +17,6 @@ return {
   fields = {
     path = { required = true, type = "string", func = validate_file },
     reopen = { type = "boolean", default = false },
+    timestamp_format = { type = "string", default = nil },
   }
 }

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,10 +1,12 @@
 local tablex = require "pl.tablex"
+local ts = require "kong.tools.timestamp"
 
 local _M = {}
 
 local EMPTY = tablex.readonly({})
 
-function _M.serialize(ngx)
+function _M.serialize(ngx, conf)
+  conf = conf or {}
   local authenticated_entity
   if ngx.ctx.authenticated_credential ~= nil then
     authenticated_entity = {
@@ -34,13 +36,13 @@ function _M.serialize(ngx)
              (ngx.ctx.KONG_REWRITE_TIME or 0) + 
              (ngx.ctx.KONG_BALANCER_TIME or 0),
       proxy = ngx.ctx.KONG_WAITING_TIME or -1,
-      request = ngx.var.request_time * 1000
+      request = ts.format_timestamp(ngx.var.request_time * 1000, conf.timestamp_format)
     },
     authenticated_entity = authenticated_entity,
     api = ngx.ctx.api,
     consumer = ngx.ctx.authenticated_consumer,
     client_ip = ngx.var.remote_addr,
-    started_at = ngx.req.start_time() * 1000
+    started_at = ts.format_timestamp(ngx.req.start_time() * 1000, conf.timestamp_format)
   }
 end
 

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -67,9 +67,22 @@ local function get_timestamps(now)
   return stamps
 end
 
+--- format the timestamp to string.
+-- @param timestamp
+-- @param format datetime format like '%Y-%m-%d %H:%M:%S.%s'
+-- @return formatted string of timestamp if format is provided otherwise the original timestamp
+function format_timestamp(timestamp, format)
+  if format then
+    return os.date(format, timestamp)
+  else
+    return timestamp
+  end
+end
+
 return {
   get_utc = get_utc,
   get_utc_ms = get_utc_ms,
   get_timetable = get_timetable,
   get_timestamps = get_timestamps,
+  format_timestamps = format_timestamps,
 }


### PR DESCRIPTION
### Summary

The origin log has a request start timestamp but in milliseconds format. It's inconvenience for people to read. This commit include a tiny change to add a human readable field for request `started_at` timestamp in format `%Y-%m-%d %H:%M:%S`.

### Full changelog

* `kong/plugins/log-serializers/basic.lua` add field `started_at_s` in log .

