### PR TITLE
fix(postgres) ensure APIs created_at has ms precision

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -51,6 +51,10 @@ local function build_router(dao, version)
     end
   end
 
+  table.sort(apis, function(api_a, api_b)
+    return api_a.created_at < api_b.created_at
+  end)
+
   router, err = Router.new(apis)
   if not router then
     return nil, "could not create router: " .. err

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -346,7 +346,7 @@ local function deserialize_timestamps(self, row, schema)
   for k, v in pairs(schema.fields) do
     if v.type == "timestamp" and result[k] then
       local query = fmt([[
-        SELECT (extract(epoch from timestamp '%s')*1000)::bigint as %s;
+        SELECT (extract(epoch from timestamp '%s') * 1000) as %s;
       ]], result[k], k)
       local res, err = self:query(query)
       if not res then return nil, err
@@ -363,8 +363,8 @@ local function serialize_timestamps(self, tbl, schema)
   for k, v in pairs(schema.fields) do
     if v.type == "timestamp" and result[k] then
       local query = fmt([[
-        SELECT to_timestamp(%d/1000) at time zone 'UTC' as %s;
-      ]], result[k], k)
+        SELECT to_timestamp(%f) at time zone 'UTC' as %s;
+      ]], result[k] / 1000, k)
       local res, err = self:query(query)
       if not res then return nil, err
       elseif #res <= 1 then

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -42,7 +42,7 @@ return {
         strip_request_path boolean NOT NULL,
         upstream_url text,
         preserve_host boolean NOT NULL,
-        created_at timestamp without time zone default (CURRENT_TIMESTAMP(0) at time zone 'utc')
+        created_at timestamp without time zone default (CURRENT_TIMESTAMP(3) at time zone 'utc')
       );
       DO $$
       BEGIN


### PR DESCRIPTION
APIs are retrieved without an `ORDER BY` clause from the datastore when
building the router. Because of the lack of such a clause in our current
Cassandra schema, we wish to implement sorting by creation date in our
business logic, right before building the router.

However, the PostgreSQL default clause of the APIs `created_at` field
is set to `CURRENT_TIMESTAMP(0)`, which strips ms precision out of the
timestamp. This changes the default timestamp precision to 3 digits so
our sorting attribute (`created_at`) can be meaningful.

This fix is targeting 0.11.1, and as such does not introduce a new
migration to update the default value of `created_at`. This fix will
only have effect for new database schemas.

A second commit will introduce a migration, which, as per our policy,
will be targeted for 0.12.0.

Fix #2899