### PR TITLE
tests(*) run helper migrations in individual tests where necessary

### DIFF
--- a/spec/02-integration/01-helpers/00-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/00-helpers_spec.lua
@@ -5,7 +5,7 @@ describe("helpers: assertions and modifiers", function()
   local client
 
   setup(function()
-    assert(helpers.dao:run_migrations())
+    helpers.run_migrations()
     assert(helpers.dao.apis:insert {
       name = "mockbin",
       hosts = { "mockbin.com" },

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong start/stop", function()
   setup(function()
+    helpers.run_migrations()
     helpers.prepare_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/02-cmd/04-reload_spec.lua
+++ b/spec/02-integration/02-cmd/04-reload_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong reload", function()
   setup(function()
+    helpers.run_migrations()
     helpers.prepare_prefix()
   end)
   teardown(function()

--- a/spec/02-integration/02-cmd/07-restart_spec.lua
+++ b/spec/02-integration/02-cmd/07-restart_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong restart", function()
   setup(function()
+    helpers.run_migrations()
     helpers.prepare_prefix()
   end)
   teardown(function()

--- a/spec/02-integration/02-cmd/09-quit_spec.lua
+++ b/spec/02-integration/02-cmd/09-quit_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong quit", function()
   setup(function()
+    helpers.run_migrations()
     helpers.prepare_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
+local DAOFactory = require "kong.dao.factory"
+
 local dao_helpers = require "spec.02-integration.03-dao.helpers"
 
 describe("Admin API - Kong routes", function()
@@ -9,6 +11,7 @@ describe("Admin API - Kong routes", function()
     local client
 
     setup(function()
+      helpers.run_migrations()
       assert(helpers.start_kong {
         pg_password = "hide_me"
       })
@@ -90,8 +93,12 @@ describe("Admin API - Kong routes", function()
   dao_helpers.for_each_dao(function(kong_conf)
     describe("/status with DB: " .. kong_conf.database, function()
       local client
+      local dao
 
       setup(function()
+        dao = assert(DAOFactory.new(kong_conf))
+        helpers.run_migrations(dao)
+
         assert(helpers.start_kong {
           database = kong_conf.database,
         })

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -18,6 +18,7 @@ describe("Admin API " .. kong_config.database, function()
   local dao
   setup(function()
     dao = assert(DAOFactory.new(kong_config))
+    helpers.run_migrations(dao)
 
     assert(helpers.start_kong{
       database = kong_config.database
@@ -1148,6 +1149,8 @@ describe("Admin API request size", function()
       hosts = "my.api.com",
       upstream_url = "http://api.com"
     })
+
+    helpers.run_migrations()
 
     assert(helpers.start_kong())
     client = assert(helpers.admin_client())

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -12,6 +12,7 @@ end
 describe("Admin API", function()
   local client
   setup(function()
+    helpers.run_migrations()
     assert(helpers.start_kong())
     client = helpers.admin_client()
   end)

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -4,6 +4,7 @@ local cjson = require "cjson"
 describe("Admin API", function()
   local client
   setup(function()
+    helpers.run_migrations()
     assert(helpers.start_kong())
     client = helpers.admin_client()
   end)

--- a/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
@@ -7,6 +7,7 @@ describe("Admin API /cache", function()
 
 
   setup(function()
+    helpers.run_migrations()
     local api = assert(helpers.dao.apis:insert {
       name = "api-cache",
       hosts = { "cache.com" },

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -22,6 +22,7 @@ describe("Admin API", function()
   setup(function()
     dao = assert(DAOFactory.new(kong_config))
 
+    helpers.run_migrations(dao)
     assert(helpers.start_kong({
       database = kong_config.database
     }))

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -42,6 +42,7 @@ describe("Admin API", function()
   setup(function()
     dao = assert(DAOFactory.new(kong_config))
 
+    helpers.run_migrations(dao)
     assert(helpers.start_kong{
       database = kong_config.database
     })

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -17,6 +17,7 @@ describe("Admin API", function()
   local default_port = 8000
   
   before_each(function()
+    helpers.run_migrations()
     assert(helpers.start_kong())
     client = assert(helpers.admin_client())
     

--- a/spec/02-integration/04-admin_api/09-post_processing_spec.lua
+++ b/spec/02-integration/04-admin_api/09-post_processing_spec.lua
@@ -14,6 +14,7 @@ describe("Admin API post-processing", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
     assert(helpers.start_kong {
       custom_plugins = "admin-api-post-process"
     })

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -30,6 +30,7 @@ describe("Router", function()
 
     setup(function()
       helpers.dao:truncate_tables()
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -88,6 +89,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -190,6 +192,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",
       })
@@ -263,6 +266,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -305,6 +309,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -382,6 +387,7 @@ describe("Router", function()
         }
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",
       })
@@ -484,6 +490,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -530,6 +537,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -569,6 +577,7 @@ describe("Router", function()
         },
       }
 
+      helpers.run_migrations()
       assert(helpers.start_kong())
     end)
 
@@ -658,6 +667,7 @@ describe("Router", function()
         })
       end
 
+      helpers.run_migrations()
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",
       })

--- a/spec/02-integration/05-proxy/04-dns_spec.lua
+++ b/spec/02-integration/05-proxy/04-dns_spec.lua
@@ -45,6 +45,7 @@ describe("DNS", function()
     local client
 
     setup(function()
+      helpers.run_migrations()
       assert(helpers.dao.apis:insert {
         name = "tests-retries",
         hosts = { "retries.com" },
@@ -85,6 +86,7 @@ describe("DNS", function()
     local client
 
     setup(function()
+      helpers.run_migrations()
       assert(helpers.dao.apis:insert {
         name = "tests-retries",
         hosts = { "retries.com" },

--- a/spec/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/05-ssl_spec.lua
@@ -18,6 +18,7 @@ describe("SSL", function()
 
   setup(function()
     helpers.dao:truncate_tables()
+    helpers.run_migrations()
 
     assert(helpers.dao.apis:insert {
       name = "global-cert",

--- a/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -5,6 +5,7 @@ describe("URI encoding", function()
   local client
 
   setup(function()
+    helpers.run_migrations()
     assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "httpbin.com" },

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -5,7 +5,6 @@ local helpers = require "spec.helpers"
 local dao_helpers = require "spec.02-integration.03-dao.helpers"
 local PORT = 21000
 
-
 -- modified http-server. Accepts (sequentially) a number of incoming
 -- connections, and returns the number of succesful ones.
 -- Also features a timeout setting.
@@ -78,6 +77,7 @@ dao_helpers.for_each_dao(function(kong_config)
     local config_db
 
     setup(function()
+      helpers.run_migrations()
       config_db = helpers.test_conf.database
       helpers.test_conf.database = kong_config.database
     end)
@@ -95,6 +95,7 @@ dao_helpers.for_each_dao(function(kong_config)
       local client, api_client, upstream, target1, target2
 
       before_each(function()
+        helpers.run_migrations()
         assert(helpers.dao.apis:insert {
           name = "balancer.test",
           hosts = { "balancer.test" },

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -24,6 +24,7 @@ describe("core entities are invalidated with db: " .. kong_conf.database, functi
     local kong_dao_factory = require "kong.dao.factory"
     dao = assert(kong_dao_factory.new(kong_conf))
     dao:truncate_tables()
+    helpers.run_migrations(dao)
 
     local db_update_propagation = kong_conf.database == "cassandra" and 3 or 0
 

--- a/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
+++ b/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
@@ -5,9 +5,8 @@ describe("Plugin: key-auth (invalidations)", function()
   local admin_client, proxy_client
 
   before_each(function()
-    helpers.run_migrations()
-
     helpers.dao:truncate_tables()
+    helpers.run_migrations()
     local api = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "key-auth.com" },

--- a/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
@@ -5,9 +5,8 @@ describe("Plugin: basic-auth (invalidations)", function()
   local admin_client, proxy_client
 
   before_each(function()
-    helpers.run_migrations()
-
     helpers.dao:truncate_tables()
+    helpers.run_migrations()
     local api = assert(helpers.dao.apis:insert {
       name = "api-1",
       hosts = { "basic-auth.com" },

--- a/spec/03-plugins/17-jwt/04-invalidations_spec.lua
+++ b/spec/03-plugins/17-jwt/04-invalidations_spec.lua
@@ -6,9 +6,8 @@ describe("Plugin: jwt (invalidations)", function()
   local admin_client, proxy_client, consumer1, api1
 
   before_each(function()
-    helpers.run_migrations()
-
     helpers.dao:truncate_tables()
+    helpers.run_migrations()
 
     api1 = assert(helpers.dao.apis:insert {
       name = "api-1",

--- a/spec/03-plugins/19-acl/03-invalidations_spec.lua
+++ b/spec/03-plugins/19-acl/03-invalidations_spec.lua
@@ -5,9 +5,8 @@ describe("Plugin: ACL (invalidations)", function()
   local consumer1, acl1
 
   before_each(function()
-    helpers.run_migrations()
-
     helpers.dao:truncate_tables()
+    helpers.run_migrations()
 
     consumer1 = assert(helpers.dao.consumers:insert {
       username = "consumer1"
@@ -86,6 +85,10 @@ describe("Plugin: ACL (invalidations)", function()
   end)
 
   describe("ACL entity invalidation", function()
+    before_each(function()
+      helpers.run_migrations()
+    end)
+
     it("should invalidate when ACL entity is deleted", function()
       -- It should work
       local res = assert(proxy_client:send {
@@ -213,6 +216,10 @@ describe("Plugin: ACL (invalidations)", function()
   end)
 
   describe("Consumer entity invalidation", function()
+    before_each(function()
+      helpers.run_migrations()
+    end)
+
     it("should invalidate when Consumer entity is deleted", function()
       -- It should work
       local res = assert(proxy_client:send {


### PR DESCRIPTION
### Summary

This further improves the ability to run tests individually, without
assuming behavior about previous tests having performed migrations
and establishing a proper test schema.

### Full changelog

* add `helpers.run_migrations()` where appropriate in various integration tests