### PR TITLE
feat(cli) option to disable automatic migrations

### DIFF
--- a/kong/cmd/restart.lua
+++ b/kong/cmd/restart.lua
@@ -38,9 +38,10 @@ This command is equivalent to doing both 'kong stop' and
 'kong start'.
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) prefix at which Kong should be running
- --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf           (optional string) configuration file
+ -p,--prefix         (optional string) prefix at which Kong should be running
+ --nginx-conf        (optional string) custom Nginx configuration template
+ --no-migrations                       disable migrations on the DB
 ]]
 
 return {

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -17,7 +17,10 @@ local function execute(args)
   local dao = assert(DAOFactory.new(conf))
   xpcall(function()
     assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
-    assert(dao:run_migrations())
+    if not dao.db:migrations_initialized() or not args.no_migrations then
+      assert(dao:run_migrations())
+    end
+    assert(dao:are_migrations_uptodate())
     assert(nginx_signals.start(conf))
     log("Kong started")
   end, function(e)
@@ -39,9 +42,10 @@ Start Kong (Nginx and other configured services) in the configured
 prefix directory.
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) override prefix directory
- --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf           (optional string) configuration file
+ -p,--prefix         (optional string) prefix at which Kong should be running
+ --nginx-conf        (optional string) custom Nginx configuration template
+ --no-migrations                       disable migrations on the DB
 ]]
 
 return {

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -24,8 +24,8 @@ _M.dao_insert_values = {
     return uuid()
   end,
   timestamp = function()
-    -- return time in UNIT millisecond, and PRECISION millisecond 
-    return math.floor(timestamp.get_utc_ms()) 
+    -- return time in UNIT millisecond, and PRECISION millisecond
+    return math.floor(timestamp.get_utc_ms())
   end
 }
 
@@ -626,6 +626,39 @@ function _M:truncate_table(table_name)
     return nil, err
   end
   return true
+end
+
+function _M:migrations_initialized()
+  local q_keyspace_and_migrations_table_exists
+
+  assert(self.release_version, "release_version not set for Cassandra cluster")
+
+  if self.release_version == 3 then
+    q_keyspace_and_migrations_table_exists = [[
+      SELECT COUNT(*) FROM system_schema.tables
+      WHERE keyspace_name = ? AND table_name = ?
+    ]]
+  else
+    q_keyspace_and_migrations_table_exists = [[
+      SELECT COUNT(*) FROM system.schema_columnfamilies
+      WHERE keyspace_name = ? AND columnfamily_name = ?
+    ]]
+  end
+
+  -- Check if keyspace and "schema_migrations" table exists
+  local rows, err = self:query(q_keyspace_and_migrations_table_exists, {
+    self.cluster_options.keyspace,
+    "schema_migrations"
+  }, {
+    prepared = false,
+    --consistency = cassandra.consistencies.all,
+  }, nil, true)
+  if not rows then
+    return nil, err
+
+  elseif rows[1] and rows[1].count > 0 then
+    return true
+  end
 end
 
 function _M:current_migrations()

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -521,6 +521,16 @@ function _M:truncate_table(table_name)
   return true
 end
 
+function _M:migrations_initialized()
+  -- check if schema_migrations table exists
+  local rows, err = self:query "SELECT to_regclass('schema_migrations')"
+  if not rows then
+    return nil, err
+  end
+
+  return #rows > 0 and rows[1].to_regclass == "schema_migrations"
+end
+
 function _M:current_migrations()
   -- check if schema_migrations table exists
   local rows, err = self:query "SELECT to_regclass('schema_migrations')"

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -272,6 +272,31 @@ local function default_on_success(identifier, migration_name, db_infos)
       identifier, migration_name)
 end
 
+function _M:are_migrations_uptodate()
+  local migrations_modules = self:migrations_modules()
+  local cur_migrations, err = self:current_migrations()
+  if err then
+    return ret_error_string(self.db.name, nil,
+      "could not get current migrations: " .. err)
+  end
+
+  for module, migrations in pairs(migrations_modules) do
+    for _, migration in ipairs(migrations) do
+      if not (cur_migrations[module] and
+              utils.table_contains(cur_migrations[module], migration.name))
+      then
+        local log = require "kong.cmd.utils.log"
+        local infos = self.db:infos()
+        log.warn("%s %s '%s' is missing migration: (%s) %s",
+          self.db_type, infos.desc, infos.name, module, migration.name)
+        return false, "all migrations need to run for Kong to start"
+      end
+    end
+  end
+
+  return true
+end
+
 function _M:run_migrations(on_migrate, on_success)
   on_migrate = on_migrate or default_on_migrate
   on_success = on_success or default_on_success

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -136,7 +136,12 @@ function Kong.init()
 
   local dao = assert(DAOFactory.new(config)) -- instantiate long-lived DAO
   assert(dao:init())
-  assert(dao:run_migrations()) -- migrating in case embedded in custom nginx
+
+  -- migrating in case embedded in custom nginx
+  if not dao.db:migrations_initialized() then
+    assert(dao:run_migrations())
+  end
+  assert(dao:are_migrations_uptodate())
 
   -- populate singletons
   singletons.ip = ip.init(config)


### PR DESCRIPTION
### Summary

Here is another proposal for PR #2421, with exact same functionality 
but reverse default behavior.   

`--no-migrations` option added for CLI cmd `kong start` and
`kong restart` to give user option to disable automatic migration
when Kong (re)start.

This feature would not be applicable when Kong is started with
an empty database as Kong will override the `--no-migrations`
option and will run all the migrations. Kong will not start until all
the migrations have been applied to database irrespective of
`--no-migrations` option used or not. So user should run
migrations explicitly if they plan to use  `--no-migrations` option.

### Full changelog

* `--no-migrations` option added for `kong start` and `kong restart`
* specs updated