### PR TITLE
 	feat(aws-lambda) add support for forwarded request method/uri/body

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -8,8 +8,20 @@ local http = require "resty.http"
 local cjson = require "cjson.safe"
 local public_utils = require "kong.tools.public"
 
-local ngx_req_read_body = ngx.req.read_body
+local tostring             = tostring
+local ngx_req_read_body    = ngx.req.read_body
 local ngx_req_get_uri_args = ngx.req.get_uri_args
+local ngx_req_get_headers  = ngx.req.get_headers
+local ngx_encode_base64    = ngx.encode_base64
+
+local new_tab
+do
+  local ok
+  ok, new_tab = pcall(require, "table.new")
+  if not ok then
+    new_tab = function(narr, nrec) return {} end
+  end
+end
 
 local AWS_PORT = 443
 
@@ -19,20 +31,64 @@ function AWSLambdaHandler:new()
   AWSLambdaHandler.super.new(self, "aws-lambda")
 end
 
-local function retrieve_parameters()
-  ngx_req_read_body()
-
-  return utils.table_merge(ngx_req_get_uri_args(), public_utils.get_body_args())
-end
-
 function AWSLambdaHandler:access(conf)
   AWSLambdaHandler.super.access(self)
 
-  local bodyJson = cjson.encode(retrieve_parameters())
+  local upstream_body = new_tab(0, 6)
+
+  if conf.forward_request_body or conf.forward_request_headers
+    or conf.forward_request_method or conf.forward_request_uri
+  then
+    -- new behavior to forward request method, body, uri and their args
+    local var = ngx.var
+
+    if conf.forward_request_method then
+      upstream_body.request_method = var.request_method
+    end
+
+    if conf.forward_request_headers then
+      upstream_body.request_headers = ngx_req_get_headers()
+    end
+
+    if conf.forward_request_uri then
+      upstream_body.request_uri      = var.request_uri
+      upstream_body.request_uri_args = ngx_req_get_uri_args()
+    end
+
+    if conf.forward_request_body then
+      ngx_req_read_body()
+
+      local body_args, err_code, body_raw = public_utils.get_body_info()
+      if err_code == public_utils.req_body_errors.unknown_ct then
+        -- don't know what this body MIME type is, base64 it just in case
+        body_raw = ngx_encode_base64(body_raw)
+        upstream_body.request_body_base64 = true
+      end
+
+      upstream_body.request_body      = body_raw
+      upstream_body.request_body_args = body_args
+    end
+
+  else
+    -- backwards compatible upstream body for configurations not specifying
+    -- `forward_request_*` values
+    ngx_req_read_body()
+
+    local body_args = public_utils.get_body_args()
+    upstream_body = utils.table_merge(ngx_req_get_uri_args(), body_args)
+  end
+
+  local upstream_body_json, err = cjson.encode(upstream_body)
+  if not upstream_body_json then
+    ngx.log(ngx.ERR, "[aws-lambda] could not JSON encode upstream body",
+                     " to forward request values: ", err)
+  end
 
   local host = string.format("lambda.%s.amazonaws.com", conf.aws_region)
   local path = string.format("/2015-03-31/functions/%s/invocations",
                             conf.function_name)
+  local port = conf.port or AWS_PORT
+
   local opts = {
     region = conf.aws_region,
     service = "lambda",
@@ -42,10 +98,12 @@ function AWSLambdaHandler:access(conf)
       ["X-Amz-Invocation-Type"] = conf.invocation_type,
       ["X-Amx-Log-Type"] = conf.log_type,
       ["Content-Type"] = "application/x-amz-json-1.1",
-      ["Content-Length"] = tostring(#bodyJson)
+      ["Content-Length"] = upstream_body_json and tostring(#upstream_body_json),
     },
-    body = bodyJson,
+    body = upstream_body_json,
     path = path,
+    host = host,
+    port = port,
     access_key = conf.aws_key,
     secret_key = conf.aws_secret,
     query = conf.qualifier and "Qualifier=" .. conf.qualifier
@@ -58,8 +116,8 @@ function AWSLambdaHandler:access(conf)
 
   -- Trigger request
   local client = http.new()
-  client:connect(host, conf.port or AWS_PORT)
   client:set_timeout(conf.timeout)
+  client:connect(host, port)
   local ok, err = client:ssl_handshake()
   if not ok then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -80,5 +80,21 @@ return {
       type = "number",
       func = check_status,
     },
+    forward_request_method = {
+      type = "boolean",
+      default = false,
+    },
+    forward_request_uri = {
+      type = "boolean",
+      default = false,
+    },
+    forward_request_headers = {
+      type = "boolean",
+      default = false,
+    },
+    forward_request_body = {
+      type = "boolean",
+      default = false,
+    },
   },
 }

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -232,7 +232,7 @@ http {
                 ngx.req.read_body()
                 local args = require("cjson").decode(ngx.req.get_body_data())
 
-                say(string.format("%q", qargs.key1 or args.key1), 200)
+                say(ngx.req.get_body_data(), 200)
             }
         }
     }


### PR DESCRIPTION
### Summary

**Depends on:** #2822

Reworked version of #2470 from @akh00.

This fixes a few issues with #2470 regarding inconsistent request body parsing, some inconsistent naming for the new schema values and a slightly different approach regarding the forging of the forwarded upstream request body. It also addresses quite a few style and maintainability issues.

### Full changelog

New optional configuration properties:
- `forward_request_method`
- `forward_request_uri`
- `forward_request_headers`
- `forward_request_body`

If specified, the request body sent to the invoked Lambda will contain
the desired attributes of the client's request as a JSON payload.

If none of the above values are specified, the upstream body contains a
JSON payload which is merged from the request's body data and its
query string. This is to preserve backwards compatibility with previous
versions of this plugin.

### Issues resolved

Fix #2379 
Fix #2469 