### PR TITLE
chore(*) enable lua52 compat

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -54,10 +54,6 @@ if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
     "--with-http_v2_module"
   )
 
-  if [ "$OPENRESTY" != "1.11.2.1" ]; then
-    OPENRESTY_OPTS[${#OPENRESTY_OPTS[@]}]="--without-luajit-lua52"
-  fi
-
   pushd $OPENRESTY_DOWNLOAD
     ./configure ${OPENRESTY_OPTS[*]}
     make

--- a/kong-0.10.3-0.rockspec
+++ b/kong-0.10.3-0.rockspec
@@ -13,7 +13,7 @@ description = {
 dependencies = {
   "luasec == 0.6",
   "luasocket == 3.0-rc1",
-  "penlight == 1.4.1",
+  "penlight == 1.5.4",
   "lua-resty-http == 0.08",
   "lua-resty-jit-uuid == 0.0.5",
   "multipart == 0.5",


### PR DESCRIPTION
Since 1.5.3, Penlight should now provide compatibility for
`pl_utils.executeex` out of the box between Lua 5.1 and 5.2.

This should allow Kong to work on an OpenResty build without the
`--without-luajit-lua52` flag.