### PR TITLE
docs(style) Exception for one-line else(if) blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -786,15 +786,17 @@ if str then
 end
 ```
 
-When creating multiple branches **do** include a blank line above the `elseif`
-and `else` statements:
+When creating multiple branches that span multiple lines, **do** include a
+blank line above the `elseif` and `else` statements:
 
 ```lua
 -- bad
 if foo then
   do_stuff()
+  keep_doing_stuff()
 elseif bar then
   do_other_stuff()
+  keep_doing_other_stuff()
 else
   error()
 end
@@ -802,14 +804,29 @@ end
 -- good
 if thing then
   do_stuff()
+  keep_doing_stuff()
 
 elseif bar then
   do_other_stuff()
+  keep_doing_other_stuff()
 
 else
   error()
 end
 ```
+
+For one-line blocks, blanks are not necessary:
+
+```lua
+if foo then
+  do_stuff()
+else
+  error("failed!")
+end
+```
+
+Note in the long example that if some branches are long, then all branches
+use the blank line (including the one-liner `else` case).
 
 When a branch returns, **do not** create subsequent branches, but write the
 rest of your logic on the parent branch:


### PR DESCRIPTION
Submitting this for appreciation of the Kong team.

This PR adds an exception to the "blank line before `else`/`elseif` block" rule, so that simple `if` statements with one-liner blocks don't require the blank line. This is in line with common practice in the OpenResty code base. The OpenResty codebase is not 100% consistent in vertical whitespace rules (at first I thought it might be correlated to the age of the codebase but scanning via `git blame` it shows in both older and more recent code). See, for example:

* https://github.com/openresty/lua-resty-lrucache/blob/master/lib/resty/lrucache.lua
* https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.lua
