### PR TITLE
fix(datadog) skip non-matched apis

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -77,6 +77,12 @@ end
 
 function DatadogHandler:log(conf)
   DatadogHandler.super.log(self)
+  
+  -- unmatched apis are nil
+  if not ngx.ctx.api then
+    return
+  end
+
   local message = basic_serializer.serialize(ngx)
 
   local ok, err = ngx_timer_at(0, log, conf, message)

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local threads = require "llthreads2.ex"
+local pl_file = require "pl.file"
 
 describe("Plugin: datadog (log)", function()
   local client
@@ -42,6 +43,19 @@ describe("Plugin: datadog (log)", function()
     assert(helpers.dao.plugins:insert {
       name = "datadog",
       api_id = api3.id,
+      config = {
+        host = "127.0.0.1",
+        port = 9999,
+        metrics = "request_count,status_count,latency",
+        tags = {
+          request_count = {"T1:V1"},
+          status_count = {"T2:V2,T3:V3,T4"},
+          latency = {"T2:V2:V3,T4"},
+        }
+      }
+    })
+    assert(helpers.dao.plugins:insert {
+      name = "datadog",
       config = {
         host = "127.0.0.1",
         port = 9999,
@@ -167,5 +181,34 @@ describe("Plugin: datadog (log)", function()
     assert.contains("kong.datadog3_com.request.count:1|c|#T1:V1", gauges)
     assert.contains("kong.datadog3_com.request.status.200:1|c|#T2:V2,T3:V3,T4", gauges)
     assert.contains("kong.datadog3_com.latency:%d+|g|#T2:V2:V3,T4", gauges, true)
+  end)
+
+  it("should not return a runtime error (regression)", function()
+    local thread = threads.new({
+      function()
+        local socket = require "socket"
+        local server = assert(socket.udp())
+        server:settimeout(1)
+        server:setoption("reuseaddr", true)
+        server:setsockname("127.0.0.1", 9999)
+        local gauge = server:receive()
+        server:close()
+        return gauge
+      end
+    })
+    thread:start()
+
+    local res = assert(client:send {
+      method = "GET",
+      path = "/NonMatch",
+      headers = {
+        ["Host"] = "fakedns.com"
+      }
+    })
+
+    assert.res_status(404, res)
+    
+    local err_log = pl_file.read(helpers.test_conf.nginx_err_logs)
+    assert.not_matches("attempt to index field 'api' (a nil value)", err_log, nil, true)
   end)
 end)


### PR DESCRIPTION
Fix runtime error when the datadog plugin is global and there is
not a catch all api present

### Summary
Addresses the runtime error that occurs when datadog is registered as a global plugin and there is not a catch all api. 

Example log: 
`2017/07/06 01:41:53 [error] 101#0: *60797 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/plugins/datadog/handler.lua:60: attempt to index field 'api' (a nil value)]`

cc @p0pr0ck5 