### PR TITLE
chore(deps) change to latest kong fork of lapis to support latest openresty

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "lua-resty-jit-uuid == 0.0.5",
   "multipart == 0.5",
   "version == 0.2",
-  "lapis == 1.5.1",
+  "kong-lapis == 1.5.3",
   "lua-cassandra == 1.2.2",
   "pgmoon-mashape == 2.0.1",
   "luatz == 0.3",

--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -1,7 +1,7 @@
 local utils = require "kong.tools.utils"
 local cjson = require "cjson"
 local responses = require "kong.tools.responses"
-local app_helpers = require "lapis.application"
+local app_helpers = require "kong-lapis.application"
 
 local _M = {}
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -1,9 +1,9 @@
-local lapis = require "lapis"
+local lapis = require "kong-lapis"
 local utils = require "kong.tools.utils"
 local tablex = require "pl.tablex"
 local responses = require "kong.tools.responses"
 local singletons = require "kong.singletons"
-local app_helpers = require "lapis.application"
+local app_helpers = require "kong-lapis.application"
 local api_helpers = require "kong.api.api_helpers"
 
 

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -1,5 +1,5 @@
 local crud = require "kong.api.crud_helpers"
-local app_helpers = require "lapis.application"
+local app_helpers = require "kong-lapis.application"
 local responses = require "kong.tools.responses"
 local cjson = require "cjson"
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -195,7 +195,7 @@ server {
                 ngx.exit(204)
             end
 
-            require('lapis').serve('kong.api')
+            require('kong-lapis').serve('kong.api')
         }
     }
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -187,7 +187,7 @@ http {
                     ngx.exit(204)
                 end
 
-                require('lapis').serve('kong.api')
+                require('kong-lapis').serve('kong.api')
             }
         }
 


### PR DESCRIPTION
### Summary

This PR will change Lapis framework dependency to Mashape's temporary fork `kong-lapis`. This is added to support latest versions of OpenResty.

### Full changelog

* Change dependency from `lapis` to `kong-lapis` on a `.rockspec`
* Change code dependencies to use `kong-lapis` instead of `lapis`

### Issues resolved

Fix #2489
