### PR TITLE
chore(ci) forward output to file and print it only on errors to work-around travis output limits

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 export BUSTED_ARGS="-o gtest -v --exclude-tags=ci"
@@ -7,11 +8,11 @@ createuser --createdb kong
 createdb -U kong kong_tests
 
 if [ "$TEST_SUITE" == "lint" ]; then
-    make lint
+    make lint &>> build.log || (cat build.log && exit 1)
 elif [ "$TEST_SUITE" == "unit" ]; then
-    make test
+    make test &>> build.log || (cat build.log && exit 1)
 elif [ "$TEST_SUITE" == "integration" ]; then
-    make test-integration
+    make test-integration &>> build.log || (cat build.log && exit 1)
 elif [ "$TEST_SUITE" == "plugins" ]; then
-    make test-plugins
+    make test-plugins &>> build.log || (cat build.log && exit 1)
 fi

--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 #---------
@@ -11,18 +12,18 @@ mkdir -p $OPENSSL_DOWNLOAD $OPENRESTY_DOWNLOAD $LUAROCKS_DOWNLOAD
 
 if [ ! "$(ls -A $OPENSSL_DOWNLOAD)" ]; then
   pushd $DOWNLOAD_CACHE
-    curl -L http://www.openssl.org/source/openssl-$OPENSSL.tar.gz | tar xz
+    curl -s -S -L http://www.openssl.org/source/openssl-$OPENSSL.tar.gz | tar xz
   popd
 fi
 
 if [ ! "$(ls -A $OPENRESTY_DOWNLOAD)" ]; then
   pushd $DOWNLOAD_CACHE
-    curl -L https://openresty.org/download/openresty-$OPENRESTY.tar.gz | tar xz
+    curl -s -S -L https://openresty.org/download/openresty-$OPENRESTY.tar.gz | tar xz
   popd
 fi
 
 if [ ! "$(ls -A $LUAROCKS_DOWNLOAD)" ]; then
-  git clone https://github.com/keplerproject/luarocks.git $LUAROCKS_DOWNLOAD
+  git clone -q https://github.com/keplerproject/luarocks.git $LUAROCKS_DOWNLOAD
 fi
 
 #--------
@@ -36,9 +37,9 @@ mkdir -p $OPENSSL_INSTALL $OPENRESTY_INSTALL $LUAROCKS_INSTALL
 
 if [ ! "$(ls -A $OPENSSL_INSTALL)" ]; then
   pushd $OPENSSL_DOWNLOAD
-    ./config shared --prefix=$OPENSSL_INSTALL
-    make
-    make install
+    ./config shared --prefix=$OPENSSL_INSTALL &>> build.log || (cat build.log && exit 1)
+    make &>> build.log || (cat build.log && exit 1)
+    make install &>> build.log || (cat build.log && exit 1)
   popd
 fi
 
@@ -55,22 +56,23 @@ if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
   )
 
   pushd $OPENRESTY_DOWNLOAD
-    ./configure ${OPENRESTY_OPTS[*]}
-    make
-    make install
+    ./configure ${OPENRESTY_OPTS[*]} &>> build.log || (cat build.log && exit 1)
+    make &>> build.log || (cat build.log && exit 1)
+    make install &>> build.log || (cat build.log && exit 1)
   popd
 fi
 
 if [ ! "$(ls -A $LUAROCKS_INSTALL)" ]; then
   pushd $LUAROCKS_DOWNLOAD
-    git checkout v$LUAROCKS
+    git checkout -q v$LUAROCKS
     ./configure \
       --prefix=$LUAROCKS_INSTALL \
       --lua-suffix=jit \
       --with-lua=$OPENRESTY_INSTALL/luajit \
-      --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1
-    make build
-    make install
+      --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1 \
+      &>> build.log || (cat build.log && exit 1)
+    make build &>> build.log || (cat build.log && exit 1)
+    make install &>> build.log || (cat build.log && exit 1)
   popd
 fi
 
@@ -84,7 +86,7 @@ eval `luarocks path`
 # Install ccm & setup Cassandra cluster
 # -------------------------------------
 if [[ "$TEST_SUITE" != "unit" ]] && [[ "$TEST_SUITE" != "lint" ]]; then
-  pip install --user PyYAML six ccm
+  pip install --user PyYAML six ccm &>> build.log || (cat build.log && exit 1)
   ccm create test -v $CASSANDRA -n 1 -d
   ccm start -v
   ccm status


### PR DESCRIPTION
### Summary

> In travis, the logs size is limited to 10.000 lines. Any build that outputs more lines will not show the lines beyond that limit. A warning is displayed by travis, but it does not affect the build - it continues but we are "blind" to what happens after 10.000 lines of log.
> 
> In our travis setup, we take advantage of the travis cache to not rebuild our dependencies (OpenResty et. al.) in each build. No build means less log - we usually stay way below the 10.000 lines limit.
> 
> However, when the build has no cache and processes from scratch, we go way beyond the 10.000 limit. And because our tests are somewhat flaky, they usually fail, but we don't see the reason why, because the failure is way past the 10.000 limit.
> 
> What gets us over the 10.000 limit? Build output from OpenSSL/OpenResty/LuaRocks/Kong/Cassandra... There is a very simple way to solve this issue: redirect stdout to a temporary file, and only print it upon a failure in the build step.
> 
> OpenResty systematically does this for each project; example:
> 
> https://github.com/openresty/lua-resty-core/blob/master/.travis.yml#L71
> 
> Each build step that is susceptible to spit a log of logs is redirected, and only printed upon failure of said build step:
> 
> make > build.log 2>&1 || (cat build.log && exit 1)
> make install > build.log 2>&1 || (cat build.log && exit 1)
> 
> By doing so ourselves, we avoid running over the 10.000 logs limit on empty cache builds, and we escape our "blindness" from such cases where the tests are failing but we don't know the reason why. Less logs also means leaner, cleaner build results!

-- @thibaultcha 