### PR TITLE
feat(dao) ngx.null — allows patch requests to remove opt. conf. params

### DIFF
--- a/kong/dao/dao.lua
+++ b/kong/dao/dao.lua
@@ -268,6 +268,8 @@ local function fix(old, new, schema)
       for f_k in pairs(f_schema.fields) do
         if new[col][f_k] == nil and old[col][f_k] ~= nil then
           new[col][f_k] = old[col][f_k]
+        elseif new[col][f_k] == ngx.null then
+          new[col][f_k] = nil
         end
       end
 

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -24,8 +24,8 @@ _M.dao_insert_values = {
     return uuid()
   end,
   timestamp = function()
-    -- return time in UNIT millisecond, and PRECISION millisecond 
-    return math.floor(timestamp.get_utc_ms()) 
+    -- return time in UNIT millisecond, and PRECISION millisecond
+    return math.floor(timestamp.get_utc_ms())
   end
 }
 
@@ -262,7 +262,7 @@ end
 -- @section query_building
 
 local function serialize_arg(field, value)
-  if value == nil then
+  if value == nil or value == ngx.null then
     return cassandra.null
   elseif field.type == "id" then
     return cassandra.uuid(value)

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -188,6 +188,10 @@ end
 
 -- @see pgmoon
 local function escape_literal(val, field)
+  if val == ngx.null then
+    return "NULL"
+  end
+
   local t_val = type(val)
   if t_val == "number" then
     return tostring(val)


### PR DESCRIPTION
### Summary

Better handling of JSON `null` in DAO layer and validations.

Also allows usage of JSON `null` to remove optional parameters using `PATCH` request, e.g. with HTTPie:

```bash
http patch :8001/apis/test hosts:=null uris:=null
```
