### PR TITLE
hotfix(cli) prevent double logging in health and restart

### DIFF
--- a/kong/cmd/health.lua
+++ b/kong/cmd/health.lua
@@ -6,10 +6,12 @@ local pl_stringx = require "pl.stringx"
 local conf_loader = require "kong.conf_loader"
 
 local function execute(args)
+  log.disable()
   -- retrieve default prefix or use given one
   local default_conf = assert(conf_loader(nil, {
     prefix = args.prefix
   }))
+  log.enable()
   assert(pl_path.exists(default_conf.prefix),
          "no such prefix: " .. default_conf.prefix)
   assert(pl_path.exists(default_conf.kong_env),

--- a/kong/cmd/restart.lua
+++ b/kong/cmd/restart.lua
@@ -1,3 +1,4 @@
+local log = require "kong.cmd.utils.log"
 local stop = require "kong.cmd.stop"
 local kill = require "kong.cmd.utils.kill"
 local start = require "kong.cmd.start"
@@ -7,6 +8,8 @@ local conf_loader = require "kong.conf_loader"
 local function execute(args)
   local conf
 
+  log.disable()
+
   if args.prefix then
     conf = assert(conf_loader(pl_path.join(args.prefix, ".kong_env")))
 
@@ -15,7 +18,9 @@ local function execute(args)
     args.prefix = conf.prefix
   end
 
-  pcall(stop.execute, args)
+  log.enable()
+
+  pcall(stop.execute, args, { quiet = true })
 
   -- ensure Nginx stopped
   local texp = ngx.time() + 5 -- 5s

--- a/kong/cmd/stop.lua
+++ b/kong/cmd/stop.lua
@@ -3,7 +3,9 @@ local conf_loader = require "kong.conf_loader"
 local pl_path = require "pl.path"
 local log = require "kong.cmd.utils.log"
 
-local function execute(args)
+local function execute(args, opts)
+  opts = opts or {}
+
   log.disable()
   -- only to retrieve the default prefix or use given one
   local default_conf = assert(conf_loader(nil, {
@@ -13,9 +15,18 @@ local function execute(args)
   assert(pl_path.exists(default_conf.prefix),
          "no such prefix: " .. default_conf.prefix)
 
+  if opts.quiet then
+    log.disable()
+  end
+
   -- load <PREFIX>/kong.conf containing running node's config
   local conf = assert(conf_loader(default_conf.kong_env))
   assert(nginx_signals.stop(conf))
+
+  if opts.quiet then
+    log.enable()
+  end
+
   log("Kong stopped")
 end
 


### PR DESCRIPTION
> Opened against `release/0.11` because considered a "hotfix" (last-minute fixing of a non-released bug)

Warning logs issues by the configuration loader module would be logged
twice for `kong health` and `kong restart`. The logged warning with
which this incorrect behavior was noticed is the WARN log for
`db_update_propagation = 0` when using a Cassandra datastore.

This is a matter of a missing `disable`/`enable` in `kong health`. In
`kong restart`, however, we need a way to ensure that warning issued by
the config loading module when `stop.lua` is invoked from another
command are silent, from start to finish. We chose to add an optional
`quiet` argument for simplicity.

Another possible fix would have been to keep track of the number of
`disable()` and `enable()` calls, and make sure that we disable logging
if `n_disable > n_enable`. This would have resulted in a better
separation of concerns between different commands invoking each-other,
but would have made the code harder to read compared to the current
solution, at least for the time being.