### PR TITLE
test(core) add mock_upstream inside custom nginx template

### DIFF
--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -312,60 +312,157 @@ http {
 
     server {
         listen 55555;
+        server_name mock_upstream;
 
-        location /ws {
+        location = / {
+            access_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.filter_access_by_method("GET")
+            }
             content_by_lua_block {
-                local server = require "resty.websocket.server"
-                local wb, err = server:new{
-                  timeout = 5000,
-                  max_payload_len = 65535,
-                }
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.send_json_response({
+                    valid_routes = {
+                        ["/ws"] = "Web sockets echo server",
+                        ["/get"] = "Accepts a GET request and returns it in json format",
+                        ["/post"] = "Accepts a POST request and returns it in json format",
+                        ["/anything"] = "Accepts any request and returns it in json format",
+                        ["/request"] = "Alias to /anything",
+                        ["/delay/:duration"] = "Delay the response for <duration> seconds",
+                        ["/basic-auth/:usr/:pass"] = "Performs basic authentication with the given credentials",
+                        ["/status/:code"] = "Returns a response with the specified status code"
+                    }
+                })
+            }
+        }
 
-                if not wb then
-                  ngx.log(ngx.ERR, "failed to open websocket: ", err)
-                  return ngx.exit(444)
+        location = /ws {
+            content_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.serve_web_sockets()
+            }
+        }
+
+        location = /get {
+            access_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.filter_access_by_method("GET")
+            }
+            content_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+
+                return mu.send_json_response({
+                    args    = ngx.req.get_uri_args(),
+                    headers = ngx.req.get_headers(),
+                    origin  = ngx.var.remote_addr,
+                    url     = mu.get_request_url(),
+                })
+            }
+        }
+
+        location = /post {
+            access_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.filter_access_by_method("POST")
+            }
+            content_by_lua_block {
+                local mu                 = require("spec.fixtures.mock_upstream")
+                local headers            = ngx.req.get_headers()
+                local data, form, params = mu.parse_post_data(headers)
+                return mu.send_json_response({
+                    args    = ngx.req.get_uri_args(),
+                    data    = data,
+                    form    = form,
+                    headers = headers,
+                    origin  = ngx.var.remote_addr,
+                    params  = params,
+                    url     = mu.get_request_url(),
+                })
+            }
+        }
+
+        location ~ "^/basic-auth/(?<username>[a-zA-Z0-9_]+)/(?<password>[.]+)$" {
+            access_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.filter_access_by_basic_auth(ngx.var.username,
+                                                      ngx.var.password)
+            }
+            content_by_lua_block {
+                local mu = require("spec.fixtures.mock_upstream")
+                return mu.send_json_response({
+                  authenticated = true,
+                  user          = ngx.var.username,
+                })
+            }
+        }
+
+        location ~ "^/(request|anything)$" {
+            content_by_lua_block {
+                local mu                 = require("spec.fixtures.mock_upstream")
+                local headers            = ngx.req.get_headers()
+                local data, form, params = mu.parse_post_data(headers)
+
+                return mu.send_json_response({
+                    args    = ngx.req.get_uri_args(),
+                    data    = data,
+                    form    = form,
+                    headers = headers,
+                    method  = ngx.var.request_method,
+                    origin  = ngx.var.remote_addr,
+                    params  = params,
+                    url     = mu.get_request_url(),
+                })
+            }
+        }
+
+        location ~ "^/delay/(?<delay_seconds>\d{3})$" {
+            content_by_lua_block {
+                local delay_seconds = tonumber(ngx.var.delay_seconds)
+                if not delay_seconds then
+                    return ngx.exit(ngx.HTTP_NOT_FOUND)
                 end
 
-                while true do
-                  local data, typ, err = wb:recv_frame()
-                  if wb.fatal then
-                    ngx.log(ngx.ERR, "failed to receive frame: ", err)
-                    return ngx.exit(444)
-                  end
+                ngx.sleep(delay_seconds)
 
-                  if data then
-                    if typ == "close" then
-                      break
-                    end
+                local mu                 = require("spec.fixtures.mock_upstream")
+                local headers            = ngx.req.get_headers()
+                local data, form, params = mu.parse_post_data(headers)
 
-                    if typ == "ping" then
-                      local bytes, err = wb:send_pong(data)
-                      if not bytes then
-                        ngx.log(ngx.ERR, "failed to send pong: ", err)
-                        return ngx.exit(444)
-                      end
+                return mu.send_json_response({
+                    args    = ngx.req.get_uri_args(),
+                    data    = data,
+                    delay   = delay_seconds,
+                    form    = form,
+                    headers = headers,
+                    method  = ngx.var.request_method,
+                    origin  = ngx.var.remote_addr,
+                    params  = params,
+                    url     = mu.get_request_url(),
+                })
+            }
+        }
 
-                    elseif typ == "pong" then
-                      ngx.log(ngx.INFO, "client ponged")
-
-                    elseif typ == "text" then
-                      local bytes, err = wb:send_text(data)
-                      if not bytes then
-                        ngx.log(ngx.ERR, "failed to send text: ", err)
-                        return ngx.exit(444)
-                      end
-                    end
-
-                  else
-                    local bytes, err = wb:send_ping()
-                    if not bytes then
-                      ngx.log(ngx.ERR, "failed to send ping: ", err)
-                      return ngx.exit(444)
-                    end
-                  end
+        location ~ "^/status/(?<code>\d{3})$" {
+            content_by_lua_block {
+                local mu   = require("spec.fixtures.mock_upstream")
+                local code = tonumber(ngx.var.code)
+                if not code then
+                    return ngx.exit(ngx.HTTP_NOT_FOUND)
                 end
-
-                wb:send_close()
+                ngx.status = code
+                if code == 418 then
+                    local teapot = [[
+        -=[ teapot ]=-
+           _...._
+         .'  _ _ `.
+        | ."` ^ `". _,
+        \_;`"---"`|//
+          |       ;/
+          \_     _/
+            `"""`]]
+                    ngx.header["X-More-Info"] = "http://tools.ietf.org/html/rfc2324"
+                    return mu.send_text_response(teapot)
+                end
             }
         }
     }

--- a/spec/fixtures/mock_upstream.lua
+++ b/spec/fixtures/mock_upstream.lua
@@ -1,0 +1,175 @@
+local utils = require "kong.tools.utils"
+
+
+local function filter_access_by_method(method)
+  if ngx.req.get_method() ~= method then
+    ngx.status = ngx.HTTP_NOT_ALLOWED
+    ngx.header["X-Powered-By"] = "mock_upstream"
+    ngx.say("The method is not allowed for the requested URL")
+    return ngx.exit(ngx.HTTP_NOT_ALLOWED)
+  end
+end
+
+
+local function find_http_credentials(authorization_header)
+  if not authorization_header then
+    return
+  end
+
+  local iterator, iter_err = ngx.re.gmatch(authorization_header,
+                                           "\\s*[Bb]asic\\s*(.+)")
+  if not iterator then
+    ngx.log(ngx.ERR, iter_err)
+    return
+  end
+
+  local m, err = iterator()
+
+  if err then
+    ngx.log(ngx.ERR, err)
+    return
+  end
+
+  if m and m[1] then
+    local decoded_basic = ngx.decode_base64(m[1])
+
+    if decoded_basic then
+      local user_pass = utils.split(decoded_basic, ":")
+      return user_pass[1], user_pass[2]
+    end
+  end
+end
+
+
+local function filter_access_by_basic_auth(expected_username,
+                                           expected_password)
+   local headers = ngx.req.get_headers()
+
+   local username, password =
+   find_http_credentials(headers["proxy-authorization"])
+
+   if not username then
+     username, password =
+     find_http_credentials(headers["authorization"])
+   end
+
+   if username ~= expected_username or password ~= expected_password then
+     ngx.header["WWW-Authenticate"] = "mock_upstream"
+     ngx.header["X-Powered-By"]     = "mock_upstream"
+     return ngx.exit(ngx.HTTP_UNAUTHORIZED)
+   end
+end
+
+
+local function send_text_response(text, content_type)
+  ngx.header['X-Powered-By'] = "mock_upstream"
+
+  text = ngx.req.get_method() == "HEAD" and "" or tostring(text)
+
+  ngx.header["Content-Length"] = #text + 1
+  ngx.header["Content-Type"]   = content_type
+  return ngx.say(text)
+end
+
+
+local function send_json_response(tbl)
+  local cjson = require "cjson"
+  return send_text_response(cjson.encode(tbl), "application/json")
+end
+
+
+local function get_request_url()
+  return string.format("%s://%s%s", ngx.var.scheme,
+                       ngx.var.host, ngx.var.request_uri)
+end
+
+
+local function parse_post_data(headers)
+  local cjson_safe         = require "cjson.safe"
+  local data, form, params = "", {}, cjson_safe.null
+  local ct                 = headers["content-type"]
+  if ct then
+    ngx.req.read_body()
+    if string.find(ct, "application/x-www-form-urlencoded", nil, true) then
+      form = ngx.req.get_post_args()
+
+    elseif string.find(ct, "application/json", nil, true) then
+      local err
+      data, err = ngx.req.get_body_data()
+      if not data then
+        ngx.log(ngx.ERR, "could not read body data: ", err)
+        return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+      end
+      -- ignore decoding errors
+      params = cjson_safe.decode(data) or cjson_safe.null
+    end
+  end
+
+  return data, form, params
+end
+
+
+local function serve_web_sockets()
+  local server = require "resty.websocket.server"
+  local wb, err = server:new{
+    timeout = 5000,
+    max_payload_len = 65535,
+  }
+
+  if not wb then
+    ngx.log(ngx.ERR, "failed to open websocket: ", err)
+    return ngx.exit(444)
+  end
+
+  while true do
+    local data, typ, err = wb:recv_frame()
+    if wb.fatal then
+      ngx.log(ngx.ERR, "failed to receive frame: ", err)
+      return ngx.exit(444)
+    end
+
+    if data then
+      if typ == "close" then
+        break
+      end
+
+      if typ == "ping" then
+        local bytes, err = wb:send_pong(data)
+        if not bytes then
+          ngx.log(ngx.ERR, "failed to send pong: ", err)
+          return ngx.exit(444)
+        end
+
+      elseif typ == "pong" then
+        ngx.log(ngx.INFO, "client ponged")
+
+      elseif typ == "text" then
+        local bytes, err = wb:send_text(data)
+        if not bytes then
+          ngx.log(ngx.ERR, "failed to send text: ", err)
+          return ngx.exit(444)
+        end
+      end
+
+    else
+      local bytes, err = wb:send_ping()
+      if not bytes then
+        ngx.log(ngx.ERR, "failed to send ping: ", err)
+        return ngx.exit(444)
+      end
+    end
+  end
+
+  wb:send_close()
+end
+
+
+return {
+  filter_access_by_method     = filter_access_by_method,
+  filter_access_by_basic_auth = filter_access_by_basic_auth,
+  send_text_response          = send_text_response,
+  send_json_response          = send_json_response,
+  get_request_url             = get_request_url,
+  parse_post_data             = parse_post_data,
+  serve_web_sockets           = serve_web_sockets,
+}


### PR DESCRIPTION
Adds a  http/mockbin replacement. This pr alone should only affect the web sockets tests (which should still pass)