### PR TITLE
chore(*) cleanup un-needed marshall_event handlers on schemas

### DIFF
--- a/kong/dao/schemas/apis.lua
+++ b/kong/dao/schemas/apis.lua
@@ -211,9 +211,6 @@ return {
     upstream_send_timeout = {type = "number", default = 60000, func = check_u_int},
     upstream_read_timeout = {type = "number", default = 60000, func = check_u_int},
   },
-  marshall_event = function(self, t)
-    return { id = t.id }
-  end,
   self_check = function(schema, api_t, dao, is_update)
     if is_update then
       return true

--- a/kong/dao/schemas/consumers.lua
+++ b/kong/dao/schemas/consumers.lua
@@ -21,7 +21,4 @@ return {
     custom_id = {type = "string", unique = true, func = check_custom_id_and_username},
     username = {type = "string", unique = true, func = check_custom_id_and_username}
   },
-  marshall_event = function(self, t)
-    return { id = t.id }
-  end
 }

--- a/kong/dao/schemas/plugins.lua
+++ b/kong/dao/schemas/plugins.lua
@@ -52,27 +52,6 @@ return {
       default = true
     }
   },
-  marshall_event = function(self, plugin_t)
-    local result = {
-      id = plugin_t.id,
-      api_id = plugin_t.api_id,
-      consumer_id = plugin_t.consumer_id,
-      name = plugin_t.name
-    }
-    if plugin_t and plugin_t.config then
-      local config_schema, err = self.fields.config.schema(plugin_t)
-      if err then
-        return false, Errors.schema(err)
-      end
-
-      if config_schema.marshall_event and type(config_schema.marshall_event) == "function" then
-        result.config = config_schema.marshall_event(plugin_t.config)
-      else
-        result.config = {}
-      end
-    end
-    return result
-  end,
   self_check = function(self, plugin_t, dao, is_update)
     -- Load the config schema
     local config_schema, err = self.fields.config.schema(plugin_t)

--- a/kong/dao/schemas/ssl_certificates.lua
+++ b/kong/dao/schemas/ssl_certificates.lua
@@ -1,6 +1,3 @@
-local singletons = require "kong.singletons"
-
-
 return {
   table = "ssl_certificates",
   primary_key = { "id" },
@@ -15,24 +12,4 @@ return {
       required = true,
     },
   },
-  marshall_event = function(schema, t)
-    local rows, err = singletons.dao.ssl_servers_names:find_all {
-      ssl_certificate_id = t.id
-    }
-    if err then
-      ngx.log(ngx.ERR, "could not fetch server names for cluster event: ", err)
-      return
-    end
-
-    local entity = {
-      id = t.id,
-      snis = {}
-    }
-
-    for i = 1, #rows do
-      table.insert(entity.snis, rows[i].name)
-    end
-
-    return entity
-  end,
 }

--- a/kong/dao/schemas/ssl_servers_names.lua
+++ b/kong/dao/schemas/ssl_servers_names.lua
@@ -11,9 +11,4 @@ return {
       required = true,
     },
   },
-  marshall_event = function(_, t)
-    return {
-      name = t.name
-    }
-  end,
 }

--- a/kong/dao/schemas/targets.lua
+++ b/kong/dao/schemas/targets.lua
@@ -57,12 +57,4 @@ return {
 
     return true
   end,
-  marshall_event = function(self, t)
-    -- when sending cluster events, we must include the upstream id, as the 
-    -- upstream cache needs to be invalidated, not the target itself.
-    return {
-      id = t.id,
-      upstream_id = t.upstream_id,
-    }
-  end
 }

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -113,10 +113,4 @@ return {
 
     return true
   end,
-  marshall_event = function(self, t)
-    return {
-      id = t.id,
-      name = t.name,
-    }
-  end
 }

--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -22,9 +22,6 @@ local SCHEMA = {
     consumer_id = { type = "id", required = true, foreign = "consumers:id" },
     group = { type = "string", required = true, func = check_unique }
   },
-  marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id} -- We don't need any data in the event
-  end
 }
 
 return {acls = SCHEMA}

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -27,9 +27,6 @@ local SCHEMA = {
     username = {type = "string", required = true, unique = true },
     password = {type = "string", func = encrypt_password}
   },
-  marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id, username = t.username}
-  end
 }
 
 return {basicauth_credentials = SCHEMA}

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -11,9 +11,6 @@ local SCHEMA = {
     username = {type = "string", required = true, unique = true},
     secret = {type = "string", default = utils.random_string}
   },
-  marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id, username = t.username}
-  end
 }
 
 return {hmacauth_credentials = SCHEMA}

--- a/kong/plugins/jwt/daos.lua
+++ b/kong/plugins/jwt/daos.lua
@@ -30,9 +30,6 @@ local SCHEMA = {
      end
     return true
   end,
-  marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id, key = t.key}
-  end
 }
 
 return {jwt_secrets = SCHEMA}

--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -10,9 +10,6 @@ local SCHEMA = {
     consumer_id = {type = "id", required = true, foreign = "consumers:id"},
     key = {type = "string", required = false, unique = true, default = utils.random_string}
   },
-  marshall_event = function(self, t)
-    return {id = t.id, consumer_id = t.consumer_id, key = t.key}
-  end
 }
 
 return {keyauth_credentials = SCHEMA}

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -32,9 +32,6 @@ local OAUTH2_CREDENTIALS_SCHEMA = {
     redirect_uri = { type = "array", required = true, func = validate_uris },
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true }
   },
-  marshall_event = function(self, t)
-    return { id = t.id, consumer_id = t.consumer_id, client_id = t.client_id }
-  end
 }
 
 local OAUTH2_AUTHORIZATION_CODES_SCHEMA = {
@@ -68,9 +65,6 @@ local OAUTH2_TOKENS_SCHEMA = {
     scope = { type = "string" },
     created_at = { type = "timestamp", immutable = true, dao_insert_value = true }
   },
-  marshall_event = function(self, t)
-    return { id = t.id, credential_id = t.credential_id, access_token = t.access_token }
-  end
 }
 
 return {


### PR DESCRIPTION
Since the removal of Serf, `marshall_event` is not used anymore by any
schema (invalidations uses `cache_key` or custom invalidation handlers
instead).

This just gets rid of unused code.