### PR TITLE
 fix(postgres) migration for APIs created_at default precision

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -533,4 +533,13 @@ return {
     ]],
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2017-10-02-173400_apis_created_at_ms_precision",
+    up = [[
+      ALTER TABLE apis ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(3);
+    ]],
+    down = [[
+      ALTER TABLE apis ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);
+    ]]
+  },
 }


### PR DESCRIPTION
Follow-up commit to #2924

This migration is targeted for landing in 0.12.0, and will ensure that
newly created APIs will have a `created_at` field with ms precision.