### PR TITLE
fix(jwt) preflight: revert workaround, implement migration

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -8,6 +8,7 @@ local string_format = string.format
 local ngx_re_gmatch = ngx.re.gmatch
 
 local ngx_set_header = ngx.req.set_header
+local get_method = ngx.req.get_method
 
 local JwtHandler = BasePlugin:extend()
 
@@ -171,7 +172,16 @@ end
 
 function JwtHandler:access(conf)
   JwtHandler.super.access(self)
-  
+
+  -- check if preflight request and whether it should be authenticated
+  if conf.run_on_preflight == false and get_method() == "OPTIONS" then
+    -- FIXME: the above `== false` test is because existing entries in the db will
+    -- have `nil` and hence will by default start passing the preflight request
+    -- This should be fixed by a migration to update the actual entries
+    -- in the datastore
+    return
+  end
+
   if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
     -- we're already authenticated, and we're configured for using anonymous, 
     -- hence we're in a logical OR between auth methods and we're already done.

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -175,10 +175,6 @@ function JwtHandler:access(conf)
 
   -- check if preflight request and whether it should be authenticated
   if conf.run_on_preflight == false and get_method() == "OPTIONS" then
-    -- FIXME: the above `== false` test is because existing entries in the db will
-    -- have `nil` and hence will by default start passing the preflight request
-    -- This should be fixed by a migration to update the actual entries
-    -- in the datastore
     return
   end
 

--- a/kong/plugins/jwt/migrations/cassandra.lua
+++ b/kong/plugins/jwt/migrations/cassandra.lua
@@ -29,5 +29,29 @@ return {
       ALTER TABLE jwt_secrets DROP algorithm;
       ALTER TABLE jwt_secrets DROP rsa_public_key;
     ]]
-  }
+  },
+  {
+    name = "2017-07-31-113200_jwt_preflight_default",
+    up = function(_, _, dao)
+      for rows, err in dao.db.cluster:iterate([[
+                          SELECT * FROM plugins WHERE name = 'jwt';
+                        ]]) do
+        if err then
+          return err
+        end
+
+        for _, row in ipairs(rows) do
+          if row.config.run_on_preflight == nil then
+            local _, err = dao.apis:update({
+              run_on_preflight = true,
+            }, { id = row.id })
+            if err then
+              return err
+            end
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -38,5 +38,28 @@ return {
       ALTER TABLE jwt_secrets DROP COLUMN algorithm;
       ALTER TABLE jwt_secrets DROP COLUMN rsa_public_key;
     ]]
-  }
+  },
+  {
+    name = "2017-07-31-113200_jwt_preflight_default",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM plugins WHERE name = 'jwt';
+      ]])
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        if row.config.run_on_preflight == nil then
+          local _, err = dao.apis:update({
+            run_on_preflight = true,
+          }, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -16,5 +16,6 @@ return {
     secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}},
     anonymous = {type = "string", default = "", func = check_user},
-  }
+    run_on_preflight = {type = "boolean", default = true},
+  },
 }


### PR DESCRIPTION
This builds on top of #2744, but targets the `next` branch. The additional commit reverts the workaround and implements the proper migrations.