### PR TITLE
fix(dao) allow self-signed certificates for migrations

### DIFF
--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -62,6 +62,12 @@ function _M.new(kong_config)
   if ngx.IS_CLI then
     local policy = require("resty.cassandra.policies.reconnection.const")
     cluster_options.reconn_policy = policy.new(100)
+
+    -- Force LuaSocket usage in order to allow for self-signed certificates
+    -- to be trusted (via opts.cafile) in the resty-cli interpreter.
+    -- As usual, LuaSocket is also forced in non-supported cosocket contexts.
+    local socket = require "cassandra.socket"
+    socket.force_luasocket("timer", true)
   end
 
   --

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -62,8 +62,16 @@ end
 
 local function query_opts(self)
   local opts = self:clone_query_options()
-  opts.socket_type = forced_luasocket_phases[get_phase()] and
-                     "luasocket" or "nginx"
+
+  if ngx.IS_CLI or forced_luasocket_phases[get_phase()] then
+    -- Force LuaSocket usage in order to allow for self-signed certificates
+    -- to be trusted (via opts.cafile) in the resty-cli interpreter.
+    -- As usual, LuaSocket is also forced in non-supported cosocket contexts.
+    opts.socket_type = "luasocket"
+
+  else
+    opts.socket_type = "nginx"
+  end
 
   return opts
 end


### PR DESCRIPTION
This fixes a reported issue that Kong would not be able to run
migrations on PostgreSQL with self-signed certificates. The error "self
signed certificate" that Kong raised indicated that the root CA was not
made available to the cosocket in use.

Because the CLI is interpreted by resty-cli, it is too late to set the
resty-cli `lua_ssl_trusted_certificate` directive.

The approach we historically take is to rely on LuaSocket/LuaSec in
Kong's CLI and circumvant this limitation (the root CA file can be
specified at runtime as part of the LuaSocket instantiation options).

Fix #2856