### PR TITLE
refactor(conf) move excessive lua code out of kong nginx templates

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -43,8 +43,6 @@ lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 
 init_by_lua_block {
-    require 'luarocks.loader'
-    require 'resty.core'
     kong = require 'kong'
     kong.init()
 }
@@ -157,7 +155,7 @@ server {
     location = /kong_error_handler {
         internal;
         content_by_lua_block {
-            require('kong.core.error_handlers')(ngx)
+            kong.handle_error()
         }
     }
 }
@@ -187,15 +185,7 @@ server {
     location / {
         default_type application/json;
         content_by_lua_block {
-            ngx.header['Access-Control-Allow-Origin'] = '*'
-
-            if ngx.req.get_method() == 'OPTIONS' then
-                ngx.header['Access-Control-Allow-Methods'] = 'GET,HEAD,PUT,PATCH,POST,DELETE'
-                ngx.header['Access-Control-Allow-Headers'] = 'Content-Type'
-                ngx.exit(204)
-            end
-
-            require('lapis').serve('kong.api')
+            kong.serve_admin_api()
         }
     }
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -56,7 +56,6 @@ http {
 > end
 
     init_by_lua_block {
-        require 'resty.core'
         kong = require 'kong'
         kong.init()
     }
@@ -155,7 +154,7 @@ http {
         location = /kong_error_handler {
             internal;
             content_by_lua_block {
-                require('kong.core.error_handlers')(ngx)
+                kong.handle_error()
             }
         }
     }
@@ -179,15 +178,7 @@ http {
         location / {
             default_type application/json;
             content_by_lua_block {
-                ngx.header['Access-Control-Allow-Origin'] = '*'
-                ngx.header['Access-Control-Allow-Credentials'] = 'false'
-                if ngx.req.get_method() == 'OPTIONS' then
-                    ngx.header['Access-Control-Allow-Methods'] = 'GET,HEAD,PUT,PATCH,POST,DELETE'
-                    ngx.header['Access-Control-Allow-Headers'] = 'Content-Type'
-                    ngx.exit(204)
-                end
-
-                require('lapis').serve('kong.api')
+                kong.serve_admin_api()
             }
         }
 


### PR DESCRIPTION
### Summary

Originally did this for Lapis patch to move Admin API Lua / CORS code out of Kong Nginx templates. But I decided to make other changes to other similar parts of the code, and here it is for a review.