### PR TITLE
fix(migrations) stop depending on the order as recorded

### DIFF
--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -251,10 +251,14 @@ end
 
 local function migrate(self, identifier, migrations_modules, cur_migrations, on_migrate, on_success)
   local migrations = migrations_modules[identifier]
-  local recorded = cur_migrations[identifier] or {}
+  local recorded = {}
+  for _, name in ipairs(cur_migrations[identifier] or {}) do
+    recorded[name] = true
+  end
+
   local to_run = {}
-  for i, mig in ipairs(migrations) do
-    if mig.name ~= recorded[i] then
+  for _, mig in ipairs(migrations) do
+    if not recorded[mig.name] then
       to_run[#to_run + 1] = mig
     end
   end


### PR DESCRIPTION
Migrations are recorded in the datastore and then the order in which
they appear there is relevant for determining if they should run.
Once something goes out-of-sync on every start/restart it will keep
running migrations over and over again.