### PR TITLE
hotfix(core) handle anon reports in authenticated requests

### DIFF
--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -71,7 +71,7 @@ local function get_next(self)
       local consumer_id = consumer.id
       local schema      = plugin.schema
 
-      if not schema.no_consumer then
+      if schema and not schema.no_consumer then
         if api then
           plugin_configuration = load_plugin_configuration(api.id, consumer_id, plugin.name)
         end

--- a/kong/kong.lua
+++ b/kong/kong.lua
@@ -123,7 +123,8 @@ local function load_plugins(kong_conf, dao)
     reports.toggle(true)
     sorted_plugins[#sorted_plugins+1] = {
       name = "reports",
-      handler = reports
+      handler = reports,
+      schema = {},
     }
   end
 


### PR DESCRIPTION
If a request is authenticated via one of the authentication plugins
(key-auth, basic-auth, jwt, etc...) and if `anonymous_reports` are
enabled, Kong errors out and returns an HTTP 500 error.

This was not detected by our test suite since tests are run with
`anonymous_reports` **disabled**.

Context:

The new runloop introduced in baf69f1f230c77300f3a94be7fc72643caef1e9d
assumes that plugins always have a schema (which is a correct assumption
to make). However, the `anonymous_reports` feature is implemented as such
a plugin for legacy reasons. Furthermore, it is implemented *without* a
schema, which is an oversight from a legacy contribution. As such, once
a request is authenticated, the new runloop evaluates plugins by
considering their `schema.no_consumer` property (if set, then the
runloop does not run those plugins, since a Consumer is authenticated).
However, because the anonymous_reports plugin has no such schema, the
indexation fails:

kong/core/plugins_iterator.lua:74: attempt to index local 'schema' (a nil value)

This commit contains:

* a regression test
* a condition to check for the existence of a plugin's schema before
  indexing its `no_consumer` field
* an empty schema for the anonymous_reports plugin (since it is a
  requirement for all other plugins to have one, as enforced in the code)

Fix #2756