### PR TITLE
fix(basic-auth) removes NYI instruction

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -37,7 +37,7 @@ local function retrieve_credentials(request, header_name, conf)
       return
     end
 
-    if m and next(m) then
+    if m and m[1] then
       local decoded_basic = ngx.decode_base64(m[1])
       if decoded_basic then
         local basic_parts = utils.split(decoded_basic, ":")


### PR DESCRIPTION
### Summary

The call to `next` on this plugin checked whether table m was empty.
Since only m[1] is used later on, I changed the check to test whether
m[1] exists.