### PR TITLE
fix(admin) fix regression of trailing slash in targets uri

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -118,7 +118,7 @@ return {
     end,
   },
 
-  ["/upstreams/:upstream_name_or_id/targets/active/"] = {
+  ["/upstreams/:upstream_name_or_id/targets/active"] = {
     before = function(self, dao_factory, helpers)
       crud.find_upstream_by_name_or_id(self, dao_factory, helpers)
       self.params.upstream_id = self.upstream.id

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -302,24 +302,26 @@ describe("Admin API", function()
       end)
 
       it("only shows active targets", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/upstreams/" .. upstream_name3 .. "/targets/active",
-        })
-        assert.response(res).has.status(200)
-        local json = assert.response(res).has.jsonbody()
+        for _, append in ipairs({ "", "/" }) do
+          local res = assert(client:send {
+            method = "GET",
+            path = "/upstreams/" .. upstream_name3 .. "/targets/active" .. append,
+          })
+          assert.response(res).has.status(200)
+          local json = assert.response(res).has.jsonbody()
 
-        -- we got three active targets for this upstream
-        assert.equal(3, #json.data)
-        assert.equal(3, json.total)
+          -- we got three active targets for this upstream
+          assert.equal(3, #json.data)
+          assert.equal(3, json.total)
 
-        -- when multiple active targets are present, we only see the last one
-        assert.equal(apis[4].id, json.data[1].id)
+          -- when multiple active targets are present, we only see the last one
+          assert.equal(apis[4].id, json.data[1].id)
 
-        -- validate the remaining returned targets
-        -- note the backwards order, because we walked the targets backwards
-        assert.equal(apis[3].target, json.data[2].target)
-        assert.equal(apis[2].target, json.data[3].target)
+          -- validate the remaining returned targets
+          -- note the backwards order, because we walked the targets backwards
+          assert.equal(apis[3].target, json.data[2].target)
+          assert.equal(apis[2].target, json.data[3].target)
+        end
       end)
     end)
   end)

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -304,7 +304,7 @@ describe("Admin API", function()
       it("only shows active targets", function()
         local res = assert(client:send {
           method = "GET",
-          path = "/upstreams/" .. upstream_name3 .. "/targets/active/",
+          path = "/upstreams/" .. upstream_name3 .. "/targets/active",
         })
         assert.response(res).has.status(200)
         local json = assert.response(res).has.jsonbody()
@@ -366,7 +366,7 @@ describe("Admin API", function()
 
         local active = assert(client:send {
           method = "GET",
-          path = "/upstreams/" .. upstream_name4 .. "/targets/active/",
+          path = "/upstreams/" .. upstream_name4 .. "/targets/active",
         })
         assert.response(active).has.status(200)
         json = assert.response(active).has.jsonbody()
@@ -393,7 +393,7 @@ describe("Admin API", function()
 
         local active = assert(client:send {
           method = "GET",
-          path = "/upstreams/" .. upstream_name4 .. "/targets/active/",
+          path = "/upstreams/" .. upstream_name4 .. "/targets/active",
         })
         assert.response(active).has.status(200)
         json = assert.response(active).has.jsonbody()


### PR DESCRIPTION
With the trailing slash the `.../targets/active` endpoint would return a "method not allowed" error

fixes #2840
