### PR TITLE
tests(core) remove (http|mock)bin from unit tests

### DIFF
--- a/spec/01-unit/004-utils_spec.lua
+++ b/spec/01-unit/004-utils_spec.lua
@@ -426,18 +426,18 @@ describe("Utils", function()
       end)
       it("validates hostnames", function()
         local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
-                        "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
-                        "hello.abcd", "mockbin_api.com", "localhost",
+                        "HELLO.com", "123helloWORLD.com", "example.123", "example-api.com",
+                        "hello.abcd", "example_api.com", "localhost",
                         -- punycode examples from RFC3492; https://tools.ietf.org/html/rfc3492#page-14
                         -- specifically the japanese ones as they mix ascii with escaped characters
                         "3B-ww4c5e180e575a65lsy2b", "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
                         "Hello-Another-Way--fc4qua05auwb3674vfr0b", "2-u9tlzr9756bt3uc0v",
                         "MajiKoi5-783gue6qz075azm5e", "de-jg4avhby1noc0d", "d9juau41awczczp",
                         }
-        local invalids = {"/mockbin", ".mockbin", "mockbin.", "mock;bin",
-                          "mockbin.com/org",
-                          "mockbin-.org", "mockbin.org-",
-                          "hello..mockbin.com", "hello-.mockbin.com",
+        local invalids = {"/example", ".example", "example.", "exam;ple",
+                          "example.com/org",
+                          "example-.org", "example.org-",
+                          "hello..example.com", "hello-.example.com",
                          }
         for _, name in ipairs(valids) do
           assert.are.same(name, (utils.check_hostname(name)))
@@ -461,7 +461,7 @@ describe("Utils", function()
         assert.are.same({host = "0000:0000:0000:0000:0000:0000:0000:0001", type = "ipv6", port = nil}, utils.normalize_ip("::1"))
         assert.are.same({host = "localhost", type = "name", port = 80}, utils.normalize_ip("localhost:80"))
         assert.are.same({host = "mashape.com", type = "name", port = nil}, utils.normalize_ip("mashape.com"))
-      
+
         assert.is_nil((utils.normalize_ip("1.2.3.4:8x0")))
         assert.is_nil((utils.normalize_ip("1.2.3.400")))
         assert.is_nil((utils.normalize_ip("[::1]:8x0")))

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -39,7 +39,7 @@ describe("Schemas", function()
     }
 
     it("should confirm a valid entity is valid", function()
-      local values = {string = "mockbin entity", url = "mockbin.com"}
+      local values = {string = "example entity", url = "example.com"}
 
       local valid, err = validate_entity(values, schema)
       assert.falsy(err)
@@ -48,7 +48,7 @@ describe("Schemas", function()
 
     describe("[required]", function()
       it("should invalidate entity if required property is missing", function()
-        local values = {url = "mockbin.com"}
+        local values = {url = "example.com"}
 
         local valid, err = validate_entity(values, schema)
         assert.False(valid)
@@ -298,7 +298,7 @@ describe("Schemas", function()
     describe("[default]", function()
       it("should set default values if those are variables or functions specified in the validator", function()
         -- Variables
-        local values = {string = "mockbin entity", url = "mockbin.com"}
+        local values = {string = "example entity", url = "example.com"}
 
         local valid, err = validate_entity(values, schema)
         assert.falsy(err)
@@ -306,7 +306,7 @@ describe("Schemas", function()
         assert.are.same(123456, values.date)
 
         -- Functions
-        local values = {string = "mockbin entity", url = "mockbin.com"}
+        local values = {string = "example entity", url = "example.com"}
 
         local valid, err = validate_entity(values, schema)
         assert.falsy(err)
@@ -316,7 +316,7 @@ describe("Schemas", function()
 
       it("should override default values if specified", function()
         -- Variables
-        local values = {string = "mockbin entity", url = "mockbin.com", date = 654321}
+        local values = {string = "example entity", url = "example.com", date = 654321}
 
         local valid, err = validate_entity(values, schema)
         assert.falsy(err)
@@ -324,7 +324,7 @@ describe("Schemas", function()
         assert.are.same(654321, values.date)
 
         -- Functions
-        local values = {string = "mockbin entity", url = "mockbin.com", default = "abcdef"}
+        local values = {string = "example entity", url = "example.com", default = "abcdef"}
 
         local valid, err = validate_entity(values, schema)
         assert.falsy(err)
@@ -344,7 +344,7 @@ describe("Schemas", function()
 
     describe("[regex]", function()
       it("should validate a field against a regex", function()
-        local values = {string = "mockbin entity", url = "mockbin_!"}
+        local values = {string = "example entity", url = "example_!"}
 
         local valid, err = validate_entity(values, schema)
         assert.falsy(valid)
@@ -450,7 +450,7 @@ describe("Schemas", function()
     end)
 
     it("should return error when unexpected values are included in the schema", function()
-      local values = {string = "mockbin entity", url = "mockbin.com", unexpected = "abcdef"}
+      local values = {string = "example entity", url = "example.com", unexpected = "abcdef"}
 
       local valid, err = validate_entity(values, schema)
       assert.falsy(valid)
@@ -458,7 +458,7 @@ describe("Schemas", function()
     end)
 
     it("should be able to return multiple errors at once", function()
-      local values = {url = "mockbin.com", unexpected = "abcdef"}
+      local values = {url = "example.com", unexpected = "abcdef"}
 
       local valid, err = validate_entity(values, schema)
       assert.falsy(valid)

--- a/spec/01-unit/007-entities_schemas_spec.lua
+++ b/spec/01-unit/007-entities_schemas_spec.lua
@@ -42,11 +42,11 @@ describe("Entities Schemas", function()
       end)
 
       it("should not accept a name with reserved URI characters in it", function()
-        for _, name in ipairs({"mockbin#2", "mockbin/com", "mockbin\"", "mockbin:2", "mockbin?", "[mockbin]"}) do
+        for _, name in ipairs({"example#2", "example/com", "example\"", "example:2", "example?", "[example]"}) do
           local t = {
             name = name,
-            upstream_url = "http://mockbin.com",
-            hosts = { "mockbin.com" }
+            upstream_url = "http://example.com",
+            hosts = { "example.com" }
           }
 
           local valid, errors = validate_entity(t, api_schema)
@@ -60,9 +60,9 @@ describe("Entities Schemas", function()
     describe("upstream_url", function()
       it("should return error with wrong upstream_url", function()
         local valid, errors = validate_entity({
-          name = "mockbin",
+          name = "example",
           upstream_url = "asdasd",
-          hosts = { "mockbin.com" },
+          hosts = { "example.com" },
         }, api_schema)
         assert.is_false(valid)
         assert.equal("upstream_url is not a url", errors.upstream_url)
@@ -70,9 +70,9 @@ describe("Entities Schemas", function()
 
       it("should return error with wrong upstream_url protocol", function()
         local valid, errors = validate_entity({
-          name = "mockbin",
-          upstream_url = "wot://mockbin.com/",
-          hosts = { "mockbin.com" },
+          name = "example",
+          upstream_url = "wot://example.com/",
+          hosts = { "example.com" },
         }, api_schema)
         assert.is_false(valid)
         assert.equal("Supported protocols are HTTP and HTTPS", errors.upstream_url)
@@ -80,9 +80,9 @@ describe("Entities Schemas", function()
 
       it("should not return error with final slash in upstream_url", function()
         local valid, errors = validate_entity({
-          name = "mockbin",
-          upstream_url = "http://mockbin.com/",
-          hosts = { "mockbin.com" },
+          name = "example",
+          upstream_url = "http://example.com/",
+          hosts = { "example.com" },
         }, api_schema)
         assert.is_nil(errors)
         assert.is_true(valid)
@@ -90,9 +90,9 @@ describe("Entities Schemas", function()
 
       it("should validate with upper case protocol", function()
         local valid, errors = validate_entity({
-          name = "mockbin",
-          upstream_url = "HTTP://mockbin.com/world",
-          hosts = { "mockbin.com" },
+          name = "example",
+          upstream_url = "HTTP://example.com/world",
+          hosts = { "example.com" },
         }, api_schema)
         assert.falsy(errors)
         assert.is_true(valid)
@@ -102,9 +102,9 @@ describe("Entities Schemas", function()
     describe("hosts", function()
       it("accepts an array", function()
         local t = {
-          name = "httpbin",
-          upstream_url = "http://httpbin.org",
-          hosts = { "httpbin.org" },
+          name = "example",
+          upstream_url = "http://example.org",
+          hosts = { "example.org" },
         }
 
         local ok, errors = validate_entity(t, api_schema)
@@ -114,8 +114,8 @@ describe("Entities Schemas", function()
 
       it("accepts valid hosts", function()
         local valids = {"hello.com", "hello.fr", "test.hello.com", "1991.io", "hello.COM",
-                        "HELLO.com", "123helloWORLD.com", "mockbin.123", "mockbin-api.com",
-                        "hello.abcd", "mockbin_api.com", "localhost",
+                        "HELLO.com", "123helloWORLD.com", "example.123", "example-api.com",
+                        "hello.abcd", "example_api.com", "localhost",
                         -- punycode examples from RFC3492; https://tools.ietf.org/html/rfc3492#page-14
                         -- specifically the japanese ones as they mix ascii with escaped characters
                         "3B-ww4c5e180e575a65lsy2b", "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
@@ -125,8 +125,8 @@ describe("Entities Schemas", function()
 
         for _, v in ipairs(valids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             hosts = { v },
           }
 
@@ -137,12 +137,12 @@ describe("Entities Schemas", function()
       end)
 
       it("accepts hosts with valid wildcard", function()
-        local valids = {"mockbin.*", "*.mockbin.org"}
+        local valids = {"example.*", "*.example.org"}
 
         for _, v in ipairs(valids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             hosts = { v },
           }
 
@@ -155,12 +155,12 @@ describe("Entities Schemas", function()
       describe("errors", function()
         pending("rejects if not a table", function()
           -- pending: currently, schema_validation uses `split()` which creates
-          -- a table containing { "mockbin.com" }, hence this test is not
+          -- a table containing { "example.com" }, hence this test is not
           -- relevant.
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
-            hosts = "mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
+            hosts = "example.com",
           }
 
           local ok, errors = validate_entity(t, api_schema)
@@ -170,8 +170,8 @@ describe("Entities Schemas", function()
 
         it("rejects values that are not strings", function()
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             hosts = { 123 },
           }
 
@@ -185,8 +185,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               hosts = { v },
             }
 
@@ -197,15 +197,15 @@ describe("Entities Schemas", function()
         end)
 
         it("rejects invalid hosts", function()
-          local invalids = {"/mockbin", ".mockbin", "mockbin.", "mock;bin",
-                            "mockbin.com/org",
-                            "mockbin-.org", "mockbin.org-",
-                            "hello..mockbin.com", "hello-.mockbin.com"}
+          local invalids = {"/example", ".example", "example.", "mock;bin",
+                            "example.com/org",
+                            "example-.org", "example.org-",
+                            "hello..example.com", "hello-.example.com"}
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               hosts = { v },
             }
 
@@ -216,12 +216,12 @@ describe("Entities Schemas", function()
         end)
 
         it("rejects invalid wildcard placement", function()
-          local invalids = {"*mockbin.com", "www.mockbin*", "mock*bin.com"}
+          local invalids = {"*example.com", "www.example*", "mock*bin.com"}
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               hosts = { v },
             }
 
@@ -233,9 +233,9 @@ describe("Entities Schemas", function()
 
         it("rejects host with too many wildcards", function()
           local api_t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
-            hosts = { "*.mockbin.*" },
+            name = "example",
+            upstream_url = "http://example.com",
+            hosts = { "*.example.*" },
           }
 
           local ok, errors = validate_entity(api_t, api_schema)
@@ -248,8 +248,8 @@ describe("Entities Schemas", function()
     describe("uris", function()
       it("accepts correct uris", function()
         local t = {
-          name = "httpbin",
-          upstream_url = "http://httpbin.org",
+          name = "example",
+          upstream_url = "http://example.org",
           uris = { "/path" },
         }
 
@@ -260,8 +260,8 @@ describe("Entities Schemas", function()
 
       it("accepts unreserved characters from RFC 3986", function()
         local t = {
-          name = "httpbin",
-          upstream_url = "http://httpbin.org",
+          name = "example",
+          upstream_url = "http://example.org",
           uris = { "/abcd~user~2" },
         }
 
@@ -272,8 +272,8 @@ describe("Entities Schemas", function()
 
       it("accepts reserved characters from RFC 3986 (considered as a regex)", function()
         local t = {
-          name = "httpbin",
-          upstream_url = "http://httpbin.org",
+          name = "example",
+          upstream_url = "http://example.org",
           uris = { "/users/[a-z]+/" },
         }
 
@@ -287,8 +287,8 @@ describe("Entities Schemas", function()
 
         for _, v in ipairs(valids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -303,8 +303,8 @@ describe("Entities Schemas", function()
 
         for _, v in ipairs(invalids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             uris = { v },
           }
 
@@ -316,8 +316,8 @@ describe("Entities Schemas", function()
 
       it("accepts root (prefix slash)", function()
         local ok, errors = validate_entity({
-          name = "mockbin",
-          upstream_url = "http://mockbin.com",
+          name = "example",
+          upstream_url = "http://example.com",
           uris = { "/" },
         }, api_schema)
 
@@ -330,8 +330,8 @@ describe("Entities Schemas", function()
 
         for _, v in ipairs(valids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             uris = { v },
           }
 
@@ -345,8 +345,8 @@ describe("Entities Schemas", function()
       describe("errors", function()
         it("rejects values that are not strings", function()
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             uris = { 123 },
           }
 
@@ -360,8 +360,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -385,8 +385,8 @@ describe("Entities Schemas", function()
 
           for i, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -401,8 +401,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -417,8 +417,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -433,8 +433,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               uris = { v },
             }
 
@@ -449,8 +449,8 @@ describe("Entities Schemas", function()
     describe("methods", function()
       it("accepts correct methods", function()
         local t = {
-          name = "httpbin",
-          upstream_url = "http://httpbin.org",
+          name = "example",
+          upstream_url = "http://example.org",
           methods = { "GET", "POST" },
         }
 
@@ -462,8 +462,8 @@ describe("Entities Schemas", function()
       describe("errors", function()
         it("rejects values that are not strings", function()
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             methods = { 123 },
           }
 
@@ -477,8 +477,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               methods = { v },
             }
 
@@ -493,8 +493,8 @@ describe("Entities Schemas", function()
 
           for _, v in ipairs(invalids) do
             local t = {
-              name = "mockbin",
-              upstream_url = "http://mockbin.com",
+              name = "example",
+              upstream_url = "http://example.com",
               methods = { v },
             }
 
@@ -511,8 +511,8 @@ describe("Entities Schemas", function()
         local valids = {0, 5, 100, 32767}
         for _, v in ipairs(valids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             hosts = { "mydomain.com" },
             retries = v,
           }
@@ -526,8 +526,8 @@ describe("Entities Schemas", function()
         local valids = { -5, 32768}
         for _, v in ipairs(valids) do
           local t = {
-            name = "mockbin",
-            upstream_url = "http://mockbin.com",
+            name = "example",
+            upstream_url = "http://example.com",
             hosts = { "mydomain.com" },
             retries = v,
           }
@@ -541,8 +541,8 @@ describe("Entities Schemas", function()
 
     it("should complain if no [hosts] or [uris] or [methods]", function()
       local ok, errors, self_err = validate_entity({
-        name = "httpbin",
-        upstream_url = "http://httpbin.org",
+        name = "example",
+        upstream_url = "http://example.org",
       }, api_schema)
 
       assert.is_false(ok)
@@ -566,7 +566,7 @@ describe("Entities Schemas", function()
           for j = 1, #valids do
             assert(validate_entity({
               name         = "api",
-              upstream_url = "http://httpbin.org",
+              upstream_url = "http://example.org",
               methods      = "GET",
               [field]      = valids[j],
             }, api_schema))
@@ -579,7 +579,7 @@ describe("Entities Schemas", function()
           for j = 1, #invalids do
             local ok, errors = validate_entity({
               name         = "api",
-              upstream_url = "http://httpbin.org",
+              upstream_url = "http://example.org",
               methods      = "GET",
               [field]      = invalids[j],
             }, api_schema)
@@ -938,7 +938,7 @@ describe("Entities Schemas", function()
       -- does not complain about the missing "name" field
 
       local t = {
-        upstream_url = "http://mockbin.com",
+        upstream_url = "http://example.com",
         hosts = { "" },
       }
 

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -556,16 +556,16 @@ describe("Router", function()
           },
           {
             name = "api-2",
-            uris = { "/httpbin" },
+            uris = { "/example" },
           }
         }
 
         local router = assert(Router.new(use_case))
-        local match_t = router.select("GET", "/httpbin")
+        local match_t = router.select("GET", "/example")
         assert.truthy(match_t)
         assert.same(use_case[2], match_t.api)
 
-        match_t = router.select("GET", "/httpbin/status/200")
+        match_t = router.select("GET", "/example/status/200")
         assert.truthy(match_t)
         assert.same(use_case[2], match_t.api)
       end)
@@ -921,12 +921,12 @@ describe("Router", function()
         {
           name = "api-1",
           uris = { "/my-api" },
-          upstream_url = "http://httpbin.org",
+          upstream_url = "http://example.org",
         },
         {
           name = "api-2",
           uris = { "/my-api-2" },
-          upstream_url = "https://httpbin.org",
+          upstream_url = "https://example.org",
         }
       }
 
@@ -938,7 +938,7 @@ describe("Router", function()
 
       -- upstream_url_t
       assert.equal("http", match_t.upstream_url_t.scheme)
-      assert.equal("httpbin.org", match_t.upstream_url_t.host)
+      assert.equal("example.org", match_t.upstream_url_t.host)
       assert.equal(80, match_t.upstream_url_t.port)
 
       -- upstream_uri
@@ -951,7 +951,7 @@ describe("Router", function()
 
       -- upstream_url_t
       assert.equal("https", match_t.upstream_url_t.scheme)
-      assert.equal("httpbin.org", match_t.upstream_url_t.host)
+      assert.equal("example.org", match_t.upstream_url_t.host)
       assert.equal(443, match_t.upstream_url_t.port)
 
       -- upstream_uri
@@ -1110,7 +1110,7 @@ describe("Router", function()
         {
           name = "api-1",
           uris = { "/my-api" },
-          upstream_url = "http://httpbin.org/get",
+          upstream_url = "http://example.org/get",
         }
       }
 
@@ -1127,12 +1127,12 @@ describe("Router", function()
         {
           name = "api-1",
           uris = { "/my-api" },
-          upstream_url = "http://httpbin.org:8080",
+          upstream_url = "http://example.org:8080",
         },
         {
           name = "api-2",
           uris = { "/my-api-2" },
-          upstream_url = "https://httpbin.org:8443",
+          upstream_url = "https://example.org:8443",
         }
       }
 
@@ -1356,7 +1356,7 @@ describe("Router", function()
         -- use the request's Host header
         {
           name = "api-1",
-          upstream_url = "http://httpbin.org",
+          upstream_url = "http://example.org",
           preserve_host = true,
           headers = {
             ["host"] = { "preserve.com" },
@@ -1365,7 +1365,7 @@ describe("Router", function()
         -- use the API's upstream_url's Host
         {
           name = "api-2",
-          upstream_url = "http://httpbin.org",
+          upstream_url = "http://example.org",
           preserve_host = false,
           headers = {
             ["host"] = { "discard.com" },
@@ -1401,14 +1401,14 @@ describe("Router", function()
 
           local match_t = router.exec(_ngx)
           assert.same(use_case_apis[1], match_t.api)
-          assert.equal("httpbin.org", match_t.upstream_url_t.host)
+          assert.equal("example.org", match_t.upstream_url_t.host)
         end)
 
         it("uses the request's Host header when `grab_header` is disabled", function()
           local use_case_apis = {
             {
               name          = "api-1",
-              upstream_url  = "http://httpbin.org",
+              upstream_url  = "http://example.org",
               preserve_host = true,
               uris          = { "/foo" },
             }
@@ -1432,7 +1432,7 @@ describe("Router", function()
 
           local match_t = router.exec(_ngx)
           assert.same(use_case_apis[2], match_t.api)
-          assert.equal("httpbin.org", match_t.upstream_url_t.host)
+          assert.equal("example.org", match_t.upstream_url_t.host)
         end)
 
         it("does not set the host_header", function()
@@ -1493,7 +1493,7 @@ describe("Router", function()
             {
               name         = "api-1",
               strip_uri    = args[5],
-              upstream_url = "http://httpbin.org" .. args[1],
+              upstream_url = "http://example.org" .. args[1],
               uris         = {
                 args[2],
               },


### PR DESCRIPTION
Replaces httpbin/mockbin with "example" in the unit tests.

This makes it easier to grep for appearances of those two later on, and is also a bit more explicit, since no actual requests to httpbin or mockbin are needed during the unit tests.