### PR TITLE
fix(aws-lambda) Fix typo in X-Amz-Function-Error header

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -84,7 +84,7 @@ function AWSLambdaHandler:access(conf)
   end
 
   if conf.unhandled_status
-     and headers["X-Amzn-Function-Error"] == "Unhandled"
+     and headers["X-Amz-Function-Error"] == "Unhandled"
   then
     ngx.status = conf.unhandled_status
 

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -184,7 +184,7 @@ describe("Plugin: AWS Lambda (access)", function()
     local body = assert.res_status(200, res)
     assert.is_string(res.headers["x-amzn-RequestId"])
     assert.equal([["some_value1"]], body)
-    assert.is_nil(res.headers["X-Amzn-Function-Error"])
+    assert.is_nil(res.headers["X-Amz-Function-Error"])
   end)
   it("invokes a Lambda function with POST params", function()
     local res = assert(client:send {
@@ -293,7 +293,7 @@ describe("Plugin: AWS Lambda (access)", function()
       }
     })
     assert.res_status(200, res)
-    assert.equal("Unhandled", res.headers["X-Amzn-Function-Error"])
+    assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
   end)
   it("invokes a Lambda function with an unhandled function error with Event invocation type", function()
     local res = assert(client:send {
@@ -304,7 +304,7 @@ describe("Plugin: AWS Lambda (access)", function()
       }
     })
     assert.res_status(202, res)
-    assert.equal("Unhandled", res.headers["X-Amzn-Function-Error"])
+    assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
   end)
   it("invokes a Lambda function with an unhandled function error with DryRun invocation type", function()
     local res = assert(client:send {
@@ -315,7 +315,7 @@ describe("Plugin: AWS Lambda (access)", function()
       }
     })
     assert.res_status(204, res)
-    assert.equal("Unhandled", res.headers["X-Amzn-Function-Error"])
+    assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
   end)
   it("invokes a Lambda function with an unhandled function error", function()
     local res = assert(client:send {
@@ -326,6 +326,6 @@ describe("Plugin: AWS Lambda (access)", function()
       }
     })
     assert.res_status(412, res)
-    assert.equal("Unhandled", res.headers["X-Amzn-Function-Error"])
+    assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
   end)
 end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -279,7 +279,7 @@ http {
                 local function say(res, status)
                   ngx.header["x-amzn-RequestId"] = "foo"
                   if string.match(ngx.var.uri, "functionWithUnhandledError") then
-                    ngx.header["X-Amzn-Function-Error"] = "Unhandled"
+                    ngx.header["X-Amz-Function-Error"] = "Unhandled"
                   end
                   ngx.status = status
 


### PR DESCRIPTION
```
HTTP/1.1 200 OK
Content-Type: application/json
Connection: keep-alive
Content-Length: 444
Connection: keep-alive
x-amzn-RequestId: ...
X-Amzn-Trace-Id: ...
Date: Thu, 06 Jul 2017 16:23:07 GMT
X-Amz-Function-Error: Handled
x-amzn-Remapped-Content-Length: 0
Server: kong/0.10.2
```

Today I noticed that I mistakenly added a `n` to the aws lambda function http header. ☹️ 

This fixes the aws-lambda plugin and specs to use the correct function header name as per the latest documentation at http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_ResponseSyntax

> ## Response Syntax
>```
>HTTP/1.1 StatusCode
>X-Amz-Function-Error: FunctionError
>X-Amz-Log-Result: LogResult
>
>Payload
>```

I'll open a separate PR to support updating the status code for Handled errors.

suggested reviewers: @thibaultcha and @p0pr0ck5 since they helped me land https://github.com/Mashape/kong/pull/2587.