### PR TITLE
fix(tests) re-enable (re)start/stop tests

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -20,10 +20,9 @@ describe("kong start/stop", function()
     local _, stderr = helpers.kong_exec "stop --help"
     assert.not_equal("", stderr)
   end)
-  pending("start/stop gracefully with default conf/prefix", function()
-    -- don't want to force migrations to be run on default
-    -- keyspace/database
+  it("start/stop gracefully with default conf/prefix", function()
     assert(helpers.kong_exec("start", {
+      prefix = helpers.test_conf.prefix,
       database = helpers.test_conf.database,
       pg_database = helpers.test_conf.pg_database,
       cassandra_keyspace = helpers.test_conf.cassandra_keyspace

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -27,7 +27,9 @@ describe("kong start/stop", function()
       pg_database = helpers.test_conf.pg_database,
       cassandra_keyspace = helpers.test_conf.cassandra_keyspace
     }))
-    assert(helpers.kong_exec "stop")
+    assert(helpers.kong_exec("stop", {
+      prefix = helpers.test_conf.prefix,
+    }))
   end)
   it("start/stop custom Kong conf/prefix", function()
     assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))

--- a/spec/02-integration/02-cmd/07-restart_spec.lua
+++ b/spec/02-integration/02-cmd/07-restart_spec.lua
@@ -63,10 +63,11 @@ describe("kong restart", function()
     assert.res_status(200, res)
     client:close()
   end)
-  pending("restarts with default configuration and prefix", function()
+  it("restarts with default configuration and prefix", function()
     -- don't want to force migrations to be run on default
     -- keyspace/database
     local env = {
+      prefix = helpers.test_conf.prefix,
       database = helpers.test_conf.database,
       pg_database = helpers.test_conf.pg_database,
       cassandra_keyspace = helpers.test_conf.cassandra_keyspace,


### PR DESCRIPTION
Re-enable tests for `kong stop`/`kong start` and
`kong stop`/`kong restart` which were pending, since
those no longer perform migrations. Also, make sure
they don't depend on affecting a system-wide
installation of Kong.