### PR TITLE
fix(cluster) add missing error handling

### DIFF
--- a/kong/cluster_events/strategies/postgres.lua
+++ b/kong/cluster_events/strategies/postgres.lua
@@ -98,6 +98,9 @@ function _M:select_interval(channels, min_at, max_at)
     end
 
     local res, err = self.db:query(q)
+    if not res then
+      return nil, err
+    end
 
     local page = #res > 0 and 1 or 0
 


### PR DESCRIPTION
properly reports this error:
```
2017/07/18 03:43:34 [error] 105#0: *67 [lua] cluster_events.lua:366: [cluster_events] poll() threw an error: ...hare/lua/5.1/kong/cluster_events/strategies/postgres.lua:102: attempt to get length of local 'res' (a nil value), context: ngx.timer
2017/07/18 03:43:34 [debug] 103#0: *805 [lua] cluster_events.lua:231: [cluster_events] polling events from: 1500349349.017 to: 1500349414.026
2017/07/18 03:43:34 [error] 103#0: *805 [lua] cluster_events.lua:366: [cluster_events] poll() threw an error: ...hare/lua/5.1/kong/cluster_events/strategies/postgres.lua:102: attempt to get length of local 'res' (a nil value), context: ngx.timer
2017/07/18 03:43:39 [debug] 100#0: *870 [lua] cluster_events.lua:231: [cluster_events] polling events from: 1500349349.017 to: 1500349419.028
20
```