### PR TITLE
chore(tests) rename #ci to #flaky

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export BUSTED_ARGS="-o gtest -v --exclude-tags=ci"
+export BUSTED_ARGS="-o gtest -v --exclude-tags=flaky"
 export TEST_CMD="bin/busted $BUSTED_ARGS"
 
 createuser --createdb kong

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -300,7 +300,7 @@ describe("Admin API", function()
         end
       end)
 
-      it("#ci only shows active targets", function()
+      it("#flaky only shows active targets", function()
         -- Pending (as of 2017/07/26) (CI-only)
         -- This test is failing to often on Travis CI because of the eventual
         -- consistency of the 3 C* nodes running on Travis (gossip seems to be

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -3,7 +3,7 @@ local utils = require "kong.tools.utils"
 local cjson = require "cjson"
 local pl_stringx = require "pl.stringx"
 
-describe("#ci Plugin: syslog (log)", function()
+describe("#flaky Plugin: syslog (log)", function()
   local client, platform
   setup(function()
     helpers.run_migrations()

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -47,7 +47,7 @@ local function flush_redis()
 end
 
 for i, policy in ipairs({"local", "cluster", "redis"}) do
-  describe("#ci Plugin: rate-limiting (access) with policy: " .. policy, function()
+  describe("#flaky Plugin: rate-limiting (access) with policy: " .. policy, function()
     setup(function()
       helpers.kill_all()
       flush_redis()

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -47,7 +47,7 @@ local function flush_redis()
 end
 
 for i, policy in ipairs({"local", "cluster", "redis"}) do
-  describe("#ci Plugin: response-ratelimiting (access) with policy: " .. policy, function()
+  describe("#flaky Plugin: response-ratelimiting (access) with policy: " .. policy, function()
     setup(function()
       flush_redis()
       helpers.dao:drop_schema()


### PR DESCRIPTION
Rename tests which are disabled due to intermittent failure
from #ci to #flaky, to better identify them.