### PR TITLE
fix(bot-detection) replace ngx.re.match with find

### DIFF
--- a/kong/plugins/bot-detection/handler.lua
+++ b/kong/plugins/bot-detection/handler.lua
@@ -6,7 +6,7 @@ local strip = require("kong.tools.utils").strip
 
 local ipairs = ipairs
 local get_headers = ngx.req.get_headers
-local re_match = ngx.re.match
+local re_find = ngx.re.find
 
 local BotDetectionHandler = BasePlugin:extend()
 
@@ -49,7 +49,7 @@ function BotDetectionHandler:access(conf)
 
     if conf.whitelist then
       for _, rule in ipairs(conf.whitelist) do
-        if re_match(user_agent, rule) then
+        if re_find(user_agent, rule) then
           bot_cache.set(cache_key, true)
           return
         end
@@ -58,15 +58,15 @@ function BotDetectionHandler:access(conf)
 
     if conf.blacklist then
       for _, rule in ipairs(conf.blacklist) do
-        if re_match(user_agent, rule) then
+        if re_find(user_agent, rule) then
           bot_cache.set(cache_key, false)
           return responses.send_HTTP_FORBIDDEN()
         end
       end
     end
-  
+
     for _, rule in ipairs(rules.bots) do
-      if re_match(user_agent, rule) then
+      if re_find(user_agent, rule) then
         bot_cache.set(cache_key, false)
         return responses.send_HTTP_FORBIDDEN()
       end


### PR DESCRIPTION
### Summary

We don't need to use the match's return value, only whether the match
happened.
