### PR TITLE
hotfix(reports) propagate API events and don't send plugins config

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -203,7 +203,7 @@ function _M.get(primary_keys, dao_collection, post_process)
 end
 
 --- Insertion of an entity.
-function _M.post(params, dao_collection, success, post_process)
+function _M.post(params, dao_collection, post_process)
   local data, err = dao_collection:insert(params)
   if err then
     return app_helpers.yield_error(err)

--- a/kong/api/routes/apis.lua
+++ b/kong/api/routes/apis.lua
@@ -47,7 +47,9 @@ return {
 
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.plugins, function(data)
-        reports.send("api", utils.deep_copy(data))
+        local r_data = utils.deep_copy(data)
+        r_data.config = nil
+        reports.send("api", r_data)
       end)
     end,
 

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -29,7 +29,9 @@ return {
 
     POST = function(self, dao_factory)
       crud.post(self.params, dao_factory.plugins, function(data)
-        reports.send("api", utils.deep_copy(data))
+        local r_data = utils.deep_copy(data)
+        r_data.config = nil
+        reports.send("api", r_data)
       end)
     end
   },

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-post-process/api.lua
@@ -27,8 +27,7 @@ return {
     end,
 
     POST = function(self, dao_factory)
-      crud.post(self.params, dao_factory.consumers, nil,
-                uppercase_table_values)
+      crud.post(self.params, dao_factory.consumers, uppercase_table_values)
     end,
   },
 


### PR DESCRIPTION
* Fixes the reports (that were broken with https://github.com/Mashape/kong/commit/cc4ffc30397b0a1291c456f39840d88ba00f7b98).
* Removes plugin configuration from report log.