### PR TITLE
chore(deps) replace pgmoon-mashape with pgmoon

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "version == 0.2",
   "lapis == 1.5.1",
   "lua-cassandra == 1.2.2",
-  "pgmoon-mashape == 2.0.1",
+  "pgmoon == 1.8.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.2",
   "lua-resty-iputils == 0.2.1",

--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -267,93 +267,81 @@ return function(options)
 
 
   do -- cosockets connect patch for dns resolution for: cli, rbusted and OpenResty
+    local sub = string.sub
 
-    if options.cli then
-      -- Because the CLI runs in `xpcall`, we cannot use yielding cosockets.
-      -- Hence, we need to stick to luasocket when using cassandra or pgmoon
-      -- in the CLI.
-      for _, namespace in ipairs({"cassandra", "pgmoon-mashape"}) do
-        local socket = require(namespace .. ".socket")
-        socket.force_luasocket(ngx.get_phase(), true)
+    --- Patch the TCP connect and UDP setpeername methods such that all
+    -- connections will be resolved first by the internal DNS resolver.
+    -- STEP 1: load code that should not be using the patched versions
+    require "resty.dns.resolver" -- will cache TCP and UDP functions
+
+    -- STEP 2: forward declaration of locals to hold stuff loaded AFTER patching
+    local toip
+
+    -- STEP 3: store original unpatched versions
+    local old_tcp = ngx.socket.tcp
+    local old_udp = ngx.socket.udp
+
+    local old_tcp_connect
+    local old_udp_setpeername
+
+    local function tcp_resolve_connect(sock, host, port, sock_opts)
+      local target_ip, target_port = toip(host, port)
+      if not target_ip then
+        return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
       end
 
-    else
-      local sub = string.sub
+      -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
+      if not sock_opts then
+        return old_tcp_connect(sock, target_ip, target_port)
+      end
 
-      --- Patch the TCP connect and UDP setpeername methods such that all
-      -- connections will be resolved first by the internal DNS resolver.
-      -- STEP 1: load code that should not be using the patched versions
-      require "resty.dns.resolver" -- will cache TCP and UDP functions
+      return old_tcp_connect(sock, target_ip, target_port, sock_opts)
+    end
 
-      -- STEP 2: forward declaration of locals to hold stuff loaded AFTER patching
-      local toip
+    local function udp_resolve_setpeername(sock, host, port)
+      local target_ip, target_port
 
-      -- STEP 3: store original unpatched versions
-      local old_tcp = ngx.socket.tcp
-      local old_udp = ngx.socket.udp
+      if sub(host, 1, 5) == "unix:" then
+        target_ip = host -- unix domain socket, so just maintain the named values
 
-      local old_tcp_connect
-      local old_udp_setpeername
+      else
+        target_ip, target_port = toip(host, port)
 
-      local function tcp_resolve_connect(sock, host, port, sock_opts)
-        local target_ip, target_port = toip(host, port)
         if not target_ip then
           return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
         end
-
-        -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
-        if not sock_opts then
-          return old_tcp_connect(sock, target_ip, target_port)
-        end
-
-        return old_tcp_connect(sock, target_ip, target_port, sock_opts)
       end
 
-      local function udp_resolve_setpeername(sock, host, port)
-        local target_ip, target_port
-
-        if sub(host, 1, 5) == "unix:" then
-          target_ip = host -- unix domain socket, so just maintain the named values
-
-        else
-          target_ip, target_port = toip(host, port)
-
-          if not target_ip then
-            return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
-          end
-        end
-
-        return old_udp_setpeername(sock, target_ip, target_port)
-      end
-
-      -- STEP 4: patch globals
-      _G.ngx.socket.tcp = function(...)
-        local sock = old_tcp(...)
-
-        if not old_tcp_connect then
-          old_tcp_connect = sock.connect
-        end
-
-        sock.connect = tcp_resolve_connect
-
-        return sock
-      end
-
-      _G.ngx.socket.udp = function(...)
-        local sock = old_udp(...)
-
-        if not old_udp_setpeername then
-          old_udp_setpeername = sock.setpeername
-        end
-
-        sock.setpeername = udp_resolve_setpeername
-
-        return sock
-      end
-
-      -- STEP 5: load code that should be using the patched versions, if any (because of dependency chain)
-      toip = require("resty.dns.client").toip  -- this will load utils and penlight modules for example
+      return old_udp_setpeername(sock, target_ip, target_port)
     end
+
+    -- STEP 4: patch globals
+    _G.ngx.socket.tcp = function(...)
+      local sock = old_tcp(...)
+
+      if not old_tcp_connect then
+        old_tcp_connect = sock.connect
+      end
+
+      sock.connect = tcp_resolve_connect
+
+      return sock
+    end
+
+    _G.ngx.socket.udp = function(...)
+      local sock = old_udp(...)
+
+      if not old_udp_setpeername then
+        old_udp_setpeername = sock.setpeername
+      end
+
+      sock.setpeername = udp_resolve_setpeername
+
+      return sock
+    end
+
+    -- STEP 5: load code that should be using the patched versions, if any (because of dependency chain)
+    toip = require("resty.dns.client").toip  -- this will load utils and penlight modules for example
   end
 end
 

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -92,15 +92,6 @@ function _M.new(kong_config)
   self.query_options = query_opts
   self.cluster_options = cluster_options
 
-  if ngx.IS_CLI then
-    -- we must manually call our init phase (usually called from `init_by_lua`)
-    -- to refresh the cluster.
-    local ok, err = self:init()
-    if not ok then
-      return nil, err
-    end
-  end
-
   return self
 end
 
@@ -631,7 +622,12 @@ end
 function _M:current_migrations()
   local q_keyspace_exists, q_migrations_table_exists
 
-  assert(self.release_version, "release_version not set for Cassandra cluster")
+  if not self.release_version then
+    local ok, err = self:init()
+    if not ok then
+      return nil, err
+    end
+  end
 
   if self.release_version == 3 then
     q_keyspace_exists = [[

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -8,6 +8,8 @@ describe("Plugin: tcp-log (log)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "tcp_logging.com" },

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -9,6 +9,8 @@ describe("Plugin: udp-log (log)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api2 = assert(helpers.dao.apis:insert {
       name = "tests-udp-logging2",
       hosts = { "udp_logging2.com" },

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -29,6 +29,8 @@ pending("Plugin: http-log (log)", function()
   -- seems to be broken.
   local client
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "http_logging.com" },

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -10,6 +10,8 @@ local FILE_LOG_PATH = os.tmpname()
 describe("Plugin: file-log (log)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "file_logging.com" },

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -6,6 +6,8 @@ local pl_stringx = require "pl.stringx"
 describe("#ci Plugin: syslog (log)", function()
   local client, platform
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "logging.com" },

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -4,6 +4,8 @@ local UDP_PORT = 20000
 describe("Plugin: statsd (log)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local consumer1 = assert(helpers.dao.consumers:insert {
       username = "bob",
       custom_id = "robert"

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -6,6 +6,8 @@ local UDP_PORT = 20000
 describe("Plugin: loggly (log)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "logging.com" },

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -4,6 +4,8 @@ local threads = require "llthreads2.ex"
 describe("Plugin: datadog (log)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local consumer1 = assert(helpers.dao.consumers:insert {
       username = "foo",
       custom_id = "bar"

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: key-auth (API)", function()
   local consumer
   local admin_client
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.dao.apis:insert {
       name = "keyauth1",
       upstream_url = "http://mockbin.com",

--- a/spec/03-plugins/10-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/10-key-auth/02-access_spec.lua
@@ -6,6 +6,8 @@ local utils = require "kong.tools.utils"
 describe("Plugin: key-auth (access)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local anonymous_user = assert(helpers.dao.consumers:insert {
       username = "no-body"
     })

--- a/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
+++ b/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: key-auth (invalidations)", function()
   local admin_client, proxy_client
 
   before_each(function()
+    helpers.run_migrations()
+
     helpers.dao:truncate_tables()
     local api = assert(helpers.dao.apis:insert {
       name = "api-1",

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -4,6 +4,8 @@ local helpers = require "spec.helpers"
 describe("Plugin: basic-auth (API)", function()
   local consumer, admin_client
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.start_kong())
     admin_client = helpers.admin_client()
   end)

--- a/spec/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/11-basic-auth/03-access_spec.lua
@@ -8,6 +8,8 @@ describe("Plugin: basic-auth (access)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "basic-auth1.com" },

--- a/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: basic-auth (invalidations)", function()
   local admin_client, proxy_client
 
   before_each(function()
+    helpers.run_migrations()
+
     helpers.dao:truncate_tables()
     local api = assert(helpers.dao.apis:insert {
       name = "api-1",

--- a/spec/03-plugins/12-correlation-id/01-access_spec.lua
+++ b/spec/03-plugins/12-correlation-id/01-access_spec.lua
@@ -8,6 +8,8 @@ local TRACKER_PATTERN = "%d+%.%d+%.%d+%.%d+%-%d+%-%d+%-%d+%-%d+%-%d%d%d%d%d%d%d%
 describe("Plugin: correlation-id (access)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "correlation1.com" },

--- a/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
+++ b/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
@@ -8,6 +8,8 @@ describe("Plugin: request-size-limiting (access)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api = assert(helpers.dao.apis:insert {
       name = "limit.com",
       hosts = { "limit.com" },

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: cors (access)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "cors1.com" },

--- a/spec/03-plugins/15-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/15-request-transformer/02-access_spec.lua
@@ -4,6 +4,8 @@ describe("Plugin: request-transformer (access)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert { name = "api-1", hosts = { "test1.com" }, upstream_url = "http://mockbin.com"})
     local api2 = assert(helpers.dao.apis:insert { name = "api-2", hosts = { "test2.com" }, upstream_url = "http://httpbin.org"})
     local api3 = assert(helpers.dao.apis:insert { name = "api-3", hosts = { "test3.com" }, upstream_url = "http://mockbin.com"})

--- a/spec/03-plugins/15-request-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-request-transformer/03-api_spec.lua
@@ -14,6 +14,8 @@ describe("Plugin: request-transformer (API)", function()
 
   describe("POST", function()
     setup(function()
+      helpers.run_migrations()
+
       assert(helpers.dao.apis:insert {
         name = "test",
         hosts = { "test1.com" },

--- a/spec/03-plugins/16-response-transformer/03-api_spec.lua
+++ b/spec/03-plugins/16-response-transformer/03-api_spec.lua
@@ -13,6 +13,8 @@ describe("Plugin: response-transformer (API)", function()
 
   describe("POST", function()
     setup(function()
+      helpers.run_migrations()
+
       assert(helpers.dao.apis:insert {
         name = "test",
         hosts = { "test1.com" },

--- a/spec/03-plugins/16-response-transformer/04-filter_spec.lua
+++ b/spec/03-plugins/16-response-transformer/04-filter_spec.lua
@@ -4,6 +4,8 @@ describe("Plugin: response-transformer (filter)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "tests-response-transformer",
       hosts = { "response.com" },

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -7,6 +7,8 @@ local fixtures = require "spec.03-plugins.17-jwt.fixtures"
 describe("Plugin: jwt (API)", function()
   local admin_client, consumer, jwt_secret
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.start_kong())
     admin_client = helpers.admin_client()
   end)

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -16,6 +16,8 @@ describe("Plugin: jwt (access)", function()
   local proxy_client, admin_client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {name = "tests-jwt1", hosts = { "jwt.com" }, upstream_url = "http://mockbin.com"})
     local api2 = assert(helpers.dao.apis:insert {name = "tests-jwt2", hosts = { "jwt2.com" }, upstream_url = "http://mockbin.com"})
     local api3 = assert(helpers.dao.apis:insert {name = "tests-jwt3", hosts = { "jwt3.com" }, upstream_url = "http://mockbin.com"})

--- a/spec/03-plugins/17-jwt/04-invalidations_spec.lua
+++ b/spec/03-plugins/17-jwt/04-invalidations_spec.lua
@@ -6,6 +6,8 @@ describe("Plugin: jwt (invalidations)", function()
   local admin_client, proxy_client, consumer1, api1
 
   before_each(function()
+    helpers.run_migrations()
+
     helpers.dao:truncate_tables()
 
     api1 = assert(helpers.dao.apis:insert {

--- a/spec/03-plugins/18-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/18-ip-restriction/02-access_spec.lua
@@ -6,6 +6,8 @@ describe("Plugin: ip-restriction (access)", function()
   local client, admin_client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "ip-restriction1.com" },

--- a/spec/03-plugins/19-acl/01-api_spec.lua
+++ b/spec/03-plugins/19-acl/01-api_spec.lua
@@ -4,6 +4,8 @@ local helpers = require "spec.helpers"
 describe("Plugin: acl (API)", function()
   local consumer, admin_client
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.start_kong())
     admin_client = helpers.admin_client()
   end)

--- a/spec/03-plugins/19-acl/02-access_spec.lua
+++ b/spec/03-plugins/19-acl/02-access_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: ACL (access)", function()
   local client, api_client
 
   setup(function()
+    helpers.run_migrations()
+
     local consumer1 = assert(helpers.dao.consumers:insert {
       username = "consumer1"
     })

--- a/spec/03-plugins/19-acl/03-invalidations_spec.lua
+++ b/spec/03-plugins/19-acl/03-invalidations_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: ACL (invalidations)", function()
   local consumer1, acl1
 
   before_each(function()
+    helpers.run_migrations()
+
     helpers.dao:truncate_tables()
 
     consumer1 = assert(helpers.dao.consumers:insert {

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -4,6 +4,8 @@ local cjson = require "cjson"
 describe("Plugin: hmac-auth (API)", function()
   local client, credential, consumer
   setup(function()
+    helpers.run_migrations()
+
     helpers.prepare_prefix()
     assert(helpers.start_kong())
     client = helpers.admin_client()

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -14,6 +14,8 @@ describe("Plugin: hmac-auth (access)", function()
   local client, consumer, credential
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "hmacauth.com" },

--- a/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
@@ -7,6 +7,8 @@ describe("Plugin: hmac-auth (invalidations)", function()
   local client_proxy, client_admin, consumer, credential
 
   setup(function()
+    helpers.run_migrations()
+
     local api = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "hmacauth.com" },

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -10,6 +10,8 @@ local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 describe("Plugin: ldap-auth (access)", function()
   local client, client_admin, api2, plugin2
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "test-ldap",
       hosts = { "ldap.com" },

--- a/spec/03-plugins/22-bot-detection/01-access_spec.lua
+++ b/spec/03-plugins/22-bot-detection/01-access_spec.lua
@@ -6,6 +6,8 @@ local FACEBOOK = "facebookexternalhit/1.1"  -- matches a known bot in `rules.lua
 describe("Plugin: bot-detection (access)", function()
   local client
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "bot.com" },

--- a/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
+++ b/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
@@ -4,6 +4,8 @@ describe("Plugin: bot-detection (hooks)", function()
   local plugin, proxy_client, admin_client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "bot.com",
       hosts = { "bot.com" },

--- a/spec/03-plugins/22-bot-detection/03-api_spec.lua
+++ b/spec/03-plugins/22-bot-detection/03-api_spec.lua
@@ -6,6 +6,8 @@ describe("Plugin: bot-detection (API)", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.dao.apis:insert {
       name = "bot1.com",
       hosts = { "bot1.com" },

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -4,6 +4,8 @@ describe("Plugin: AWS Lambda (access)", function()
   local client, api_client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "lambda.com",
       hosts = { "lambda.com" } ,

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -52,7 +52,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
       helpers.kill_all()
       flush_redis()
       helpers.dao:drop_schema()
-      assert(helpers.dao:run_migrations())
+      helpers.run_migrations()
 
       local consumer1 = assert(helpers.dao.consumers:insert {
         custom_id = "provider_123"
@@ -407,7 +407,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         before_each(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
-          assert(helpers.dao:run_migrations())
+          helpers.run_migrations()
 
           local api1 = assert(helpers.dao.apis:insert {
             name = "failtest1_com",
@@ -437,7 +437,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         teardown(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
-          assert(helpers.dao:run_migrations())
+          helpers.run_migrations()
         end)
 
         it("does not work if an error occurs", function()
@@ -561,7 +561,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
       setup(function()
         helpers.stop_kong()
         helpers.dao:drop_schema()
-        assert(helpers.dao:run_migrations())
+        helpers.run_migrations()
 
         api = assert(helpers.dao.apis:insert {
           name = "expire1_com",

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -51,7 +51,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
     setup(function()
       flush_redis()
       helpers.dao:drop_schema()
-      assert(helpers.dao:run_migrations())
+      helpers.run_migrations()
 
       local consumer1 = assert(helpers.dao.consumers:insert {custom_id = "provider_123"})
       assert(helpers.dao.keyauth_credentials:insert {
@@ -520,7 +520,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         before_each(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
-          assert(helpers.dao:run_migrations())
+          helpers.run_migrations()
 
           local api1 = assert(helpers.dao.apis:insert {
             name = "failtest1_com",
@@ -564,7 +564,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
         teardown(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
-          assert(helpers.dao:run_migrations())
+          helpers.run_migrations()
         end)
 
         it("does not work if an error occurs", function()
@@ -695,7 +695,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
       setup(function()
         helpers.stop_kong()
         helpers.dao:drop_schema()
-        assert(helpers.dao:run_migrations())
+        helpers.run_migrations()
         assert(helpers.start_kong())
 
         api = assert(helpers.dao.apis:insert {

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -4,6 +4,8 @@ local helpers = require "spec.helpers"
 describe("Plugin: oauth (API)", function()
   local consumer, api, admin_client
   setup(function()
+    helpers.run_migrations()
+
     helpers.prepare_prefix()
     assert(helpers.start_kong())
 

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -60,6 +60,8 @@ describe("Plugin: oauth2 (access)", function()
   local proxy_ssl_client, proxy_client
   local client1
   setup(function()
+    helpers.run_migrations()
+
     local consumer = assert(helpers.dao.consumers:insert {
       username = "bob"
     })

--- a/spec/03-plugins/27-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/27-request-termination/02-access_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: request-termination (access)", function()
   local client, admin_client
 
   setup(function()
+    helpers.run_migrations()
+
     local api1 = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "api1.request-termination.com" },

--- a/spec/03-plugins/27-request-termination/03-integration_spec.lua
+++ b/spec/03-plugins/27-request-termination/03-integration_spec.lua
@@ -5,6 +5,8 @@ describe("Plugin: request-termination (integration)", function()
   local consumer1
 
   setup(function()
+    helpers.run_migrations()
+
     assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "api1.request-termination.com" },

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -32,7 +32,14 @@ package.path = CUSTOM_PLUGIN_PATH .. ";" .. package.path
 local conf = assert(conf_loader(TEST_CONF_PATH))
 local dao = assert(DAOFactory.new(conf))
 -- make sure migrations are up-to-date
-assert(dao:run_migrations())
+
+local function run_migrations(given_dao)
+  -- either use the dao provided to this call, or use
+  -- the helper dao
+  local d = given_dao or dao
+
+  assert(d:run_migrations())
+end
 
 -----------------
 -- Custom helpers
@@ -864,6 +871,7 @@ return {
   prepare_prefix = prepare_prefix,
   clean_prefix = clean_prefix,
   wait_for_invalidation = wait_for_invalidation,
+  run_migrations = run_migrations,
   
   -- miscellaneous
   intercept = intercept,


### PR DESCRIPTION
### Summary

pgmoon now supports overriding sockets with Luasocket! Huzzah!

Additionally, we expose a run_migrations helper function that allows individual tests to ensure that schema/keyspaces are in place. This also removes the bad-citizen behavior of running migrations inside a 'require' context.

For convenience, the helpers run_migrations function is now explicitly called from within a number of test setup() functions, to facilitate executing individual tests.


### Full changelog

* remove `dao:run_migrations` from `spec.helpers` require context in favor of a module function
* explicitly call `helpers.run_migrations` in tests that need the schemas in place
* replace pgmoon-mashape dependancy with upstream pgmoon
* use the appropriate pgmoon socket_type based on the current phase