### PR TITLE
tests(proxy) Increase delay to workaround Travis failures

### DIFF
--- a/spec/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -3,7 +3,7 @@ local cjson   = require "cjson"
 
 
 local S502_MESSAGE = "An invalid response was received from the upstream server"
-local RELOAD_DELAY = 0.5
+local RELOAD_DELAY = 1.0
 
 
 describe("error_default_type", function()


### PR DESCRIPTION
Workaround the intermittent Travis failures we keep getting,
by increasing the delay in `error_default_type_spec.lua` tests
to 1 second.

These tests are failing because they update the configuration,
run `kong reload`, wait for an arbitrary amount of time, then
run the test. This arbitrary amount of time (currently 0.5s)
is not always enough, so while increasing it is not a real
solution to the problem, at least it can make our Travis tests
pass on these, so that the fail/pass status in the Travis/Github
integration becomes useful again.

See #2803.