### PR TITLE
chore(deps) change to kong-lapis 1.5.4 that has pgmoon-mashape switched to pgmoon

### DIFF
--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "lua-resty-jit-uuid == 0.0.5",
   "multipart == 0.5",
   "version == 0.2",
-  "kong-lapis == 1.5.3",
+  "kong-lapis == 1.5.4",
   "lua-cassandra == 1.2.2",
   "pgmoon == 1.8.0",
   "luatz == 0.3",


### PR DESCRIPTION
This needs to be done (and released) before this can be merged:
https://github.com/Mashape/kong-lapis/pull/2