### PR TITLE
fix(router) enforce api types

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -91,6 +91,10 @@ end
 
 
 local function marshall_api(api)
+  if not (api.headers or api.methods or api.uris) then
+    return nil, "could not categorize API"
+  end
+
   local api_t      = {
     api            = api,
     strip_uri      = api.strip_uri,

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -65,7 +65,7 @@ describe("Router", function()
         end, "expected arg #1 apis to be a table", nil, true)
       end)
 
-      pending("enforces apis fields types", function()
+      it("enforces apis fields types", function()
         local router, err = Router.new {
           { name = "api-invalid" }
         }


### PR DESCRIPTION
Add a check to `marshall_api` to make sure it returns an error
when it fails to categorize an API.

This moves a test from `pending` to running. 
