### PR TITLE
fix(dao) allow escaped commas in arrays

### DIFF
--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -117,9 +117,16 @@ function _M.validate_entity(tbl, schema, options)
               is_valid_type = bool == "true" or bool == "false"
               t[column] = bool == "true"
             elseif v.type == "array" then
-              t[column] = utils.strip(t[column]) == "" and {} or utils.split(t[column], ",") -- Handling empty arrays
+              -- handle escaped commas inside the comma-separated array
+              -- by flipping them into a \0 and then back
+              local escaped = t[column]:gsub("\\,", "\0")
+              if utils.strip(t[column]) == "" then
+                t[column] = {} -- Handling empty arrays
+              else
+                t[column] = utils.split(escaped, ",")
+              end
               for arr_k, arr_v in ipairs(t[column]) do
-                t[column][arr_k] = utils.strip(arr_v)
+                t[column][arr_k] = utils.strip(arr_v):gsub("%z", ",")
               end
               is_valid_type = validate_type(v.type, t[column])
             elseif v.type == "number" or v.type == "timestamp" then

--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -35,6 +35,22 @@ local function validate_type(field_type, value)
   return type(value) == field_type
 end
 
+local function validate_array(v, tbl, column)
+  -- Handle empty arrays
+  if utils.strip(tbl[column]) == "" then
+    tbl[column] = {}
+    return true
+  end
+  -- handle escaped commas inside the comma-separated array
+  -- by flipping them into a \0 and then back
+  local escaped = tbl[column]:gsub("\\,", "\0")
+  tbl[column] = utils.split(escaped, ",")
+  for arr_k, arr_v in ipairs(tbl[column]) do
+    tbl[column][arr_k] = utils.strip(arr_v):gsub("%z", ",")
+  end
+  return validate_type(v.type, tbl[column])
+end
+
 local _M = {}
 
 --- Validate a table against a given schema.
@@ -117,18 +133,7 @@ function _M.validate_entity(tbl, schema, options)
               is_valid_type = bool == "true" or bool == "false"
               t[column] = bool == "true"
             elseif v.type == "array" then
-              -- handle escaped commas inside the comma-separated array
-              -- by flipping them into a \0 and then back
-              local escaped = t[column]:gsub("\\,", "\0")
-              if utils.strip(t[column]) == "" then
-                t[column] = {} -- Handling empty arrays
-              else
-                t[column] = utils.split(escaped, ",")
-              end
-              for arr_k, arr_v in ipairs(t[column]) do
-                t[column][arr_k] = utils.strip(arr_v):gsub("%z", ",")
-              end
-              is_valid_type = validate_type(v.type, t[column])
+              is_valid_type = validate_array(v, t, column)
             elseif v.type == "number" or v.type == "timestamp" then
               t[column] = tonumber(t[column])
               is_valid_type = validate_type(v.type, t[column])

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -294,19 +294,23 @@ describe("Schemas", function()
       end)
 
       it("should handle escaped commas in comma-separated arrays", function()
+        -- Note: regression test for arrays of PCRE URIs:
+        -- https://github.com/Mashape/kong/issues/2780
         local s = {
           fields = {
             array = {type = "array"}
           }
         }
 
-        -- It should also strip the resulting strings
-        local values = { array = "hello\\, world,goodbye world\\,,/hello/\\d{1\\,3}" }
+        local values = {
+          array = [[ hello\, world,goodbye world\,,/hello/\d{1\,3} ]]
+        }
 
         local valid, err = validate_entity(values, s)
         assert.True(valid)
         assert.falsy(err)
-        assert.same({"hello, world", "goodbye world,", "/hello/\\d{1,3}"}, values.array)
+        assert.same({ "hello, world", "goodbye world,", [[/hello/\d{1,3}]] },
+                    values.array)
       end)
     end)
   end)

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -292,6 +292,22 @@ describe("Schemas", function()
         assert.falsy(err)
         assert.same({"hello", "world"}, values.array)
       end)
+
+      it("should handle escaped commas in comma-separated arrays", function()
+        local s = {
+          fields = {
+            array = {type = "array"}
+          }
+        }
+
+        -- It should also strip the resulting strings
+        local values = { array = "hello\\, world,goodbye world\\,,/hello/\\d{1\\,3}" }
+
+        local valid, err = validate_entity(values, s)
+        assert.True(valid)
+        assert.falsy(err)
+        assert.same({"hello, world", "goodbye world,", "/hello/\\d{1,3}"}, values.array)
+      end)
     end)
   end)
 

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -293,17 +293,17 @@ describe("Schemas", function()
         assert.same({"hello", "world"}, values.array)
       end)
 
-      it("should handle escaped commas in comma-separated arrays", function()
+      it("preserves escaped commas in comma-separated arrays", function()
         -- Note: regression test for arrays of PCRE URIs:
         -- https://github.com/Mashape/kong/issues/2780
         local s = {
           fields = {
-            array = {type = "array"}
+            array = { type = "array" }
           }
         }
 
         local values = {
-          array = [[ hello\, world,goodbye world\,,/hello/\d{1\,3} ]]
+          array = [[hello\, world,goodbye world\,,/hello/\d{1\,3}]]
         }
 
         local valid, err = validate_entity(values, s)


### PR DESCRIPTION
Support using `\,` for representing a `,` character in a comma-separated array, without using it as a separator. This allows one to use commas when entering URIs using the PCRE regex syntax `{n,m}` for `n`-to-`m` repetitions. For example:

```
$ curl localhost:8001/apis -d name=test -d upstream_url=http://httpbin.org -d uris='/foo/\d{1\,3},/bar'
```

Fixes #2780.
