### PR TITLE
chore(dao) modify postgres for bdr compatibility

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -147,7 +147,9 @@ return {
     up = [[
       DO $$
       BEGIN
-        ALTER TABLE apis ADD COLUMN retries smallint NOT NULL DEFAULT 5;
+        ALTER TABLE apis ADD COLUMN retries smallint;
+        ALTER TABLE apis ALTER COLUMN retries SET DEFAULT 5;
+        UPDATE apis SET retries = 5;
       EXCEPTION WHEN duplicate_column THEN
           -- Do nothing, accept existing state
       END$$;


### PR DESCRIPTION
### Summary
This change helps support compatibility with BDR.
Kong performs postgres database migrations on start-up.
Postgres logs an error when postgres.lua calls ALTER TABLE … DEFAULT.
Per the BDR docs, ALTER TABLE ... DEFAULT is not supported by BDR.
However, it can be rewritten into a short sequence that is supported.
This commit replaces the one command with the short sequence.

http://bdr-project.org/docs/0.9/ddl-replication-statements.html

### Full changelog

* [Implement restructured postgreSQL commands in kong/dao/migrations/postgres.lua]

### Issues resolved

Fix  #2671
