### PR TITLE
feat(acl) allow acl plugin to use a consumer without credentials

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -7,6 +7,8 @@ local constants = require "kong.constants"
 
 local table_insert = table.insert
 local table_concat = table.concat
+local ngx_error = ngx.ERR
+local ngx_log = ngx.log
 local ipairs = ipairs
 local empty = {}
 
@@ -45,9 +47,9 @@ function ACLHandler:access(conf)
   end
 
   if not consumer_id then
-    return responses.send_HTTP_FORBIDDEN(
-      "Cannot identify the consumer, add an authentication plugin to use the ACL plugin"
-    )
+    ngx_log(ngx_error, "[acl plugin] Cannot identify the consumer, add an ",
+                       "authentication plugin to use the ACL plugin")
+    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
   -- Retrieve ACL

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -30,10 +30,24 @@ function ACLHandler:access(conf)
   ACLHandler.super.access(self)
 
   local consumer_id
-  if ngx.ctx.authenticated_credential then
-    consumer_id = ngx.ctx.authenticated_credential.consumer_id
-  else
-    return responses.send_HTTP_FORBIDDEN("Cannot identify the consumer, add an authentication plugin to use the ACL plugin")
+  local ctx = ngx.ctx
+
+  local authenticated_consumer = ctx.authenticated_consumer
+  if authenticated_consumer then
+    consumer_id = authenticated_consumer.id
+  end
+
+  if not consumer_id then
+    local authenticated_credential = ctx.authenticated_credential
+    if authenticated_credential then
+      consumer_id = authenticated_credential.consumer_id
+    end
+  end
+
+  if not consumer_id then
+    return responses.send_HTTP_FORBIDDEN(
+      "Cannot identify the consumer, add an authentication plugin to use the ACL plugin"
+    )
   end
 
   -- Retrieve ACL

--- a/spec/03-plugins/19-acl/02-access_spec.lua
+++ b/spec/03-plugins/19-acl/02-access_spec.lua
@@ -268,7 +268,7 @@ describe("Plugin: ACL (access)", function()
       })
       local body = assert.res_status(403, res)
       local json = cjson.decode(body)
-      assert.same({ message = "Cannot identify the consumer, add an authentication plugin to use the ACL plugin" }, json)
+      assert.same({ message = "You cannot consume this service" }, json)
     end)
 
     it("should fail when not in whitelist", function()


### PR DESCRIPTION
### Summary

Sometimes Kong is not the provider of credentials, but a third-party identity provider does that. E.g. with OpenID Connect and LDAP the credentials are stored in 3rd party IdP or directory.

ACL plugin on the other hand did only work with `ngx.ctx.authenticated_credential`, this patch adds a support to `ngx.ctx.authenticated_consumer` as well.