### PR TITLE
fix(balancer) log the proper field

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -292,7 +292,7 @@ function Kong.balancer()
     local ok, err = balancer_execute(addr)
     if not ok then
       ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ",
-              addr.upstream.host, "' with: ", tostring(err))
+              tostring(addr.host), "' with: ", tostring(err))
 
       return responses.send(500)
     end


### PR DESCRIPTION
The field referenced did not exist and failed with an error while
indexing a nil value. This error happened during logging, and hence the
actual underlying error was lost unfortunately.

Note: the `addr` structure is [defined here](https://github.com/Mashape/kong/blob/0.10.3/kong/core/handler.lua#L103-L117) and does not have an `upstream` field.