### PR TITLE
README.md(Tests) minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ When developing, you can use the `Makefile` for doing the following operations:
 | `test`             | Run the unit tests suite                               |
 | `test-integration` | Run the integration tests suite                        |
 | `test-plugins`     | Run the plugins test suite                             |
-| `test-all`         | Run all unit + integration tests at once               |
+| `test-all`         | Run all unit + integration + plugins tests at once     |
 
 ## Enterprise Support & Demo
 


### PR DESCRIPTION
test-all = unit + integration + plugins, I found it in Makefile

```
test:
	@$(TEST_CMD) spec/01-unit

test-integration:
	@$(TEST_CMD) spec/02-integration

test-plugins:
	@$(TEST_CMD) spec/03-plugins

test-all:
	@$(TEST_CMD) spec/
```