### PR TITLE
tests(conf) use test_conf explicitly when starting kong in multi-thre…

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -182,7 +182,8 @@ describe("kong start/stop", function()
         thread:join()
       end)
 
-      local ok, err = helpers.kong_exec("start --conf " .. helpers.test_conf_path)
+      local ok, err = helpers.start_kong()
+
       assert.False(ok)
       assert.matches("Address already in use", err, nil, true)
     end)


### PR DESCRIPTION
Related with #2802 

This is a difficult to replicate issue, possibly involving some race condition, so I'm not 100% sure that this will fix it. But after adding these changes (basically making it explicit that we're on a test env, and also using `start_kong` instead of `kong_exec(... start ...)`) I would not replicate the error any more.