### PR TITLE
tests(fixtures) use upstream mock in integration tests

### DIFF
--- a/spec/02-integration/02-cmd/04-reload_spec.lua
+++ b/spec/02-integration/02-cmd/04-reload_spec.lua
@@ -69,9 +69,11 @@ describe("kong reload", function()
     ngx.sleep(1)
 
     -- new server
-    client = helpers.http_client("0.0.0.0", 9999, 5000)
+    client = helpers.http_client(helpers.mock_upstream_host,
+                                 helpers.mock_upstream_port,
+                                 5000)
     local res = assert(client:send {
-      path = "/custom_server_path"
+      path = "/get",
     })
     assert.res_status(200, res)
     client:close()

--- a/spec/02-integration/02-cmd/07-restart_spec.lua
+++ b/spec/02-integration/02-cmd/07-restart_spec.lua
@@ -54,9 +54,11 @@ describe("kong restart", function()
     ngx.sleep(2)
 
     -- new server
-    local client = helpers.http_client("0.0.0.0", 9999, 5000)
+    local client = helpers.http_client(helpers.mock_upstream_host,
+                                       helpers.mock_upstream_port,
+                                       5000)
     local res = assert(client:send {
-      path = "/custom_server_path"
+      path = "/get",
     })
     assert.res_status(200, res)
     client:close()

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -23,11 +23,11 @@ local helpers = require "spec.02-integration.03-dao.helpers"
 local Factory = require "kong.dao.factory"
 
 local api_tbl = {
-  name = "mockbin",
-  hosts = { "mockbin.com" },
-  uris = { "/mockbin" },
+  name = "example",
+  hosts = { "example.org" },
+  uris = { "/example" },
   strip_uri = true,
-  upstream_url = "https://mockbin.com"
+  upstream_url = "https://example.org"
 }
 
 helpers.for_each_dao(function(kong_config)
@@ -64,39 +64,39 @@ helpers.for_each_dao(function(kong_config)
       end)
       it("insert a valid API bis", function()
         local api, err = apis:insert {
-          name = "httpbin",
-          hosts = { "httpbin.org" },
-          upstream_url = "http://httpbin.org"
+          name = "example",
+          hosts = { "example.org" },
+          upstream_url = "http://example.org",
         }
         assert.falsy(err)
         assert.is_table(api)
-        assert.equal("httpbin", api.name)
+        assert.equal("example", api.name)
         assert.raw_table(api)
       end)
       it("insert a valid array field and return it properly", function()
         local res, err = oauth2_credentials:insert {
           name = "test_app",
-          redirect_uri = "https://mockbin.com"
+          redirect_uri = "https://example.org"
         }
         assert.falsy(err)
         assert.is_table(res)
         assert.equal("test_app", res.name)
         assert.is_table(res.redirect_uri)
         assert.equal(1, #res.redirect_uri)
-        assert.same({"https://mockbin.com"}, res.redirect_uri)
+        assert.same({"https://example.org"}, res.redirect_uri)
         assert.raw_table(res)
       end)
       it("insert a valid array field and return it properly bis", function()
         local res, err = oauth2_credentials:insert {
           name = "test_app",
-          redirect_uri = "https://mockbin.com, https://mockbin.org"
+          redirect_uri = "https://example.org, https://example.com"
         }
         assert.falsy(err)
         assert.is_table(res)
         assert.equal("test_app", res.name)
         assert.is_table(res.redirect_uri)
         assert.equal(2, #res.redirect_uri)
-        assert.same({"https://mockbin.com", "https://mockbin.org"}, res.redirect_uri)
+        assert.same({"https://example.org", "https://example.com"}, res.redirect_uri)
         assert.raw_table(res)
       end)
       it("add DAO-inserted values", function()
@@ -117,19 +117,19 @@ helpers.for_each_dao(function(kong_config)
         assert.falsy(api)
         assert.truthy(err)
         assert.True(err.unique)
-        assert.equal("already exists with value 'mockbin'", err.tbl.name)
+        assert.equal("already exists with value 'example'", err.tbl.name)
       end)
       it("ignores ngx.null fields", function()
         local api, err = apis:insert {
-          name = "httpbin",
-          hosts = { "httpbin.org" },
-          upstream_url = "http://httpbin.org",
+          name = "example",
+          hosts = { "example.org" },
+          upstream_url = "http://example.org",
           uris = ngx.null,
           methods = ngx.null,
         }
         assert.falsy(err)
         assert.is_table(api)
-        assert.equal("httpbin", api.name)
+        assert.equal("example", api.name)
         assert.is_nil(api.uris)
         assert.is_nil(api.methods)
         assert.raw_table(api)
@@ -138,15 +138,15 @@ helpers.for_each_dao(function(kong_config)
       describe("errors", function()
         it("refuse if invalid schema", function()
           local api, err = apis:insert {
-            name = "mockbin"
+            name = "example"
           }
           assert.falsy(api)
           assert.truthy(err)
           assert.True(err.schema)
 
           api, err = apis:insert {
-            name = "mockbin",
-            hosts = { "hostcom" }
+            name = "example",
+            hosts = { "example" }
           }
           assert.falsy(api)
           assert.truthy(err)
@@ -201,7 +201,7 @@ helpers.for_each_dao(function(kong_config)
       describe("errors", function()
         it("error if no primary key", function()
           assert.has_error(function()
-            apis:find {name = "mockbin"}
+            apis:find {name = "example"}
           end, "Missing PRIMARY KEY field")
         end)
         it("handle nil arg", function()
@@ -233,7 +233,7 @@ helpers.for_each_dao(function(kong_config)
 
         local res, err = oauth2_credentials:insert {
           name = "test_app",
-          redirect_uri = "https://mockbin.com, https://mockbin.org"
+          redirect_uri = "https://example.org, https://example.com"
         }
         assert.falsy(err)
         assert.truthy(res)
@@ -277,7 +277,7 @@ helpers.for_each_dao(function(kong_config)
         assert.equal("test_app", rows[1].name)
         assert.is_table(rows[1].redirect_uri)
         assert.equal(2, #rows[1].redirect_uri)
-        assert.same({"https://mockbin.com", "https://mockbin.org"}, rows[1].redirect_uri)
+        assert.same({ "https://example.org", "https://example.com" }, rows[1].redirect_uri)
       end)
       pending("return empty table if no row match", function()
         local rows, err = apis:find_all {
@@ -524,7 +524,7 @@ helpers.for_each_dao(function(kong_config)
       it("update with arbitrary filtering keys", function()
         api_fixture.name = "updated"
 
-        local api, err = apis:update(api_fixture, {name = "mockbin"})
+        local api, err = apis:update(api_fixture, { name = "example" })
         assert.falsy(err)
         assert.same(api_fixture, api)
         assert.raw_table(api)

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -3,11 +3,11 @@ local Factory = require "kong.dao.factory"
 local utils = require "kong.tools.utils"
 
 local api_tbl = {
-  name = "mockbin",
-  hosts = { "mockbin.com" },
-  uris = { "/mockbin" },
-  strip_uri = true,
-  upstream_url = "https://mockbin.com"
+  name         = "example",
+  hosts        = { "example.com" },
+  uris         = { "/example" },
+  strip_uri    = true,
+  upstream_url = "https://example.com",
 }
 
 local plugin_tbl = {
@@ -150,10 +150,10 @@ helpers.for_each_dao(function(kong_config)
       before_each(function()
         local err
         api_fixture, err = apis:insert {
-          name = "to-delete",
-          hosts = { "to-delete.com" },
-          uris = { "/to-delete" },
-          upstream_url = "https://mockbin.com"
+          name         = "to-delete",
+          hosts        = { "to-delete.com" },
+          uris         = { "/to-delete" },
+          upstream_url = "https://example.com",
         }
         assert.falsy(err)
 

--- a/spec/02-integration/03-dao/05-use_cases_spec.lua
+++ b/spec/02-integration/03-dao/05-use_cases_spec.lua
@@ -16,8 +16,9 @@ helpers.for_each_dao(function(kong_config)
 
     it("retrieves plugins for plugins_iterator", function()
       local api, err = factory.apis:insert {
-        name = "mockbin", hosts = { "mockbin.com" },
-        upstream_url = "http://mockbin.com"
+        name = "example",
+        hosts = { "example.com" },
+        upstream_url = "http://example.com",
       }
       assert.falsy(err)
 
@@ -71,8 +72,9 @@ helpers.for_each_dao(function(kong_config)
 
     it("update a plugin config", function()
       local api, err = factory.apis:insert {
-        name = "mockbin", hosts = { "mockbin.com" },
-        upstream_url = "http://mockbin.com"
+        name         = "example",
+        hosts        = { "example.com" },
+        upstream_url = "http://example.com",
       }
       assert.falsy(err)
 
@@ -90,8 +92,9 @@ helpers.for_each_dao(function(kong_config)
 
     it("does not override plugin config if partial update", function()
       local api, err = factory.apis:insert {
-        name = "mockbin", hosts = { "mockbin.com" },
-        upstream_url = "http://mockbin.com"
+        name         = "example",
+        hosts        = { "example.com" },
+        upstream_url = "http://example.com",
       }
       assert.falsy(err)
 

--- a/spec/02-integration/03-dao/07-ttl_spec.lua
+++ b/spec/02-integration/03-dao/07-ttl_spec.lua
@@ -17,10 +17,10 @@ helpers.for_each_dao(function(kong_config)
 
     it("on insert", function()
       local api, err = factory.apis:insert({
-        name = "mockbin",
-        hosts = { "mockbin.com" },
-        upstream_url = "http://mockbin.com"
-      }, {ttl = 3})
+        name         = "example",
+        hosts        = { "example.com" },
+        upstream_url = "http://example.com"
+      }, { ttl = 3 })
       assert.falsy(err)
 
       local row, err = factory.apis:find {id = api.id}
@@ -38,10 +38,10 @@ helpers.for_each_dao(function(kong_config)
 
     it("on update", function()
       local api, err = factory.apis:insert({
-        name = "mockbin",
-        hosts = { "mockbin.com" },
-        upstream_url = "http://mockbin.com"
-      }, {ttl = 3})
+        name         = "example",
+        hosts        = { "example.com" },
+        upstream_url = "http://example.com"
+      }, { ttl = 3 })
       assert.falsy(err)
 
       local row, err = factory.apis:find {id = api.id}
@@ -49,18 +49,18 @@ helpers.for_each_dao(function(kong_config)
       assert.truthy(row)
 
       -- Updating the TTL to a higher value
-      factory.apis:update({name = "mockbin2"}, {id = api.id}, {ttl = 4})
+      factory.apis:update({ name = "example2" }, { id = api.id }, { ttl = 4 })
 
       ngx.sleep(1)
 
-      row, err = factory.apis:find {id = api.id}
+      row, err = factory.apis:find { id = api.id }
       assert.falsy(err)
       assert.truthy(row)
 
       ngx.sleep(4)
 
       spec_helpers.wait_until(function()
-        row, err = factory.apis:find {id = api.id}
+        row, err = factory.apis:find { id = api.id }
         assert.falsy(err)
         return row == nil
       end, 1)
@@ -69,10 +69,10 @@ helpers.for_each_dao(function(kong_config)
     if kong_config.database == "postgres" then
       it("retrieves proper entity with no TTL properties attached", function()
         local _, err = factory.apis:insert({
-          name = "mockbin",
-          hosts = { "mockbin.com" },
-          upstream_url = "http://mockbin.com"
-        }, {ttl = 5})
+          name         = "example",
+          hosts        = { "example.com" },
+          upstream_url = "http://example.com"
+        }, { ttl = 5 })
 
         assert.falsy(err)
         local rows, err = factory.apis:find_all()
@@ -87,25 +87,25 @@ helpers.for_each_dao(function(kong_config)
         assert.is_nil(rows[1].primary_key_name)
         assert.is_nil(rows[1].expire_at)
       end)
-      
+
       it("clears old entities", function()
         local DB = require "kong.dao.db.postgres"
         local _db = DB.new(kong_config)
 
         for i = 1, 4 do
           local _, err = factory.apis:insert({
-            name = "api-" .. i,
-            hosts = { "mockbin" .. i .. ".com" },
-            upstream_url = "http://mockbin.com"
-          }, {ttl = 1})
+            name         = "api-" .. i,
+            hosts        = { "example" .. i .. ".com" },
+            upstream_url = "http://example.com"
+          }, { ttl = 1 })
           assert.falsy(err)
         end
 
         local _, err = factory.apis:insert({
-          name = "long-ttl",
-          hosts = { "mockbin-longttl.com" },
-          upstream_url = "http://mockbin.com"
-        }, {ttl = 3})
+          name         = "long-ttl",
+          hosts        = { "example-longttl.com" },
+          upstream_url = "http://example.com"
+        }, { ttl = 3 })
         assert.falsy(err)
 
         local res, err = _db:query("SELECT COUNT(*) FROM apis")

--- a/spec/02-integration/03-dao/08-ipc_events_spec.lua
+++ b/spec/02-integration/03-dao/08-ipc_events_spec.lua
@@ -37,7 +37,7 @@ describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function(
       local api = assert(dao.apis:insert {
         name         = "api-1",
         hosts        = { "example.com" },
-        upstream_url = "http://httpbin.org",
+        upstream_url = "http://example.org",
       })
 
       assert.spy(mock_ipc.post_local).was_called(1)
@@ -52,7 +52,7 @@ describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function(
       assert(dao.apis:insert({
         name         = "api-2",
         hosts        = { "example.com" },
-        upstream_url = "http://httpbin.org",
+        upstream_url = "http://example.org",
       }, { quiet = true }))
 
       assert.spy(mock_ipc.post_local).was_not_called()
@@ -66,13 +66,13 @@ describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function(
       api = assert(dao.apis:insert({
         name         = "api-to-update",
         hosts        = { "example.com" },
-        upstream_url = "http://httpbin.org",
+        upstream_url = "http://example.org",
       }, { quiet = true }))
     end)
 
     it("= false (default)", function()
       local new_api = assert(dao.apis:update({
-                               upstream_url = "http://mockbin.com",
+                               upstream_url = "http://example.com",
                              }, { id = api.id }))
 
       assert.spy(mock_ipc.post_local).was_called(1)
@@ -86,7 +86,7 @@ describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function(
 
     it("= true", function()
       assert(dao.apis:update({
-        upstream_url = "http://mockbin.com",
+        upstream_url = "http://example.com",
       }, { id = api.id }, { quiet = true }))
 
       assert.spy(mock_ipc.post_local).was_not_called()
@@ -100,7 +100,7 @@ describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function(
       api = assert(dao.apis:insert({
         name         = "api-to-update",
         hosts        = { "example.com" },
-        upstream_url = "http://httpbin.org",
+        upstream_url = "http://example.org",
       }, { quiet = true }))
     end)
 

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -64,16 +64,16 @@ describe("Admin API " .. kong_config.database, function()
       it_content_types("creates an API with complex routing", function(content_type)
         return function()
           local res = assert(client:send {
-            method = "POST",
-            path = "/apis",
-            body = {
-              name = "my-api",
-              upstream_url = "http://httpbin.org",
-              methods = "GET,POST,PATCH",
-              hosts = "foo.api.com,bar.api.com",
-              uris = "/foo,/bar",
+            method  = "POST",
+            path    = "/apis",
+            body    = {
+              name         = "my-api",
+              upstream_url = helpers.mock_upstream_url,
+              methods      = "GET,POST,PATCH",
+              hosts        = "foo.api.com,bar.api.com",
+              uris         = "/foo,/bar",
             },
-            headers = {["Content-Type"] = content_type}
+            headers = { ["Content-Type"] = content_type }
           })
 
           local body = assert.res_status(201, res)

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -31,9 +31,9 @@ describe("Admin API", function()
     setup(function()
       for i = 1, 3 do
         local api = assert(helpers.dao.apis:insert {
-          name = "api-" .. i,
-          hosts = { i .. "-api.com" },
-          upstream_url = "http://mockbin.com"
+          name         = "api-" .. i,
+          hosts        = { i .. "-api.com" },
+          upstream_url = "http://example.com",
         })
 
         plugins[i] = assert(helpers.dao.plugins:insert {

--- a/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
@@ -9,16 +9,18 @@ describe("Admin API /cache", function()
   setup(function()
     helpers.run_migrations()
     local api = assert(helpers.dao.apis:insert {
-      name = "api-cache",
-      hosts = { "cache.com" },
-      upstream_url = "http://mockbin.com"
+      name         = "api-cache",
+      hosts        = { "cache.com" },
+      upstream_url = helpers.mock_upstream_url,
     })
     assert(helpers.dao.plugins:insert {
       api_id = api.id,
-      name = "cache",
+      name   = "cache",
     })
 
-    assert(helpers.start_kong())
+    assert(helpers.start_kong({
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
     proxy_client = helpers.proxy_client()
     admin_client = helpers.admin_client()
   end)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -58,39 +58,41 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "api-1",
-          upstream_url = "http://httpbin.org",
-          methods = { "GET" },
+          name         = "api-1",
+          upstream_url = helpers.mock_upstream_url,
+          methods      = { "GET" },
         },
         {
-          name = "api-2",
-          upstream_url = "http://httpbin.org",
-          methods = { "POST", "PUT" },
-          uris = { "/post", "/put" },
-          strip_uri = false,
+          name         = "api-2",
+          upstream_url = helpers.mock_upstream_url,
+          methods      = { "POST", "PUT" },
+          uris         = { "/post", "/put" },
+          strip_uri    = false,
         },
         {
-          name = "api-3",
-          upstream_url = "http://httpbin.org/status",
-          uris = { "/httpbin" },
-          strip_uri = true,
+          name         = "api-3",
+          upstream_url = helpers.mock_upstream_url .. "/status",
+          uris         = { [[/mock_upstream]] },
+          strip_uri    = true,
         },
         {
-          name = "api-4",
-          upstream_url = "http://httpbin.org/basic-auth",
-          uris = { "/private" },
-          strip_uri = false,
+          name         = "api-4",
+          upstream_url = helpers.mock_upstream_url .. "/basic-auth",
+          uris         = { "/private" },
+          strip_uri    = false,
         },
         {
-          name = "api-5",
-          upstream_url = "http://httpbin.org/anything",
-          uris = { [[/users/\d+/profile]] },
-          strip_uri = true,
+          name         = "api-5",
+          upstream_url = helpers.mock_upstream_url .. "/anything",
+          uris         = { [[/users/\d+/profile]] },
+          strip_uri    = true,
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
@@ -135,8 +137,8 @@ describe("Router", function()
     describe("API with a path component in its upstream_url", function()
       it("with strip_uri = true", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/httpbin/201",
+          method  = "GET",
+          path    = "/mock_upstream/201",
           headers = { ["kong-debug"] = 1 },
         })
 
@@ -181,21 +183,16 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "api-1",
-          upstream_url = "http://httpbin.org",
-          hosts = { "example.com" },
-        },
-        {
-          name = "api-2",
-          upstream_url = "http://localhost:9999",
-          hosts = { "localhost" },
+          name         = "api-1",
+          upstream_url = helpers.mock_upstream_url,
+          hosts        = { "mock_upstream" },
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
-      })
+      }))
     end)
 
     teardown(function()
@@ -204,14 +201,14 @@ describe("Router", function()
 
     it("preserves URI arguments", function()
       local res = assert(client:send {
-        method = "GET",
-        path   = "/get",
-        query  = {
+        method  = "GET",
+        path    = "/get",
+        query   = {
           foo   = "bar",
           hello = "world",
         },
         headers = {
-          ["Host"] = "example.com",
+          ["Host"] = "mock_upstream",
         },
       })
 
@@ -224,23 +221,23 @@ describe("Router", function()
     it("does proxy an empty querystring if URI does not contain arguments", function()
       local res = assert(client:send {
         method = "GET",
-        path   = "/get?",
+        path   = "/request?",
         headers = {
-          ["Host"] = "localhost",
+          ["Host"] = "mock_upstream",
         },
       })
 
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.matches("/get%?$", json.vars.request_uri)
+      assert.matches("/request%?$", json.vars.request_uri)
     end)
 
     it("does proxy a querystring with an empty value", function()
       local res = assert(client:send {
-        method = "GET",
-        path   = "/get?hello",
+        method  = "GET",
+        path    = "/get?hello",
         headers = {
-          ["Host"] = "example.com",
+          ["Host"] = "mock_upstream",
         },
       })
 
@@ -255,19 +252,21 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "api-1",
-          upstream_url = "http://httpbin.org",
-          uris = "/endel%C3%B8st",
+          name         = "api-1",
+          upstream_url = helpers.mock_upstream_url,
+          uris         = "/endel%C3%B8st",
         },
         {
-          name = "api-2",
-          upstream_url = "http://httpbin.org",
-          uris = "/foo/../bar",
+          name         = "api-2",
+          upstream_url = helpers.mock_upstream_url,
+          uris         = "/foo/../bar",
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
@@ -303,21 +302,23 @@ describe("Router", function()
       insert_apis {
         {
           name         = "api-strip-uri",
-          upstream_url = "http://httpbin.org",
+          upstream_url = helpers.mock_upstream_url,
           uris         = { "/x/y/z", "/z/y/x" },
           strip_uri    = true,
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
       helpers.stop_kong()
     end)
 
-    describe(" = true", function()
+    describe("= true", function()
       it("strips subsequent calls to an API with different [uris]", function()
         local res_uri_1 = assert(client:send {
           method = "GET",
@@ -367,109 +368,111 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "api-1",
+          name          = "api-1",
           preserve_host = true,
-          upstream_url = "http://localhost:9999/headers-inspect",
-          hosts = "preserved.com",
+          upstream_url  = helpers.mock_upstream_url .. "/request",
+          hosts         = "preserved.com",
         },
         {
-          name = "api-2",
+          name          = "api-2",
           preserve_host = false,
-          upstream_url = "http://localhost:9999/headers-inspect",
-          hosts = "discarded.com",
+          upstream_url  = helpers.mock_upstream_url .. "/request",
+          hosts         = "discarded.com",
         },
         {
-          name = "api-3",
-          strip_uri = false,
+          name          = "api-3",
+          strip_uri     = false,
           preserve_host = true,
-          upstream_url = "http://localhost:9999",
-          uris = "/headers-inspect",
+          upstream_url  = helpers.mock_upstream_url,
+          uris          = "/request",
         }
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
-      })
+      }))
     end)
 
     teardown(function()
       helpers.stop_kong()
     end)
 
-    describe(" = false (default)", function()
+    describe("x = false (default)", function()
       it("uses hostname from upstream_url", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+          method  = "GET",
+          path    = "/get",
           headers = { ["Host"] = "discarded.com" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.matches("localhost", json.host, nil, true) -- not testing :port
+        assert.matches(helpers.mock_upstream_host,
+                       json.headers.host, nil, true) -- not testing :port
       end)
 
       it("uses port value from upstream_url if not default", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+          method  = "GET",
+          path    = "/get",
           headers = { ["Host"] = "discarded.com" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.matches(":9999", json.host, nil, true) -- not testing hostname
+        assert.matches(":" .. helpers.mock_upstream_port,
+                        json.headers.host, nil, true) -- not testing hostname
       end)
     end)
 
     describe(" = true", function()
       it("forwards request Host", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/",
+          method  = "GET",
+          path    = "/",
           headers = { ["Host"] = "preserved.com" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal("preserved.com", json.host)
+        assert.equal("preserved.com", json.headers.host)
       end)
 
       it("forwards request Host:Port even if port is default", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+          method  = "GET",
+          path    = "/get",
           headers = { ["Host"] = "preserved.com:80" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal("preserved.com:80", json.host)
+        assert.equal("preserved.com:80", json.headers.host)
       end)
 
       it("forwards request Host:Port if port isn't default", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+          method  = "GET",
+          path    = "/get",
           headers = { ["Host"] = "preserved.com:123" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal("preserved.com:123", json.host)
+        assert.equal("preserved.com:123", json.headers.host)
       end)
 
       it("forwards request Host even if not matched by [hosts]", function()
         local res = assert(client:send {
-          method = "GET",
-          path = "/headers-inspect",
+          method  = "GET",
+          path    = "/get",
           headers = { ["Host"] = "preserved.com" },
         })
 
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal("preserved.com", json.host)
+        assert.equal("preserved.com", json.headers.host)
       end)
     end)
   end)
@@ -479,19 +482,21 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "root-uri",
-          upstream_url = "http://httpbin.org",
-          uris = "/",
+          name         = "root-uri",
+          upstream_url = helpers.mock_upstream_url,
+          uris         = "/",
         },
         {
-          name = "fixture-api",
-          upstream_url = "http://httpbin.org",
-          uris = "/foobar",
+          name         = "fixture-api",
+          upstream_url = helpers.mock_upstream_url,
+          uris         = "/foobar",
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
@@ -527,18 +532,20 @@ describe("Router", function()
           name = "root-api",
           methods = { "GET" },
           uris = "/root",
-          upstream_url = "http://httpbin.org",
+          upstream_url = helpers.mock_upstream_url,
         },
         {
           name = "fixture-api",
           methods = { "GET" },
           uris = "/root/fixture",
-          upstream_url = "http://httpbin.org",
+          upstream_url = helpers.mock_upstream_url,
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
@@ -564,21 +571,23 @@ describe("Router", function()
     setup(function()
       insert_apis {
         {
-          name = "root-api",
-          hosts = "api.com",
-          uris = "/root",
-          upstream_url = "http://httpbin.org",
+          name         = "root-api",
+          hosts        = "api.com",
+          uris         = "/root",
+          upstream_url = helpers.mock_upstream_url,
         },
         {
-          name = "fixture-api",
-          hosts = "api.com",
-          uris = "/root/fixture",
-          upstream_url = "http://httpbin.org",
+          name         = "fixture-api",
+          hosts        = "api.com",
+          uris         = "/root/fixture",
+          upstream_url = helpers.mock_upstream_url,
         },
       }
 
       helpers.run_migrations()
-      assert(helpers.start_kong())
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
     end)
 
     teardown(function()
@@ -604,50 +613,50 @@ describe("Router", function()
     local checks = {
       -- upstream url    uris            request path    expected path           strip uri
       {  "/",            "/",            "/",            "/",                    nil       },
-      {  "/",            "/",            "/foo/bar",     "/foo/bar",             nil       },
-      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            nil       },
-      {  "/",            "/foo/bar",     "/foo/bar",     "/",                    nil       },
-      {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    nil       },
-      {  "/foo/bar",     "/",            "/",            "/foo/bar",             nil       },
-      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     nil       },
-      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    nil       },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
-      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            nil       },
-      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     nil       },
-      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    nil       },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar",             nil       },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            nil       },
+      {  "/",            "/",            "/get/bar",     "/get/bar",             nil       },
+      {  "/",            "/",            "/get/bar/",    "/get/bar/",            nil       },
+      {  "/",            "/get/bar",     "/get/bar",     "/",                    nil       },
+      {  "/",            "/get/bar/",    "/get/bar/",    "/",                    nil       },
+      {  "/get/bar",     "/",            "/",            "/get/bar",             nil       },
+      {  "/get/bar",     "/",            "/get/bar",     "/get/bar/get/bar",     nil       },
+      {  "/get/bar",     "/",            "/get/bar/",    "/get/bar/get/bar/",    nil       },
+      {  "/get/bar",     "/get/bar",     "/get/bar",     "/get/bar",             nil       },
+      {  "/get/bar",     "/get/bar/",    "/get/bar/",    "/get/bar/",            nil       },
+      {  "/get/bar/",    "/",            "/",            "/get/bar/",            nil       },
+      {  "/get/bar/",    "/",            "/get/bar",     "/get/bar/get/bar",     nil       },
+      {  "/get/bar/",    "/",            "/get/bar/",    "/get/bar/get/bar/",    nil       },
+      {  "/get/bar/",    "/get/bar",     "/get/bar",     "/get/bar",             nil       },
+      {  "/get/bar/",    "/get/bar/",    "/get/bar/",    "/get/bar/",            nil       },
       {  "/",            "/",            "/",            "/",                    true      },
-      {  "/",            "/",            "/foo/bar",     "/foo/bar",             true      },
-      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            true      },
-      {  "/",            "/foo/bar",     "/foo/bar",     "/",                    true      },
-      {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    true      },
-      {  "/foo/bar",     "/",            "/",            "/foo/bar",             true      },
-      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
-      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
-      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            true      },
-      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     true      },
-      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    true      },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar",             true      },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            true      },
+      {  "/",            "/",            "/get/bar",     "/get/bar",             true      },
+      {  "/",            "/",            "/get/bar/",    "/get/bar/",            true      },
+      {  "/",            "/get/bar",     "/get/bar",     "/",                    true      },
+      {  "/",            "/get/bar/",    "/get/bar/",    "/",                    true      },
+      {  "/get/bar",     "/",            "/",            "/get/bar",             true      },
+      {  "/get/bar",     "/",            "/get/bar",     "/get/bar/get/bar",     true      },
+      {  "/get/bar",     "/",            "/get/bar/",    "/get/bar/get/bar/",    true      },
+      {  "/get/bar",     "/get/bar",     "/get/bar",     "/get/bar",             true      },
+      {  "/get/bar",     "/get/bar/",    "/get/bar/",    "/get/bar/",            true      },
+      {  "/get/bar/",    "/",            "/",            "/get/bar/",            true      },
+      {  "/get/bar/",    "/",            "/get/bar",     "/get/bar/get/bar",     true      },
+      {  "/get/bar/",    "/",            "/get/bar/",    "/get/bar/get/bar/",    true      },
+      {  "/get/bar/",    "/get/bar",     "/get/bar",     "/get/bar",             true      },
+      {  "/get/bar/",    "/get/bar/",    "/get/bar/",    "/get/bar/",            true      },
       {  "/",            "/",            "/",            "/",                    false     },
-      {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     },
-      {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
-      {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
-      {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
-      {  "/foo/bar",     "/",            "/",            "/foo/bar",             false     },
-      {  "/foo/bar",     "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar",     "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
-      {  "/foo/bar",     "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar",     "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
-      {  "/foo/bar/",    "/",            "/",            "/foo/bar/",            false     },
-      {  "/foo/bar/",    "/",            "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar/",    "/",            "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
-      {  "/foo/bar/",    "/foo/bar",     "/foo/bar",     "/foo/bar/foo/bar",     false     },
-      {  "/foo/bar/",    "/foo/bar/",    "/foo/bar/",    "/foo/bar/foo/bar/",    false     },
+      {  "/",            "/",            "/get/bar",     "/get/bar",             false     },
+      {  "/",            "/",            "/get/bar/",    "/get/bar/",            false     },
+      {  "/",            "/get/bar",     "/get/bar",     "/get/bar",             false     },
+      {  "/",            "/get/bar/",    "/get/bar/",    "/get/bar/",            false     },
+      {  "/get/bar",     "/",            "/",            "/get/bar",             false     },
+      {  "/get/bar",     "/",            "/get/bar",     "/get/bar/get/bar",     false     },
+      {  "/get/bar",     "/",            "/get/bar/",    "/get/bar/get/bar/",    false     },
+      {  "/get/bar",     "/get/bar",     "/get/bar",     "/get/bar/get/bar",     false     },
+      {  "/get/bar",     "/get/bar/",    "/get/bar/",    "/get/bar/get/bar/",    false     },
+      {  "/get/bar/",    "/",            "/",            "/get/bar/",            false     },
+      {  "/get/bar/",    "/",            "/get/bar",     "/get/bar/get/bar",     false     },
+      {  "/get/bar/",    "/",            "/get/bar/",    "/get/bar/get/bar/",    false     },
+      {  "/get/bar/",    "/get/bar",     "/get/bar",     "/get/bar/get/bar",     false     },
+      {  "/get/bar/",    "/get/bar/",    "/get/bar/",    "/get/bar/get/bar/",    false     },
     }
 
     setup(function()
@@ -657,7 +666,7 @@ describe("Router", function()
         assert(helpers.dao.apis:insert {
             name         = "localbin-" .. i,
             strip_uri    = args[5],
-            upstream_url = "http://localhost:9999" .. args[1],
+            upstream_url = helpers.mock_upstream_url .. args[1],
             uris         = {
               args[2],
             },
@@ -668,9 +677,9 @@ describe("Router", function()
       end
 
       helpers.run_migrations()
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
-      })
+      }))
     end)
 
     teardown(function()

--- a/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -25,64 +25,64 @@ describe("Plugins triggering", function()
 
     -- Global configuration
     assert(helpers.dao.apis:insert {
-      name = "global1",
-      hosts = { "global1.com" },
-      upstream_url = "http://mockbin.com"
+      name         = "global1",
+      hosts        = { "global1.com" },
+      upstream_url = helpers.mock_upstream_url,
     })
     assert(helpers.dao.plugins:insert {
-      name = "key-auth",
-      config = { }
+      name   = "key-auth",
+      config = {},
     })
     assert(helpers.dao.plugins:insert {
-      name = "rate-limiting",
+      name   = "rate-limiting",
       config = {
         hour = 1,
-      }
+      },
     })
 
     -- API Specific Configuration
     local api1 = assert(helpers.dao.apis:insert {
-      name = "api1",
-      hosts = { "api1.com" },
-      upstream_url = "http://mockbin.com"
+      name         = "api1",
+      hosts        = { "api1.com" },
+      upstream_url = helpers.mock_upstream_url,
     })
     assert(helpers.dao.plugins:insert {
-      name = "rate-limiting",
+      name   = "rate-limiting",
       api_id = api1.id,
       config = {
         hour = 2,
-      }
+      },
     })
 
     -- Consumer Specific Configuration
     assert(helpers.dao.plugins:insert {
-      name = "rate-limiting",
+      name        = "rate-limiting",
       consumer_id = consumer2.id,
-      config = {
+      config      = {
         hour = 3,
-      }
+      },
     })
 
     -- API and Consumer Configuration
     local api2 = assert(helpers.dao.apis:insert {
-      name = "api2",
-      hosts = { "api2.com" },
-      upstream_url = "http://mockbin.com"
+      name         = "api2",
+      hosts        = { "api2.com" },
+      upstream_url = helpers.mock_upstream_url,
     })
     assert(helpers.dao.plugins:insert {
-      name = "rate-limiting",
-      api_id = api2.id,
+      name        = "rate-limiting",
+      api_id      = api2.id,
       consumer_id = consumer2.id,
       config = {
         hour = 4,
-      }
+      },
     })
 
     -- API with anonymous configuration
     local api3 = assert(helpers.dao.apis:insert {
-      name = "api3",
-      hosts = { "api3.com" },
-      upstream_url = "http://mockbin.com"
+      name         = "api3",
+      hosts        = { "api3.com" },
+      upstream_url = helpers.mock_upstream_url,
     })
     assert(helpers.dao.plugins:insert {
       name = "key-auth",
@@ -100,7 +100,9 @@ describe("Plugins triggering", function()
       }
     })
 
-    assert(helpers.start_kong())
+    assert(helpers.start_kong({
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
     client = helpers.proxy_client()
   end)
 
@@ -189,8 +191,8 @@ describe("Plugins triggering", function()
 
       local api      = assert(helpers.dao.apis:insert {
         name         = "example",
-        hosts        = { "httpbin.org" },
-        upstream_url = "http://httpbin.org",
+        hosts        = { "mock_upstream" },
+        upstream_url = helpers.mock_upstream_url
       })
 
       assert(helpers.dao.plugins:insert {
@@ -208,6 +210,7 @@ describe("Plugins triggering", function()
       })
 
       assert(helpers.start_kong {
+        nginx_conf        = "spec/fixtures/custom_nginx.template",
         anonymous_reports = true,
       })
       client = helpers.proxy_client()
@@ -226,7 +229,7 @@ describe("Plugins triggering", function()
         method  = "GET",
         path    = "/status/200",
         headers = {
-          ["Host"] = "httpbin.org",
+          ["Host"] = "mock_upstream",
         },
       })
       assert.res_status(401, res)
@@ -235,7 +238,7 @@ describe("Plugins triggering", function()
         method  = "GET",
         path    = "/status/200",
         headers = {
-          ["Host"]   = "httpbin.org",
+          ["Host"]   = "mock_upstream",
           ["apikey"] = "abcd",
         },
       })

--- a/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -31,27 +31,28 @@ dao_helpers.for_each_dao(function(kong_config)
 
       insert_apis {
         {
-          name = "api-1",
-          methods = "HEAD",
-          upstream_url = "http://httpbin.org:81",
+          name                     = "api-1",
+          methods                  = "HEAD",
+          upstream_url             = "http://httpbin.org:81",
           upstream_connect_timeout = 1, -- ms
         },
         {
-          name = "api-2",
-          methods = "POST",
-          upstream_url = "http://httpbin.org",
+          name                  = "api-2",
+          methods               = "POST",
+          upstream_url          = helpers.mock_upstream_url,
           upstream_send_timeout = 1, -- ms
         },
         {
-          name = "api-3",
-          methods = "GET",
-          upstream_url = "http://httpbin.org",
+          name                  = "api-3",
+          methods               = "GET",
+          upstream_url          = helpers.mock_upstream_url,
           upstream_read_timeout = 1, -- ms
         }
       }
 
       assert(helpers.start_kong({
-        database = kong_config.database
+        database   = kong_config.database,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
     end)
 
@@ -94,12 +95,12 @@ dao_helpers.for_each_dao(function(kong_config)
     describe("upstream_send_timeout", function()
       it("sets upstream send timeout value", function()
         local res = assert(client:send {
-          method = "POST",
-          path = "/post",
-          body = {
-            huge = string.rep("a", 2^20)
+          method  = "POST",
+          path    = "/post",
+          body    = {
+            huge = string.rep("a", 2^25)
           },
-          headers = { ["Content-Type"] = "application/json" }
+          headers = { ["Content-Type"] = "application/json" },
         })
 
         -- do *not* use assert.res_status() here in case of

--- a/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -7,32 +7,34 @@ describe("URI encoding", function()
   setup(function()
     helpers.run_migrations()
     assert(helpers.dao.apis:insert {
-      name = "api-1",
-      hosts = { "httpbin.com" },
-      upstream_url = "http://httpbin.org",
+      name         = "api-1",
+      hosts        = { "mock_upstream" },
+      upstream_url = helpers.mock_upstream_url,
     })
 
     assert(helpers.dao.apis:insert {
-      name = "api-2",
-      hosts = { "mockbin.com" },
-      upstream_url = "http://mockbin.com",
+      name         = "api-2",
+      hosts        = { "mock_upstream" },
+      upstream_url = helpers.mock_upstream_url,
     })
 
     assert(helpers.dao.apis:insert {
       name         = "api-3",
       uris         = "/request",
       strip_uri    = false,
-      upstream_url = "http://mockbin.com",
+      upstream_url = helpers.mock_upstream_url,
     })
 
     assert(helpers.dao.apis:insert {
       name         = "api-4",
-      uris         = "/stripped-mockbin",
+      uris         = "/stripped-path",
       strip_uri    = true,
-      upstream_url = "http://mockbin.com",
+      upstream_url = helpers.mock_upstream_url,
     })
 
-    assert(helpers.start_kong())
+    assert(helpers.start_kong({
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
     client = helpers.proxy_client()
   end)
 
@@ -44,11 +46,11 @@ describe("URI encoding", function()
     -- https://github.com/Mashape/kong/pull/1975
 
     local res = assert(client:send {
-      method = "GET",
-      path = "/get?limit=25&where=%7B%22or%22:%5B%7B%22name%22:%7B%22like%22:%22%25bac%25%22%7D%7D%5D%7D",
+      method  = "GET",
+      path    = "/get?limit=25&where=%7B%22or%22:%5B%7B%22name%22:%7B%22like%22:%22%25bac%25%22%7D%7D%5D%7D",
       headers = {
-        ["Host"] = "httpbin.com"
-      }
+        ["Host"] = "mock_upstream",
+      },
     })
 
     local body = assert.res_status(200, res)
@@ -63,73 +65,67 @@ describe("URI encoding", function()
     -- a change is planned and documented.
     -- https://github.com/Mashape/kong/issues/1480
 
-    -- we use mockbin because httpbin.org/get performs URL decode
-    -- on `url` and `args` fields.
     local res = assert(client:send {
-      method = "GET",
-      path = "/request?param=1.2.3",
+      method  = "GET",
+      path    = "/request?param=1.2.3",
       headers = {
-        ["Host"] = "mockbin.com"
-      }
+        ["Host"] = "mock_upstream",
+      },
     })
 
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
 
-    assert.equal("http://mockbin.com/request?param=1.2.3", json.url)
+    assert.equal(helpers.mock_upstream_protocol .. "://" ..
+                 helpers.mock_upstream_host .. "/request?param=1.2.3", json.url)
   end)
 
   it("issue #749 does not decode percent-encoded args", function()
     -- https://github.com/Mashape/kong/issues/749
 
-    -- we use mockbin because httpbin.org/get performs URL decode
-    -- on `url` and `args` fields.
     local res = assert(client:send {
-      method = "GET",
-      path = "/request?param=abc%7Cdef",
+      method  = "GET",
+      path    = "/request?param=abc%7Cdef",
       headers = {
-        ["Host"] = "mockbin.com"
-      }
+        ["Host"] = "mock_upstream",
+      },
     })
 
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
 
-    assert.equal("http://mockbin.com/request?param=abc%7Cdef", json.url)
+    assert.equal(helpers.mock_upstream_protocol .. "://" ..
+                 helpers.mock_upstream_host .. "/request?param=abc%7Cdef", json.url)
   end)
 
   it("issue #688 does not percent-decode proxied URLs", function()
     -- https://github.com/Mashape/kong/issues/688
 
-    -- we use mockbin because httpbin.org/get performs URL decode
-    -- on `url` and `args` fields.
     local res = assert(client:send {
-      method = "GET",
-      path = "/request/foo%2Fbar",
+      method  = "GET",
+      path    = "/request/foo%2Fbar",
       headers = {
-        ["Host"] = "mockbin.com",
-      }
+        ["Host"] = "mock_upstream",
+      },
     })
 
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
 
-    assert.equal("http://mockbin.com/request/foo%2Fbar", json.url)
+    assert.equal(helpers.mock_upstream_protocol .. "://" ..
+                 helpers.mock_upstream_host .. "/request/foo%2Fbar", json.url)
   end)
 
   it("issue #2512 does not double percent-encode upstream URLs", function()
     -- https://github.com/Mashape/kong/issues/2512
-
-    -- we use mockbin because httpbin.org/get performs URL decode
-    -- on `url` and `args` fields.
 
     -- with `hosts` matching
     local res    = assert(client:send {
       method     = "GET",
       path       = "/request/auth%7C123",
       headers    = {
-        ["Host"] = "mockbin.com",
-      }
+        ["Host"] = "mock_upstream",
+      },
     })
 
     local body = assert.res_status(200, res)
@@ -151,7 +147,7 @@ describe("URI encoding", function()
     -- with `uris` matching + `strip_uri`
     local res3 = assert(client:send {
       method   = "GET",
-      path     = "/stripped-mockbin/request/auth%7C123",
+      path     = "/stripped-path/request/auth%7C123",
     })
 
     local body3 = assert.res_status(200, res3)

--- a/spec/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -13,11 +13,11 @@ describe("error_default_type", function()
     helpers.dao:truncate_tables()
 
     assert(helpers.dao.apis:insert {
-      name = "api-1",
-      upstream_url = "http://127.0.0.1:3333/",
-      hosts = {
+      name         = "api-1",
+      upstream_url = helpers.mock_upstream_url .. "/status/500",
+      hosts        = {
         "example.com",
-      }
+      },
     })
 
     assert(helpers.start_kong {
@@ -42,6 +42,15 @@ describe("error_default_type", function()
 
   describe("request `Accept` is missing", function()
     describe("(default)", function()
+      setup(function()
+        assert(helpers.kong_exec("reload", {
+          prefix             = helpers.test_conf.prefix,
+          nginx_conf         = "spec/fixtures/custom_nginx.template",
+        }))
+
+        ngx.sleep(RELOAD_DELAY)
+      end)
+
       it("returns error messages in plain text", function()
         local res = assert(client:send {
           method  = "GET",

--- a/spec/02-integration/05-proxy/12-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/12-server_tokens_spec.lua
@@ -8,11 +8,11 @@ local default_server_header = _KONG._NAME .. "/" .. _KONG._VERSION
 local function start(config)
   return function()
     helpers.dao.apis:insert {
-      name = "api-1",
-      upstream_url = "http://localhost:9999/headers-inspect",
-      hosts = {
+      name         = "api-1",
+      upstream_url = helpers.mock_upstream_url,
+      hosts        = {
         "headers-inspect.com",
-      }
+      },
     }
 
     config = config or {}

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -38,6 +38,7 @@ describe("core entities are invalidated with db: " .. kong_conf.database, functi
       admin_ssl             = false,
       db_update_frequency   = POLL_INTERVAL,
       db_update_propagation = db_update_propagation,
+      nginx_conf            = "spec/fixtures/custom_nginx.template",
     })
 
     assert(helpers.start_kong {
@@ -114,16 +115,16 @@ describe("core entities are invalidated with db: " .. kong_conf.database, functi
 
     it("on create", function()
       local admin_res = assert(admin_client_1:send {
-        method = "POST",
-        path   = "/apis",
-        body   = {
+        method  = "POST",
+        path    = "/apis",
+        body    = {
           name         = "example",
           hosts        = "example.com",
-          upstream_url = "http://httpbin.org",
+          upstream_url = helpers.mock_upstream_url,
         },
         headers = {
           ["Content-Type"] = "application/json",
-        }
+        },
       })
       assert.res_status(201, admin_res)
 
@@ -153,16 +154,16 @@ describe("core entities are invalidated with db: " .. kong_conf.database, functi
 
     it("on update", function()
       local admin_res = assert(admin_client_1:send {
-        method = "PATCH",
-        path   = "/apis/example",
-        body   = {
+        method  = "PATCH",
+        path    = "/apis/example",
+        body    = {
           name         = "example",
           hosts        = "example.com",
-          upstream_url = "http://httpbin.org/status/418",
+          upstream_url = helpers.mock_upstream_url .. "/status/418",
         },
         headers = {
           ["Content-Type"] = "application/json",
-        }
+        },
       })
       assert.res_status(200, admin_res)
 
@@ -424,12 +425,12 @@ describe("core entities are invalidated with db: " .. kong_conf.database, functi
       -- create API
 
       local admin_res = assert(admin_client_1:send {
-        method = "POST",
-        path   = "/apis",
-        body   = {
-          name  = "dummy-api",
-          hosts = "dummy.com",
-          upstream_url = "http://httpbin.org",
+        method  = "POST",
+        path    = "/apis",
+        body    = {
+          name         = "dummy-api",
+          hosts        = "dummy.com",
+          upstream_url = helpers.mock_upstream_url,
         },
         headers = {
           ["Content-Type"] = "application/json",

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -64,6 +64,10 @@ http {
         kong.init_worker()
     }
 
+    rewrite_by_lua_block {
+        kong.rewrite()
+    }
+
     proxy_next_upstream_tries 999;
 
     upstream kong_upstream {
@@ -186,89 +190,12 @@ http {
     }
 
     server {
-        server_name custom_server;
-        listen 9999;
+        server_name mock_aws_lambda;
         listen 10001 ssl;
 
         ssl_certificate ${{SSL_CERT}};
         ssl_certificate_key ${{SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;
-
-        location /custom_server_path {
-            return 200;
-        }
-
-        location / {
-            content_by_lua_block {
-                local cjson = require "cjson"
-                local var   = ngx.var
-                local req   = ngx.req
-
-                req.read_body()
-
-                local json = cjson.encode {
-                    vars = {
-                        uri                = var.uri,
-                        host               = var.host,
-                        hostname           = var.hostname,
-                        https              = var.https,
-                        scheme             = var.scheme,
-                        is_args            = var.is_args,
-                        server_addr        = var.server_addr,
-                        server_port        = var.server_port,
-                        server_name        = var.server_name,
-                        server_protocol    = var.server_protocol,
-                        remote_addr        = var.remote_addr,
-                        remote_port        = var.remote_port,
-                        realip_remote_addr = var.realip_remote_addr,
-                        realip_remote_port = var.realip_remote_port,
-                        binary_remote_addr = var.binary_remote_addr,
-                        request            = var.request,
-                        request_uri        = var.request_uri,
-                        request_time       = var.request_time,
-                        request_length     = var.request_length,
-                        request_method     = var.request_method,
-                        bytes_received     = var.bytes_received,
-                    },
-                    method       = req.get_method(),
-                    headers      = req.get_headers(0),
-                    uri_args     = req.get_uri_args(0),
-                    post_args    = req.get_post_args(0),
-                    http_version = req.http_version(),
-                }
-
-                ngx.status = 200
-                ngx.say(json)
-                ngx.exit(200)
-            }
-        }
-
-        location /headers-inspect {
-            content_by_lua_block {
-                local cjson = require "cjson"
-
-                local headers = ngx.req.get_headers()
-                local json = cjson.encode(headers)
-
-                ngx.status = 200
-                ngx.say(json)
-                ngx.exit(200)
-            }
-        }
-
-        # N.B. this fixture only exists because the current testing environment
-        # offers no other tenable method to inspect the upstream TLS handshake
-        # this fixture SHOULD NOT be used in the future to build further tests;
-        # the location blocks here must be treated as temporary exceptions, not
-        # an acceptable pattern on which to derive further test architectures
-        location /ssl-inspect {
-            content_by_lua_block {
-                local name = ngx.var.ssl_server_name and ngx.var.ssl_server_name
-                  or "no SNI"
-
-                ngx.say(name)
-            }
-        }
 
         location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {
             content_by_lua_block {
@@ -311,18 +238,20 @@ http {
     }
 
     server {
-        listen 55555;
         server_name mock_upstream;
 
+        listen 55555;
+        listen 55556 ssl;
+
+        ssl_certificate ${{SSL_CERT}};
+        ssl_certificate_key ${{SSL_CERT_KEY}};
+        ssl_protocols TLSv1.1 TLSv1.2;
+
         location = / {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_method("GET")
-            }
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_json_response({
-                    valid_routes                    = {
+                return mu.send_default_json_response({
+                    valid_routes = {
                         ["/ws"]                     = "Websocket echo server",
                         ["/get"]                    = "Accepts a GET request and returns it in JSON format",
                         ["/post"]                   = "Accepts a POST request and returns it in JSON format",
@@ -331,7 +260,7 @@ http {
                         ["/delay/:duration"]        = "Delay the response for <duration> seconds",
                         ["/basic-auth/:user/:pass"] = "Performs HTTP basic authentication with the given credentials",
                         ["/status/:code"]           = "Returns a response with the specified <status code>"
-                    }
+                    },
                 })
             }
         }
@@ -343,45 +272,29 @@ http {
             }
         }
 
-        location = /get {
+        location /get {
             access_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.filter_access_by_method("GET")
             }
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
-
-                return mu.send_json_response({
-                    args    = ngx.req.get_uri_args(),
-                    headers = ngx.req.get_headers(),
-                    origin  = ngx.var.remote_addr,
-                    url     = mu.get_request_url(),
-                })
+                return mu.send_default_json_response()
             }
         }
 
-        location = /post {
+        location /post {
             access_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.filter_access_by_method("POST")
             }
             content_by_lua_block {
-                local mu                 = require "spec.fixtures.mock_upstream"
-                local headers            = ngx.req.get_headers()
-                local data, form, params = mu.parse_post_data(headers)
-                return mu.send_json_response({
-                    args    = ngx.req.get_uri_args(),
-                    data    = data,
-                    form    = form,
-                    headers = headers,
-                    origin  = ngx.var.remote_addr,
-                    params  = params,
-                    url     = mu.get_request_url(),
-                })
+                local mu  = require "spec.fixtures.mock_upstream"
+                return mu.send_default_json_response()
             }
         }
 
-        location ~ "^/basic-auth/(?<username>[a-zA-Z0-9_]+)/(?<password>[.]+)$" {
+        location ~ "^/basic-auth/(?<username>[a-zA-Z0-9_]+)/(?<password>.+)$" {
             access_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.filter_access_by_basic_auth(ngx.var.username,
@@ -389,34 +302,23 @@ http {
             }
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_json_response({
-                  authenticated = true,
-                  user          = ngx.var.username,
+                return mu.send_default_json_response({
+                    authenticated = true,
+                    user          = ngx.var.username,
                 })
             }
         }
 
-        location ~ "^/(request|anything)$" {
+        location ~ "^/(request|anything)" {
             content_by_lua_block {
-                local mu                 = require "spec.fixtures.mock_upstream"
-                local headers            = ngx.req.get_headers()
-                local data, form, params = mu.parse_post_data(headers)
-
-                return mu.send_json_response({
-                    args    = ngx.req.get_uri_args(),
-                    data    = data,
-                    form    = form,
-                    headers = headers,
-                    method  = ngx.var.request_method,
-                    origin  = ngx.var.remote_addr,
-                    params  = params,
-                    url     = mu.get_request_url(),
-                })
+                local mu = require "spec.fixtures.mock_upstream"
+                return mu.send_default_json_response()
             }
         }
 
         location ~ "^/delay/(?<delay_seconds>\d{1,3})$" {
             content_by_lua_block {
+                local mu            = require "spec.fixtures.mock_upstream"
                 local delay_seconds = tonumber(ngx.var.delay_seconds)
                 if not delay_seconds then
                     return ngx.exit(ngx.HTTP_NOT_FOUND)
@@ -424,20 +326,8 @@ http {
 
                 ngx.sleep(delay_seconds)
 
-                local mu                 = require "spec.fixtures.mock_upstream"
-                local headers            = ngx.req.get_headers()
-                local data, form, params = mu.parse_post_data(headers)
-
                 return mu.send_json_response({
-                    args    = ngx.req.get_uri_args(),
-                    data    = data,
-                    delay   = delay_seconds,
-                    form    = form,
-                    headers = headers,
-                    method  = ngx.var.request_method,
-                    origin  = ngx.var.remote_addr,
-                    params  = params,
-                    url     = mu.get_request_url(),
+                    delay = delay_seconds,
                 })
             }
         }


### PR DESCRIPTION
This PR is continued and extended in #2827 

* Most of the usage of httpbin/mockbin is gone from `spec/02-integration`, replaced by either `mock_upstream` or `example.com`, when applicable.
* The only remaining use of httpbin in `spec/02-integration` is on one of the timeout tests. I was not able to make it pass on osx using mock_upstream (osx always closes the connection - there's a mode called "stealth mode" which could be activated, but I think that is too much to ask just to pass a test locally).
* Since `spec/03-plugins` still uses httpbin/mockbin, I added some backwards-compatibility conditions to `spec/helpers.lua`. Most of these should be gone once we change `spec/03-plugins` to work with mock_upstream.
* Merged most of the pre-existing "mock server" code from the template into mock_upstream, and changes the specs accordingly. The only surviving bit is the aws-related one, which seemed too specific for including it into a generic "mock_upstream"