### PR TITLE
fix(aws-lambda) add 6 more regions supported by AWS Lambda (14 region…

### DIFF
--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -13,8 +13,9 @@ return {
     aws_key = {type = "string", required = true},
     aws_secret = {type = "string", required = true},
     aws_region = {type = "string", required = true, enum = {
-                  "us-east-1", "us-east-2", "ap-northeast-1", "ap-northeast-2", "us-west-2",
-                  "ap-southeast-1", "ap-southeast-2", "eu-central-1", "eu-west-1"}},
+                  "us-east-1", "us-east-2", "us-west-1", "us-west-2", "ap-northeast-2",
+                  "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
+                  "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "sa-east-1"}},
     function_name = {type="string", required = true},
     qualifier = {type = "string"},
     invocation_type = {type = "string", required = true, default = "RequestResponse", 


### PR DESCRIPTION
…s total)

Amazon AWS Lambda region documentation: http://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

The list of regions in Kong's AWS Lambda plugin is missing 6 regions supported on AWS so I added them in.