### PR TITLE
refactor(conf) add ${{PROXY_PROTOCOL}} template variable

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -111,6 +111,7 @@ local function compile_conf(kong_config, conf_template)
 
   compile_env.http2 = kong_config.http2 and " http2" or ""
   compile_env.admin_http2 = kong_config.admin_http2 and " http2" or ""
+  compile_env.proxy_protocol = kong_config.real_ip_header == "proxy_protocol" and " proxy_protocol" or ""
 
   local post_template = pl_template.substitute(conf_template, compile_env)
   return string.gsub(post_template, "(${%b{}})", function(w)

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -65,11 +65,7 @@ upstream kong_upstream {
 
 server {
     server_name kong;
-> if real_ip_header == "proxy_protocol" then
-    listen ${{PROXY_LISTEN}} proxy_protocol;
-> else
-    listen ${{PROXY_LISTEN}};
-> end
+    listen ${{PROXY_LISTEN}}${{PROXY_PROTOCOL}};
     error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
@@ -79,11 +75,7 @@ server {
     client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
 
 > if ssl then
-> if real_ip_header == "proxy_protocol" then
-    listen ${{PROXY_LISTEN_SSL}} proxy_protocol ssl${{HTTP2}};
-> else
-    listen ${{PROXY_LISTEN_SSL}} ssl${{HTTP2}};
-> end
+    listen ${{PROXY_LISTEN_SSL}} ssl${{HTTP2}}${{PROXY_PROTOCOL}};
     ssl_certificate ${{SSL_CERT}};
     ssl_certificate_key ${{SSL_CERT_KEY}};
     ssl_protocols TLSv1.1 TLSv1.2;

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -107,6 +107,14 @@ describe("NGINX conf compiler", function()
       assert.matches("listen 0.0.0.0:9001;", kong_nginx_conf, nil, true)
       assert.matches("listen 0.0.0.0:8444 ssl http2;", kong_nginx_conf, nil, true)
     end)
+    it("enables proxy_protocol", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        real_ip_header = "proxy_protocol",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("listen 0.0.0.0:9000 proxy_protocol;", kong_nginx_conf, nil, true)
+      assert.matches("listen 0.0.0.0:9443 ssl proxy_protocol;", kong_nginx_conf, nil, true)
+    end)
     it("disables SSL", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         ssl = false,
@@ -279,7 +287,7 @@ describe("NGINX conf compiler", function()
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
         assert.matches("real_ip_header%s+proxy_protocol", nginx_conf)
         assert.matches("listen 0.0.0.0:8000 proxy_protocol;", nginx_conf)
-        assert.matches("listen 0.0.0.0:8443 proxy_protocol ssl;", nginx_conf)
+        assert.matches("listen 0.0.0.0:8443 ssl proxy_protocol;", nginx_conf)
       end)
     end)
   end)

--- a/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -622,12 +622,12 @@ describe("Upstream header(s)", function()
       it("should be changed according to rules if present in request", function()
         local sock = ngx.socket.tcp()
         local request = "PROXY TCP4 192.168.0.1 " .. helpers.test_conf.proxy_ip .. " 56324 " .. helpers.test_conf.proxy_port .. "\r\n" ..
-            "GET / HTTP/1.1\r\n" ..
-            "Host: headers-inspect.com\r\n" ..
-            "Connection: close\r\n" ..
-            "X-Real-IP: 10.0.0.2\r\n" ..
-            "X-Forwarded-For: 10.0.0.1, 127.0.0.2, 10.0.0.1, 192.168.0.1, 172.16.0.1\r\n" ..
-            "\r\n"
+                        "GET / HTTP/1.1\r\n" ..
+                        "Host: headers-inspect.com\r\n" ..
+                        "Connection: close\r\n" ..
+                        "X-Real-IP: 10.0.0.2\r\n" ..
+                        "X-Forwarded-For: 10.0.0.1, 127.0.0.2, 10.0.0.1, 192.168.0.1, 172.16.0.1\r\n" ..
+                        "\r\n"
 
         assert(sock:connect(helpers.test_conf.proxy_ip, helpers.test_conf.proxy_port))
         assert(sock:send(request))
@@ -652,13 +652,13 @@ describe("Upstream header(s)", function()
       it("should be forwarded even if proxy protocol and X-Forwarded-For header has a port in it", function()
         local sock = ngx.socket.tcp()
         local request = "PROXY TCP4 192.168.0.1 " .. helpers.test_conf.proxy_ip .. " 56324 " .. helpers.test_conf.proxy_port .. "\r\n" ..
-            "GET / HTTP/1.1\r\n" ..
-            "Host: headers-inspect.com\r\n" ..
-            "Connection: close\r\n" ..
-            "X-Real-IP: 10.0.0.2\r\n" ..
-            "X-Forwarded-For: 127.0.0.1:14, 10.0.0.1:15, 192.168.0.1:16, 127.0.0.1:17, 172.16.0.1:18\r\n" ..
-            "X-Forwarded-Port: 14\r\n" ..
-            "\r\n"
+                        "GET / HTTP/1.1\r\n" ..
+                        "Host: headers-inspect.com\r\n" ..
+                        "Connection: close\r\n" ..
+                        "X-Real-IP: 10.0.0.2\r\n" ..
+                        "X-Forwarded-For: 127.0.0.1:14, 10.0.0.1:15, 192.168.0.1:16, 127.0.0.1:17, 172.16.0.1:18\r\n" ..
+                        "X-Forwarded-Port: 14\r\n" ..
+                        "\r\n"
 
         assert(sock:connect(helpers.test_conf.proxy_ip, helpers.test_conf.proxy_port))
         assert(sock:send(request))
@@ -697,10 +697,10 @@ describe("Upstream header(s)", function()
       it("should be added if not present in request", function()
         local sock = ngx.socket.tcp()
         local request = "PROXY TCP4 192.168.0.1 " .. helpers.test_conf.proxy_ip .. " 56324 " .. helpers.test_conf.proxy_port .. "\r\n" ..
-            "GET / HTTP/1.1\r\n" ..
-            "Host: headers-inspect.com\r\n" ..
-            "Connection: close\r\n" ..
-            "\r\n"
+                        "GET / HTTP/1.1\r\n" ..
+                        "Host: headers-inspect.com\r\n" ..
+                        "Connection: close\r\n" ..
+                        "\r\n"
 
         assert(sock:connect(helpers.test_conf.proxy_ip, helpers.test_conf.proxy_port))
         assert(sock:send(request))
@@ -724,12 +724,12 @@ describe("Upstream header(s)", function()
       it("should be changed according to rules if present in request", function()
         local sock = ngx.socket.tcp()
         local request = "PROXY TCP4 192.168.0.1 " .. helpers.test_conf.proxy_ip .. " 56324 " .. helpers.test_conf.proxy_port .. "\r\n" ..
-            "GET / HTTP/1.1\r\n" ..
-            "Host: headers-inspect.com\r\n" ..
-            "Connection: close\r\n" ..
-            "X-Real-IP: 10.0.0.2\r\n" ..
-            "X-Forwarded-For: 10.0.0.1, 127.0.0.2, 10.0.0.1, 192.168.0.1, 172.16.0.1\r\n" ..
-            "\r\n"
+                        "GET / HTTP/1.1\r\n" ..
+                        "Host: headers-inspect.com\r\n" ..
+                        "Connection: close\r\n" ..
+                        "X-Real-IP: 10.0.0.2\r\n" ..
+                        "X-Forwarded-For: 10.0.0.1, 127.0.0.2, 10.0.0.1, 192.168.0.1, 172.16.0.1\r\n" ..
+                        "\r\n"
 
         assert(sock:connect(helpers.test_conf.proxy_ip, helpers.test_conf.proxy_port))
         assert(sock:send(request))
@@ -754,13 +754,13 @@ describe("Upstream header(s)", function()
       it("should be replaced even if proxy protocol, X-Forwarded-Port and X-Forwarded-For headers have a port in it", function()
         local sock = ngx.socket.tcp()
         local request = "PROXY TCP4 192.168.0.1 " .. helpers.test_conf.proxy_ip .. " 56324 " .. helpers.test_conf.proxy_port .. "\r\n" ..
-            "GET / HTTP/1.1\r\n" ..
-            "Host: headers-inspect.com\r\n" ..
-            "Connection: close\r\n" ..
-            "X-Real-IP: 10.0.0.2\r\n" ..
-            "X-Forwarded-For: 127.0.0.1:14, 10.0.0.1:15, 192.168.0.1:16, 127.0.0.1:17, 172.16.0.1:18\r\n" ..
-            "X-Forwarded-Port: 14\r\n" ..
-            "\r\n"
+                        "GET / HTTP/1.1\r\n" ..
+                        "Host: headers-inspect.com\r\n" ..
+                        "Connection: close\r\n" ..
+                        "X-Real-IP: 10.0.0.2\r\n" ..
+                        "X-Forwarded-For: 127.0.0.1:14, 10.0.0.1:15, 192.168.0.1:16, 127.0.0.1:17, 172.16.0.1:18\r\n" ..
+                        "X-Forwarded-Port: 14\r\n" ..
+                        "\r\n"
 
         assert(sock:connect(helpers.test_conf.proxy_ip, helpers.test_conf.proxy_port))
         assert(sock:send(request))

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -86,7 +86,7 @@ http {
         client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
 
 > if ssl then
-        listen ${{PROXY_LISTEN_SSL}} ssl${{PROXY_PROTOCOL}};
+        listen ${{PROXY_LISTEN_SSL}} ssl${{HTTP2}}${{PROXY_PROTOCOL}};
         ssl_certificate ${{SSL_CERT}};
         ssl_certificate_key ${{SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;
@@ -162,7 +162,7 @@ http {
         client_body_buffer_size 10m;
 
 > if admin_ssl then
-        listen ${{ADMIN_LISTEN_SSL}} ssl;
+        listen ${{ADMIN_LISTEN_SSL}} ssl${{ADMIN_HTTP2}};
         ssl_certificate ${{ADMIN_SSL_CERT}};
         ssl_certificate_key ${{ADMIN_SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -77,11 +77,7 @@ http {
 
     server {
         server_name kong;
-> if real_ip_header == "proxy_protocol" then
-        listen ${{PROXY_LISTEN}} proxy_protocol;
-> else
-        listen ${{PROXY_LISTEN}};
-> end
+        listen ${{PROXY_LISTEN}}${{PROXY_PROTOCOL}};
         error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
         error_page 500 502 503 504 /kong_error_handler;
 
@@ -90,11 +86,7 @@ http {
         client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
 
 > if ssl then
-> if real_ip_header == "proxy_protocol" then
-        listen ${{PROXY_LISTEN_SSL}} proxy_protocol ssl;
-> else
-        listen ${{PROXY_LISTEN_SSL}} ssl;
-> end
+        listen ${{PROXY_LISTEN_SSL}} ssl${{PROXY_PROTOCOL}};
         ssl_certificate ${{SSL_CERT}};
         ssl_certificate_key ${{SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
### Summary

@thefosk added HTTP2 flags to config, and here I decided to follow same pattern and add a new template variable ${{PROXY_PROTOCOL}} to template compilation. It makes the templates a bit easier to read. I also added couple of additional tests (originally didn't want to add this as I felt it was a bit dirty to have that variable with a space in front of the actual value, e.g. " proxy_protocol", but as I saw @thefosk using it for HTTP2, I decided to follow the suit).