### PR TITLE
fix(balancer) respect the given balancer size

### DIFF
--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -173,7 +173,7 @@ local get_balancer = function(target)
   if not balancer then
     -- no balancer yet (or invalidated) so create a new one
     balancer, err = ring_balancer.new({
-        wheelsize = upstream.slots,
+        wheelSize = upstream.slots,
         order = upstream.orderlist,
         dns = dns_client,
       })
@@ -219,7 +219,7 @@ local get_balancer = function(target)
       -- and can replay changes, but not supported by ring-balancer yet.
       -- for now; create a new balancer from scratch
       balancer, err = ring_balancer.new({
-          wheelsize = upstream.slots,
+          wheelSize = upstream.slots,
           order = upstream.orderlist,
           dns = dns_client,
         })


### PR DESCRIPTION
Due to a typo the configured balancer size was not set up,
and the default size of 1000 was always used.
This also fixes some of the (occasionally) failing tests.
