### PR TITLE
fix(cli) properly align options in help messages

### DIFF
--- a/kong/cmd/check.lua
+++ b/kong/cmd/check.lua
@@ -25,6 +25,8 @@ Usage: kong check <conf>
 Check the validity of a given Kong configuration file.
 
 <conf> (default /etc/kong/kong.conf) configuration file
+
+Options:
 ]]
 
 return {

--- a/kong/cmd/cluster.lua
+++ b/kong/cmd/cluster.lua
@@ -76,8 +76,8 @@ The available commands are:
                             number of members it is installed on to the console.
 
 Options:
- -c,--conf   (optional string) configuration file
- -p,--prefix (optional string) prefix Kong is running at
+ -c,--conf     (optional string) configuration file
+ -p,--prefix   (optional string) prefix Kong is running at
 ]]
 
 return {

--- a/kong/cmd/compile.lua
+++ b/kong/cmd/compile.lua
@@ -28,7 +28,7 @@ Note:
  and started for Kong to be fully compatible while embedded.
 
 Options:
- -c,--conf (optional string) configuration file
+ -c,--conf     (optional string) configuration file
 ]]
 
 return {

--- a/kong/cmd/health.lua
+++ b/kong/cmd/health.lua
@@ -47,7 +47,7 @@ Usage: kong health [OPTIONS]
 Check if the necessary services are running for this node.
 
 Options:
- -p,--prefix (optional string) prefix at which Kong should be running
+ -p,--prefix   (optional string) prefix at which Kong should be running
 ]]
 
 return {

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -6,8 +6,8 @@ local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
 
 local options = [[
- --v         verbose
- --vv        debug
+ --v           verbose
+ --vv          debug
 ]]
 
 local cmds_arr = {}

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -66,7 +66,7 @@ The available commands are:
  reset  Reset the configured database (irreversible).
 
 Options:
- -c,--conf (optional string) configuration file
+ -c,--conf     (optional string) configuration file
 ]]
 
 return {

--- a/kong/cmd/quit.lua
+++ b/kong/cmd/quit.lua
@@ -54,8 +54,8 @@ If the timeout delay is reached, the node will be forcefully
 stopped (SIGTERM).
 
 Options:
- -p,--prefix  (optional string) prefix Kong is running at
- -t,--timeout (default 10) timeout before forced shutdown
+ -p,--prefix   (optional string) prefix Kong is running at
+ -t,--timeout  (default 10) timeout before forced shutdown
 ]]
 
 return {

--- a/kong/cmd/reload.lua
+++ b/kong/cmd/reload.lua
@@ -40,9 +40,9 @@ and stop the old ones when they have finished processing
 current requests.
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) prefix Kong is running at
- --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf     (optional string) configuration file
+ -p,--prefix   (optional string) prefix Kong is running at
+ --nginx-conf  (optional string) custom Nginx configuration template
 ]]
 
 return {

--- a/kong/cmd/restart.lua
+++ b/kong/cmd/restart.lua
@@ -23,9 +23,9 @@ This command is equivalent to doing both 'kong stop' and
 'kong start'.
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) prefix at which Kong should be running
- --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf     (optional string) configuration file
+ -p,--prefix   (optional string) prefix at which Kong should be running
+ --nginx-conf  (optional string) custom Nginx configuration template
 ]]
 
 return {

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -42,9 +42,9 @@ Start Kong (Nginx and other configured services) in the configured
 prefix directory.
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) override prefix directory
- --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf     (optional string) configuration file
+ -p,--prefix   (optional string) override prefix directory
+ --nginx-conf  (optional string) custom Nginx configuration template
 ]]
 
 return {

--- a/kong/cmd/stop.lua
+++ b/kong/cmd/stop.lua
@@ -32,7 +32,7 @@ prefix directory.
 This command sends a SIGTERM signal to Nginx.
 
 Options:
- -p,--prefix (optional string) prefix Kong is running at
+ -p,--prefix   (optional string) prefix Kong is running at
 ]]
 
 return {

--- a/kong/cmd/version.lua
+++ b/kong/cmd/version.lua
@@ -7,7 +7,7 @@ Print Kong's version. With the -a option, will print
 the version of all underlying dependencies.
 
 Options:
- -a,--all    get version of all dependencies
+ -a,--all      get version of all dependencies
 ]]
 
 local str = [[


### PR DESCRIPTION
Properly align the CLI options with the default ones injected by the CLI main.

Before:
```
    $ kong compile --help
    [...]
    Options:
     -c,--conf (optional string) configuration file
     --v         verbose
     --vv        debug
```

After:
```
    $ kong compile --help
    [...]
    Options:
     -c,--conf   (optional string) configuration file
     --v         verbose
     --vv        debug
```