### PR TITLE
fix(migration) C* got an OD copy-pasta from Postgres

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -390,9 +390,9 @@ return {
       ALTER TABLE apis ADD upstream_read_timeout int;
     ]],
     down = [[
-      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_connect_timeout;
-      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_send_timeout;
-      ALTER TABLE apis DROP COLUMN IF EXISTS upstream_read_timeout;
+      ALTER TABLE apis DROP upstream_connect_timeout;
+      ALTER TABLE apis DROP upstream_send_timeout;
+      ALTER TABLE apis DROP upstream_read_timeout;
     ]]
   },
   {


### PR DESCRIPTION
Cassandra does not support the `COLUMN IF EXISTS` conditionals like Postgres does.
