### PR TITLE
tests(*) use hashtags to toggle cassandra/postgres

### DIFF
--- a/spec/02-integration/03-dao/08-ipc_events_spec.lua
+++ b/spec/02-integration/03-dao/08-ipc_events_spec.lua
@@ -12,7 +12,7 @@ local mock_ipc_module = {
 
 helpers.for_each_dao(function(kong_conf)
 
-describe("DAO propagates CRUD events with DB: " .. kong_conf.database, function()
+describe("DAO propagates CRUD events with DB: #" .. kong_conf.database, function()
   local dao
   local mock_ipc
 

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -91,7 +91,7 @@ describe("Admin API - Kong routes", function()
   end)
 
   dao_helpers.for_each_dao(function(kong_conf)
-    describe("/status with DB: " .. kong_conf.database, function()
+    describe("/status with DB: #" .. kong_conf.database, function()
       local client
       local dao
 

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -13,7 +13,7 @@ end
 
 dao_helpers.for_each_dao(function(kong_config)
 
-describe("Admin API " .. kong_config.database, function()
+describe("Admin API #" .. kong_config.database, function()
   local client
   local dao
   setup(function()

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -15,7 +15,7 @@ end
 
 dao_helpers.for_each_dao(function(kong_config)
 
-describe("Admin API", function()
+describe("Admin API: #" .. kong_config.database, function()
   local client
   local dao
 
@@ -38,7 +38,7 @@ describe("Admin API", function()
     helpers.stop_kong()
   end)
 
-  describe("/certificates with " .. kong_config.database, function()
+  describe("/certificates", function()
 
     describe("POST", function()
       before_each(function()
@@ -275,7 +275,7 @@ describe("Admin API", function()
   end)
 
 
-  describe("/snis with " .. kong_config.database, function()
+  describe("/snis", function()
     local ssl_certificate
 
     describe("POST", function()

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -35,7 +35,7 @@ end
 
 dao_helpers.for_each_dao(function(kong_config)
 
-describe("Admin API", function()
+describe("Admin API: #" .. kong_config.database, function()
   local client
   local dao
 
@@ -54,7 +54,7 @@ describe("Admin API", function()
     helpers.stop_kong()
   end)
 
-  describe("/upstreams " .. kong_config.database, function()
+  describe("/upstreams #" .. kong_config.database, function()
     describe("POST", function()
       before_each(function()
         dao:truncate_tables()

--- a/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -21,7 +21,7 @@ end
 
 dao_helpers.for_each_dao(function(kong_config)
 
-  describe("upstream timeouts with DB: " .. kong_config.database, function()
+  describe("upstream timeouts with DB: #" .. kong_config.database, function()
     local client
 
     setup(function()

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -9,7 +9,7 @@ local kong_cluster_events = require "kong.cluster_events"
 
 dao_helpers.for_each_dao(function(kong_conf)
 
-describe("cluster_events with db: " .. kong_conf.database, function()
+describe("cluster_events with db: #" .. kong_conf.database, function()
   local dao
 
   setup(function()

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -9,7 +9,7 @@ local POLL_INTERVAL = 0.3
 
 dao_helpers.for_each_dao(function(kong_conf)
 
-describe("core entities are invalidated with db: " .. kong_conf.database, function()
+describe("core entities are invalidated with db: #" .. kong_conf.database, function()
 
   local admin_client_1
   local admin_client_2


### PR DESCRIPTION
Mark the desciptions of all Cassandra and PostgreSQL tests
with the appropriate #cassandra and #postgres hashtags,
so they can be enabled/disabled properly via the Busted
command-line.
