### PR TITLE
fix(plugins) consumer_id may be ngx.null when configuring the plugin

### DIFF
--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -261,7 +261,7 @@ function _M.is_schema_subset(tbl, schema)
       errors = utils.add_error(errors, k, "unknown field")
     elseif schema.fields[k].type == "id" and v ~= nil then
       if not utils.is_valid_uuid(v) then
-        errors = utils.add_error(errors, k, v .. " is not a valid uuid")
+        errors = utils.add_error(errors, k, string.format("%s is not a valid uuid", v))
       end
     end
   end


### PR DESCRIPTION
attempt to concatenate local 'v' (a userdata value), replace with string.format

# Reproduction 
* ENV
  * OS: CentOS Linux release 7.3.1611 (Core)
  * Kong: 0.10.3
* STEP
1. configuring the plugin (correlation-id)
```
# curl 'http://192.168.1.193:8001/plugins' -X PUT -H 'Content-Type: application/json;charset=UTF-8' --data-binary '{"name":"correlation-id","config":{"header_name":"Kong-Request-ID","echo_downstream":false,"generator":"uuid#counter"},"consumer_id":null}'
# {"message":"An unexpected error occurred"}
```
2. view error.log
```
2017/07/22 06:50:45 [error] 684#0: *18680 lua coroutine: runtime error: /usr/local/share/lua/5.1/kong/dao/schemas_validation.lua:260: attempt to concatenate local 'v' (a userdata value)
stack traceback:
coroutine 0:
	/usr/local/share/lua/5.1/kong/dao/schemas_validation.lua: in function 'is_schema_subset'
	/usr/local/share/lua/5.1/kong/dao/dao.lua:172: in function 'find_all'
	/usr/local/share/lua/5.1/kong/dao/schemas/plugins.lua:94: in function 'self_check'
	/usr/local/share/lua/5.1/kong/dao/schemas_validation.lua:241: in function 'validate'
	/usr/local/share/lua/5.1/kong/dao/model_factory.lua:27: in function 'validate'
	/usr/local/share/lua/5.1/kong/dao/dao.lua:118: in function 'insert'
	/usr/local/share/lua/5.1/kong/api/crud_helpers.lua:201: in function 'put'
	/usr/local/share/lua/5.1/kong/api/routes/plugins.lua:27: in function </usr/local/share/lua/5.1/kong/api/routes/plugins.lua:26>
coroutine 1:
	[C]: in function 'resume'
	/usr/local/share/lua/5.1/lapis/application.lua:393: in function 'handler'
	/usr/local/share/lua/5.1/lapis/application.lua:130: in function 'resolve'
	/usr/local/share/lua/5.1/lapis/application.lua:161: in function </usr/local/share/lua/5.1/lapis/application.lua:159>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/lapis/application.lua:159: in function 'dispatch'
	/usr/local/share/lua/5.1/lapis/nginx.lua:214: in function 'serve'
	content_by_lua(nginx-kong.conf:162):10: in function <content_by_lua(nginx-kong.conf:162):1>, client: 172.17.0.1, server: kong_admin, request: "PUT /plugins HTTP/1.1", host: "192.168.1.193:8001"
2017/07/22 06:50:45 [error] 684#0: *18680 [lua] init.lua:83: handle_error(): /usr/local/share/lua/5.1/lapis/application.lua:396: /usr/local/share/lua/5.1/kong/dao/schemas_validation.lua:260: attempt to concatenate local 'v' (a userdata value)
stack traceback:
	/usr/local/share/lua/5.1/kong/dao/schemas_validation.lua: in function 'is_schema_subset'
	/usr/local/share/lua/5.1/kong/dao/dao.lua:172: in function 'find_all'
	/usr/local/share/lua/5.1/kong/dao/schemas/plugins.lua:94: in function 'self_check'
	/usr/local/share/lua/5.1/kong/dao/schemas_validation.lua:241: in function 'validate'
	/usr/local/share/lua/5.1/kong/dao/model_factory.lua:27: in function 'validate'
	/usr/local/share/lua/5.1/kong/dao/dao.lua:118: in function 'insert'
	/usr/local/share/lua/5.1/kong/api/crud_helpers.lua:201: in function 'put'
	/usr/local/share/lua/5.1/kong/api/routes/plugins.lua:27: in function </usr/local/share/lua/5.1/kong/api/routes/plugins.lua:26>

stack traceback:
	[C]: in function 'error'
	/usr/local/share/lua/5.1/lapis/application.lua:396: in function 'handler'
	/usr/local/share/lua/5.1/lapis/application.lua:130: in function 'resolve'
	/usr/local/share/lua/5.1/lapis/application.lua:161: in function </usr/local/share/lua/5.1/lapis/application.lua:159>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/lapis/application.lua:159: in function 'dispatch'
	/usr/local/share/lua/5.1/lapis/nginx.lua:214: in function 'serve'
	content_by_lua(nginx-kong.conf:162):10: in function <content_by_lua(nginx-kong.conf:162):1>, client: 172.17.0.1, server: kong_admin, request: "PUT /plugins HTTP/1.1", host: "192.168.1.193:8001"
```