### PR TITLE
feat(admin) add /consumers/:id/plugins routes

### DIFF
--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -32,5 +32,48 @@ return {
     DELETE = function(self, dao_factory)
       crud.delete(self.consumer, dao_factory.consumers)
     end
-  }
+  },
+
+  ["/consumers/:username_or_id/plugins/"] = {
+    before = function(self, dao_factory, helpers)
+      self.params.username_or_id = ngx.unescape_uri(self.params.username_or_id)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.plugins)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.plugins)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.plugins)
+    end
+  },
+
+  ["/consumers/:username_or_id/plugins/:id"] = {
+    before = function(self, dao_factory, helpers)
+      self.params.username_or_id = ngx.unescape_uri(self.params.username_or_id)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      crud.find_plugin_by_filter(self, dao_factory, {
+        consumer_id = self.consumer.id,
+        id          = self.params.id,
+      }, helpers)
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.plugin)
+    end,
+
+    PATCH = function(self, dao_factory)
+      crud.patch(self.params, dao_factory.plugins, self.plugin)
+    end,
+
+    DELETE = function(self, dao_factory)
+      crud.delete(self.plugin, dao_factory.plugins)
+    end
+  },
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/rewriter/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rewriter/schema.lua
@@ -1,5 +1,9 @@
-return { 
+return {
   fields = {
-    value = { typ = "string" }
+    value = { typ = "string" },
+    extra = {
+      typ     = "string",
+      default = "extra",
+    }
   }
 }


### PR DESCRIPTION
### Summary

Adds CRUD routes for plugins scoped by consumers to the admin API:

* `/consumers/:username_or_id/plugins/`
* `/consumers/:username_or_id/plugins/id`

This PR needs #2726 to be merged before it, otherwise the api route tests will fail.

### Issues resolved

Closes #2336 
