### PR TITLE
Fix unusable error when migrations are broken.

### DIFF
--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -202,6 +202,21 @@ function _M:migrations_modules()
     end
   end
 
+  local migration_names = {}
+  for plugin_name, plugin in pairs(migrations) do
+    for i, migration in ipairs(plugin) do
+      if not migration.name then
+        error("migration " .. i .. " for plugin " .. plugin_name .. " has no name")
+      end
+
+      if migration_names[migration.name] ~= nil then
+        error("migration " .. i .. " for plugin " .. plugin_name .. " must have a unique name")
+      end
+
+      migration_names[migration.name] = true
+    end
+  end
+
   return migrations
 end
 

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -289,7 +289,7 @@ function _M:are_migrations_uptodate()
       then
         local infos = self.db:infos()
         log.warn("%s %s '%s' is missing migration: (%s) %s",
-                 self.db_type, infos.desc, infos.name, module, migration.name)
+                 self.db_type, infos.desc, infos.name, module, migration.name or "(no name)")
         return ret_error_string(self.db.name, nil, "the current database "   ..
                                 "schema does not match this version of "     ..
                                 "Kong. Please run `kong migrations up` "     ..


### PR DESCRIPTION
### Summary

When a migration is defined without a name, Kong fails to start with a fairly useless error message:

```
/usr/local/share/lua/5.1/kong/cmd/start.lua:62: /usr/local/share/lua/5.1/kong/cmd/utils/log.lua:49: bad argument #6 to 'format' (no value)
stack traceback:
        [C]: in function 'error'
        /usr/local/share/lua/5.1/kong/cmd/start.lua:62: in function 'cmd_exec'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:88>
        [C]: in function 'xpcall'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:45>
        /usr/local/bin/kong:7: in function 'file_gen'
        init_worker_by_lua:38: in function <init_worker_by_lua:36>
        [C]: in function 'xpcall'
        init_worker_by_lua:45: in function <init_worker_by_lua:43>
```

This is because `migration.name`, being nil, when passed to the log function causes the format string to fail to resolve. This simply uses "(no name)" in place of the name.

