### PR TITLE
perf(*) increase hard-coded LRU Lua cache sizes

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -11,7 +11,17 @@ local DEBUG   = ngx.DEBUG
 
 
 local SHM_CACHE = "kong_cache"
-local LRU_SIZE  = 1000
+--[[
+Hypothesis
+----------
+
+Item size:        1024 bytes
+Max memory limit: 500 MiBs
+
+LRU size must be: (500 * 2^20) / 1024 = 512000
+Floored: 500.000 items should be a good default
+--]]
+local LRU_SIZE = 5e5
 
 
 local _init

--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -31,7 +31,17 @@ do
 end
 
 
-local MATCH_LRUCACHE_SIZE = 200
+--[[
+Hypothesis
+----------
+
+Item size:        1024 bytes
+Max memory limit: 5 MiBs
+
+LRU size must be: (5 * 2^20) / 1024 = 5120
+Floored: 5000 items should be a good default
+--]]
+local MATCH_LRUCACHE_SIZE = 5e3
 
 
 local MATCH_RULES = {


### PR DESCRIPTION
### Summary

Because those cache sizes are defined in number of units and not in
memory size, we must draw such an hypothesis as the ones described in
the related comments, and draw a conclusion from it, which is a
theoretical ideal cache size.

### Full changelog

* Increase LRU cache size for the router
* Increase LRU cache size for the DB cache