### PR TITLE
tests(*) do not launch servers in ephemeral ports

### DIFF
--- a/spec/02-integration/01-helpers/00-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/00-helpers_spec.lua
@@ -128,7 +128,7 @@ describe("helpers: assertions and modifiers", function()
         method  = "GET",
         path    = "/headers",   -- this path is not supported, but should yield valid json for the test
         headers = {
-          host = "127.0.0.1:55555",
+          host = "127.0.0.1:15555",
         },
       })
       assert.error(function() assert.request(r).True(true) end)

--- a/spec/02-integration/05-proxy/08-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/08-websockets_spec.lua
@@ -8,7 +8,7 @@ describe("Websockets", function()
       name = "ws",
       uris = { "/up-ws" },
       strip_uri = true,
-      upstream_url = "http://127.0.0.1:55555/ws",
+      upstream_url = "http://127.0.0.1:15555/ws",
     })
 
     assert(helpers.start_kong({
@@ -42,7 +42,7 @@ describe("Websockets", function()
     end
 
     it("sends and gets text without Kong", function()
-      send_text_and_get_echo("ws://127.0.0.1:55555/ws")
+      send_text_and_get_echo("ws://127.0.0.1:15555/ws")
     end)
 
     it("sends and gets text with Kong", function()
@@ -72,7 +72,7 @@ describe("Websockets", function()
     end
 
     it("plays ping-pong without Kong", function()
-      send_ping_and_get_pong("ws://127.0.0.1:55555/ws")
+      send_ping_and_get_pong("ws://127.0.0.1:15555/ws")
     end)
 
     it("plays ping-pong with Kong", function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -239,8 +239,8 @@ http {
     server {
         server_name mock_upstream;
 
-        listen 55555;
-        listen 55556 ssl;
+        listen 15555;
+        listen 15556 ssl;
 
         ssl_certificate ${{SSL_CERT}};
         ssl_certificate_key ${{SSL_CERT_KEY}};

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -12,8 +12,8 @@ local MOCK_UPSTREAM_PROTOCOL = "http"
 local MOCK_UPSTREAM_SSL_PROTOCOL = "https"
 local MOCK_UPSTREAM_HOST = "127.0.0.1"
 local MOCK_UPSTREAM_HOSTNAME = "localhost"
-local MOCK_UPSTREAM_PORT = 55555
-local MOCK_UPSTREAM_SSL_PORT = 55556
+local MOCK_UPSTREAM_PORT = 15555
+local MOCK_UPSTREAM_SSL_PORT = 15556
 
 local conf_loader = require "kong.conf_loader"
 local DAOFactory = require "kong.dao.factory"


### PR DESCRIPTION
Avoid conflicts with other client connections that may be taking place at the same time (especially frequent in the Travis CI environment).
